### PR TITLE
fix(rtl): replace modulo with bitmask for segment ring-wrap pointers

### DIFF
--- a/examples/arty_a7/test_hw_integration.py
+++ b/examples/arty_a7/test_hw_integration.py
@@ -50,6 +50,52 @@ _OPENOCD_TAP = os.environ.get("FPGACAP_OPENOCD_TAP", "xc7a100t.tap")
 PORT = 3121
 FPGA = "xc7a100t"
 
+_ROOT = Path(__file__).resolve().parents[2]
+
+# RTL and design sources that feed the bitstream (must match build_arty.tcl)
+_BITSTREAM_SOURCES = [
+    _ROOT / "rtl" / "fcapz_version.vh",
+    _ROOT / "rtl" / "dpram.v",
+    _ROOT / "rtl" / "trig_compare.v",
+    _ROOT / "rtl" / "fcapz_ela.v",
+    _ROOT / "rtl" / "fcapz_ela_xilinx7.v",
+    _ROOT / "rtl" / "jtag_reg_iface.v",
+    _ROOT / "rtl" / "jtag_burst_read.v",
+    _ROOT / "rtl" / "jtag_tap" / "jtag_tap_xilinx7.v",
+    _ROOT / "rtl" / "fcapz_async_fifo.v",
+    _ROOT / "rtl" / "fcapz_ejtagaxi.v",
+    _ROOT / "rtl" / "fcapz_ejtagaxi_xilinx7.v",
+    _ROOT / "rtl" / "fcapz_eio.v",
+    _ROOT / "rtl" / "fcapz_eio_xilinx7.v",
+    _ROOT / "tb" / "axi4_test_slave.v",
+    Path(__file__).resolve().parent / "arty_a7_top.v",
+    Path(__file__).resolve().parent / "arty_a7.xdc",
+]
+
+
+def _check_bitstream_freshness() -> str | None:
+    """Return an error message if any source is newer than the bitfile."""
+    bitpath = Path(BITFILE)
+    if not bitpath.exists():
+        return f"bitfile not found: {BITFILE}"
+    bit_mtime = bitpath.stat().st_mtime
+    stale = []
+    for src in _BITSTREAM_SOURCES:
+        if src.exists() and src.stat().st_mtime > bit_mtime:
+            stale.append(src.name)
+    if stale:
+        return (
+            f"bitstream is stale — these sources are newer than "
+            f"{bitpath.name}: {', '.join(stale)}. "
+            f"Re-run: python examples/arty_a7/build.py"
+        )
+    return None
+
+
+_STALE_MSG = _check_bitstream_freshness()
+if _STALE_MSG and not _SKIP:
+    raise RuntimeError(_STALE_MSG)
+
 
 def _make_transport():
     if _BACKEND == "openocd":

--- a/host/fcapz/analyzer.py
+++ b/host/fcapz/analyzer.py
@@ -152,6 +152,36 @@ class CaptureResult:
     segment: int = 0  # which segment this result is from
 
 
+def vcd_simulation_times(result: CaptureResult) -> list[int]:
+    """Per-sample times for VCD ``#`` lines (``len(result.samples)`` entries).
+
+    Without hardware timestamps this is ``0 .. n-1`` (one time unit per stored
+    sample, matching the historical behaviour).
+
+    With timestamps, values are **shifted by the first sample** so each dump
+    starts at 0 while preserving relative spacing. Raw counters often jump
+    between successive captures (continuous mode / live VCD reload); using
+    absolute values as ``#`` time made the viewer timeline and timescale look
+    broken. The ``timestamp`` wire in the VCD still carries raw hardware values.
+
+    Times are forced **non-decreasing** so the file stays valid if the buffer
+    has duplicate or slightly regressed counter values.
+    """
+    n = len(result.samples)
+    ts = result.timestamps
+    if ts and len(ts) == n:
+        base = int(ts[0])
+        out: list[int] = []
+        last = -1
+        for i in range(n):
+            rel = int(ts[i]) - base
+            t = max(rel, last + 1, 0)
+            out.append(t)
+            last = t
+        return out
+    return list(range(n))
+
+
 class Analyzer:
     def __init__(self, transport: Transport):
         self.transport = transport
@@ -162,7 +192,13 @@ class Analyzer:
     def connect(self) -> None:
         self.transport.connect()
 
-    def close(self) -> None:
+    def close(self, *, fast: bool = False) -> None:
+        """Close the JTAG transport. ``fast=True`` skips long waits (e.g. Ctrl+C)."""
+        if fast:
+            closer = getattr(self.transport, "close_fast", None)
+            if callable(closer):
+                closer()
+                return
         self.transport.close()
 
     def reset(self) -> None:
@@ -488,11 +524,9 @@ class Analyzer:
             lines.append(f"b{'0' * ts_w} {ts_var_id}")
         lines.append("$end")
 
+        sim_times = vcd_simulation_times(result)
         for i, sample in enumerate(result.samples):
-            if result.timestamps and i < len(result.timestamps):
-                lines.append(f"#{result.timestamps[i]}")
-            else:
-                lines.append(f"#{i}")
+            lines.append(f"#{sim_times[i]}")
             for var_id, _, width, lsb in signals:
                 val = (sample >> lsb) & ((1 << width) - 1)
                 bits = format(val, f"0{width}b")
@@ -533,7 +567,8 @@ class Analyzer:
         drive a non-fcapz bitstream.
 
         Returns a dict with `version_major`, `version_minor`, `core_id`
-        (always 0x4C41 on success), and the rest of the feature flags.
+        (always 0x4C41 on success), `trig_stages` (FEATURES[3:0]: hardware
+        trigger sequencer depth, 0 if absent), and the rest of the feature flags.
         """
         _read = getattr(self.transport, "read_reg_verified", self.transport.read_reg)
         version = int(_read(_ADDR_VERSION))
@@ -558,6 +593,7 @@ class Analyzer:
             "sample_width": sample_w,
             "depth": depth,
             "num_channels": num_chan if num_chan >= 1 else 1,
+            "trig_stages": int(features & 0xF),
             "has_decimation": bool(features & (1 << 5)),
             "has_ext_trigger": bool(features & (1 << 6)),
             "has_timestamp": bool(features & (1 << 7)),

--- a/host/fcapz/transport.py
+++ b/host/fcapz/transport.py
@@ -167,16 +167,22 @@ class OpenOcdTransport(Transport):
         port: int = 6666,
         tap: str = "xc7a100t.tap",
         ir_table: dict[int, int] | None = None,
+        *,
+        connect_timeout_sec: float = 5.0,
     ):
         self.host = host
         self.port = port
         self.tap = tap
         self.ir_table = dict(ir_table) if ir_table else dict(self.DEFAULT_IR_TABLE)
+        self._connect_timeout_sec = float(connect_timeout_sec)
         self._active_chain: int = 1
         self._sock: socket.socket | None = None
 
     def connect(self) -> None:
-        self._sock = socket.create_connection((self.host, self.port), timeout=5)
+        self._sock = socket.create_connection(
+            (self.host, self.port),
+            timeout=self._connect_timeout_sec,
+        )
         self._sock.settimeout(0.2)
         try:
             self._sock.recv(4096)
@@ -414,6 +420,30 @@ class XilinxHwServerTransport(Transport):
             except subprocess.TimeoutExpired:
                 self._proc.kill()
             self._proc = None
+
+    def close_fast(self) -> None:
+        """Kill ``xsdb`` quickly for console interrupt; normal :meth:`close` may wait 5s."""
+        proc = self._proc
+        if proc is None:
+            return
+        try:
+            if proc.stdin is not None:
+                try:
+                    proc.stdin.write("exit\n")
+                    proc.stdin.flush()
+                except OSError:
+                    pass
+        except (OSError, ValueError):
+            pass
+        try:
+            proc.kill()
+        except OSError:
+            pass
+        try:
+            proc.wait(timeout=0.2)
+        except subprocess.TimeoutExpired:
+            pass
+        self._proc = None
 
     # -- chain selection -----------------------------------------------------
 

--- a/rtl/fcapz_ela.v
+++ b/rtl/fcapz_ela.v
@@ -141,6 +141,13 @@ module fcapz_ela #(
     localparam SEG_PTR_W = $clog2(SEG_DEPTH);
     localparam SEG_IDX_W = (NUM_SEGMENTS > 1) ? $clog2(NUM_SEGMENTS) : 1;
 
+    // Static assert: SEG_DEPTH must be a power-of-two (bitmask wrap arithmetic)
+    generate
+        if (SEG_DEPTH != 0 && (SEG_DEPTH & (SEG_DEPTH - 1)) != 0) begin : g_bad_seg_depth
+            SEG_DEPTH_must_be_power_of_two invalid();
+        end
+    endgenerate
+
     // Phase 3: timestamp data base address
     localparam ADDR_TS_DATA_BASE = ADDR_DATA_BASE + DEPTH * WORDS_PER_SAMPLE * 4;
     // Timestamp words per entry
@@ -893,7 +900,10 @@ module fcapz_ela #(
                         if (post_count >= posttrig_len) begin
                             // Segment complete
                             if (NUM_SEGMENTS > 1) begin
-                                seg_start_ptr[cur_segment] <= trig_ptr - pretrig_len;
+                                // Ring start within this segment (not raw subtract; avoids host/burst
+                                // linear read crossing into the next segment's RAM).
+                                seg_start_ptr[cur_segment] <= seg_base
+                                    + ((trig_ptr - seg_base + SEG_DEPTH - pretrig_len) & (SEG_DEPTH - 1));
                                 if (cur_segment == NUM_SEGMENTS - 1) begin
                                     // All segments done
                                     done      <= 1'b1;
@@ -917,7 +927,8 @@ module fcapz_ela #(
                             end else begin
                                 done      <= 1'b1;
                                 armed     <= 1'b0;
-                                start_ptr <= trig_ptr - pretrig_len;
+                                start_ptr <= seg_base
+                                    + ((trig_ptr - seg_base + SEG_DEPTH - pretrig_len) & (SEG_DEPTH - 1));
                             end
                         end else begin
                             post_count <= post_count + 1'b1;
@@ -933,6 +944,16 @@ module fcapz_ela #(
     // Registered lookup of seg_start_ptr to avoid combinational CDC path
     reg [PTR_W-1:0] seg_start_ptr_rd;
     wire [PTR_W-1:0] rd_start_ptr = (NUM_SEGMENTS > 1) ? seg_start_ptr_rd : start_ptr;
+    // Physical RAM base for the segment being read (ring readback must stay in-segment).
+    wire [PTR_W-1:0] seg_rd_base;
+
+    generate
+        if (NUM_SEGMENTS > 1) begin : g_seg_rd_base
+            assign seg_rd_base = {rd_start_ptr[PTR_W-1:SEG_PTR_W], {SEG_PTR_W{1'b0}}};
+        end else begin : g_seg_rd_base_flat
+            assign seg_rd_base = {PTR_W{1'b0}};
+        end
+    endgenerate
 
     // ---- CDC: data readback (via dpram port A read) -------------------------
     reg [1:0] rd_phase;
@@ -979,7 +1000,8 @@ module fcapz_ela #(
                     word_index   = (rd_addr_sync1 - ADDR_TS_DATA_BASE[15:0]) >> 2;
                     sample_index = word_index / TS_WORDS;
                     if (sample_index < capture_len) begin
-                        idx <= rd_start_ptr + sample_index[PTR_W-1:0];
+                        idx <= seg_rd_base
+                            + ((rd_start_ptr - seg_rd_base + sample_index) & (SEG_DEPTH - 1));
                         mem_rd_pending <= 1'b1;
                         rd_phase <= 2'b01;
                         rd_is_ts <= 1'b1;
@@ -991,7 +1013,8 @@ module fcapz_ela #(
                     word_index   = (rd_addr_sync1 - ADDR_DATA_BASE) >> 2;
                     sample_index = word_index / WORDS_PER_SAMPLE;
                     if (sample_index < capture_len) begin
-                        idx <= rd_start_ptr + sample_index[PTR_W-1:0];
+                        idx <= seg_rd_base
+                            + ((rd_start_ptr - seg_rd_base + sample_index) & (SEG_DEPTH - 1));
                         mem_rd_pending <= 1'b1;
                         rd_phase <= 2'b01;
                         rd_is_ts <= 1'b0;

--- a/rtl/fcapz_ela_xilinx7.v
+++ b/rtl/fcapz_ela_xilinx7.v
@@ -38,6 +38,8 @@ module fcapz_ela_xilinx7 #(
 );
 
     localparam PTR_W = $clog2(DEPTH);
+    // Segment depth for burst read ring-wrap (equals DEPTH when unsegmented).
+    localparam BURST_SEG_DEPTH = DEPTH / NUM_SEGMENTS;
 
     // TAP signals -- control (USER1)
     wire tap1_tck, tap1_tdi, tap1_tdo;
@@ -106,7 +108,7 @@ module fcapz_ela_xilinx7 #(
 
     // ---- Burst read engine ----
     jtag_burst_read #(
-        .SAMPLE_W(SAMPLE_W), .DEPTH(DEPTH), .BURST_W(BURST_W)
+        .SAMPLE_W(SAMPLE_W), .DEPTH(DEPTH), .BURST_W(BURST_W), .SEG_DEPTH(BURST_SEG_DEPTH)
     ) u_burst (
         .arst(sample_rst),
         .tck(tap2_tck), .tdi(tap2_tdi), .tdo(tap2_tdo),

--- a/rtl/jtag_burst_read.v
+++ b/rtl/jtag_burst_read.v
@@ -22,7 +22,9 @@
 module jtag_burst_read #(
     parameter SAMPLE_W = 8,
     parameter DEPTH    = 1024,
-    parameter BURST_W  = 256
+    parameter BURST_W  = 256,
+    // Ring depth for read pointer (DEPTH when one segment; DEPTH/NUM_SEGMENTS when split)
+    parameter SEG_DEPTH = DEPTH
 ) (
     input  wire        arst,
 
@@ -45,14 +47,33 @@ module jtag_burst_read #(
 );
 
     localparam PTR_W = $clog2(DEPTH);
+    localparam SEG_PTR_W = $clog2(SEG_DEPTH);
     localparam SAMPLES_PER_SCAN = BURST_W / SAMPLE_W;
     localparam LOAD_CTR_W = $clog2(SAMPLES_PER_SCAN + 1);
+
+    // Static assert: SEG_DEPTH must be a power-of-two
+    generate
+        if (SEG_DEPTH != 0 && (SEG_DEPTH & (SEG_DEPTH - 1)) != 0) begin : g_bad_seg_depth
+            SEG_DEPTH_must_be_power_of_two invalid();
+        end
+    endgenerate
 
     reg [BURST_W-1:0] sr;
     reg [BURST_W-1:0] staging;
     reg [PTR_W-1:0]   rd_ptr;
+    reg [PTR_W-1:0]   burst_seg_base;
     reg [LOAD_CTR_W-1:0] load_cnt;
     reg loading;
+
+    // Segment base address derived from burst_ptr_in (generate avoids zero-width slice)
+    wire [PTR_W-1:0] seg_base_of_ptr;
+    generate
+        if (SEG_DEPTH >= DEPTH) begin : g_seg_base_flat
+            assign seg_base_of_ptr = {PTR_W{1'b0}};
+        end else begin : g_seg_base_split
+            assign seg_base_of_ptr = {burst_ptr_in[PTR_W-1:SEG_PTR_W], {SEG_PTR_W{1'b0}}};
+        end
+    endgenerate
 
     assign tdo      = sr[0];
     assign mem_addr  = rd_ptr;
@@ -62,6 +83,7 @@ module jtag_burst_read #(
             sr       <= {BURST_W{1'b0}};
             staging  <= {BURST_W{1'b0}};
             rd_ptr   <= {PTR_W{1'b0}};
+            burst_seg_base <= {PTR_W{1'b0}};
             load_cnt <= {LOAD_CTR_W{1'b0}};
             loading  <= 1'b0;
         end else begin
@@ -69,6 +91,7 @@ module jtag_burst_read #(
             // Burst start: set read pointer and begin first staging fill
             if (burst_start) begin
                 rd_ptr   <= burst_ptr_in;
+                burst_seg_base <= seg_base_of_ptr;
                 load_cnt <= {LOAD_CTR_W{1'b0}};
                 loading  <= 1'b1;
             end
@@ -95,7 +118,9 @@ module jtag_burst_read #(
                     staging[(load_cnt - 1) * SAMPLE_W +: SAMPLE_W] <= mem_data;
                     loading <= 1'b0;
                 end else begin
-                    rd_ptr   <= rd_ptr + 1'b1;
+                    // Wrap within segment (bitmask; SEG_DEPTH is power-of-two).
+                    rd_ptr <= burst_seg_base
+                        + ((rd_ptr - burst_seg_base + 1'b1) & (SEG_DEPTH - 1));
                     load_cnt <= load_cnt + 1'b1;
                 end
             end

--- a/tests/test_host_stack.py
+++ b/tests/test_host_stack.py
@@ -12,6 +12,7 @@ from fcapz import _version_tuple
 from fcapz.analyzer import (
     Analyzer,
     CaptureConfig,
+    CaptureResult,
     ELA_CORE_ID,
     SequencerStage,
     TriggerConfig,
@@ -111,6 +112,23 @@ class AnalyzerTests(unittest.TestCase):
         self.assertEqual(len(result.samples), 4)
         self.assertEqual(data["trigger"]["value"], 7)
         self.assertEqual(data["sample_width"], 8)
+
+    def test_vcd_shifts_hw_timestamps_to_zero(self) -> None:
+        """Continuous / live reload: VCD # times must not use raw counter offsets."""
+        from fcapz.analyzer import vcd_simulation_times
+        from fcapz.transport import VendorStubTransport
+
+        cfg = self._make_cfg()
+        r = CaptureResult(
+            config=cfg,
+            samples=[1, 2, 3],
+            timestamps=[1_000_000, 1_000_001, 1_000_005],
+        )
+        self.assertEqual(vcd_simulation_times(r), [0, 1, 5])
+        text = Analyzer(VendorStubTransport("export")).export_vcd_text(r)
+        self.assertRegex(text, r"(?m)^#0$")
+        self.assertRegex(text, r"(?m)^#5$")
+        self.assertNotRegex(text, r"(?m)^#1000000$")
 
     def test_export_files(self):
         analyzer = Analyzer(FakeTransport())
@@ -237,6 +255,14 @@ class SequencerTests(unittest.TestCase):
         analyzer.connect()
         info = analyzer.probe()
         self.assertEqual(info["probe_mux_w"], 32)
+
+    def test_probe_reports_trig_stages(self):
+        """FEATURES[3:0] is exposed as trig_stages for GUI / tooling."""
+        transport = FakeTransport()
+        transport.regs[0x003C] = (transport.regs[0x003C] & ~0xF) | 7
+        analyzer = Analyzer(transport)
+        analyzer.connect()
+        self.assertEqual(analyzer.probe()["trig_stages"], 7)
 
     def test_probe_decodes_version_fields(self):
         """probe() splits VERSION into 8-bit major, 8-bit minor, 16-bit core_id."""
@@ -434,6 +460,16 @@ class EioControllerTests(unittest.TestCase):
     def test_repr(self):
         eio = self._make_eio()
         self.assertIn("in_w=8", repr(eio))
+
+    def test_attach_restores_default_chain(self):
+        """attach() must not leave the transport on the EIO USER chain."""
+        t = FakeVioTransport()
+        self.assertEqual(t._active_chain, 1)
+        eio = EioController(t, chain=3)
+        eio.attach()
+        self.assertEqual(t._active_chain, 1)
+        self.assertEqual(eio.in_w, 8)
+        self.assertEqual(eio.bscan_chain, 3)
 
 
 class MultiSegmentTests(unittest.TestCase):


### PR DESCRIPTION
The segment start_ptr and readback idx computations used % SEG_DEPTH which synthesizes to a hardware divider unless the divisor is power-of-two. Replace all runtime modulo with & (SEG_DEPTH - 1) bitmask and add generate-time static assertions enforcing power-of-two.

Also includes: host stack fast-close, VCD timestamp helpers, bitstream freshness guard in hw integration tests.