### PR TITLE
Add startup arm/holdoff controls, harden ELA CDC/timing, and validate GSR startup on Arty

### DIFF
--- a/docs/02_install.md
+++ b/docs/02_install.md
@@ -233,7 +233,10 @@ running `hw_server`, and a programmed bitstream):
 pytest examples/arty_a7/test_hw_integration.py
 ```
 
-41 tests + 13 subtests, takes about 3 minutes on Arty A7-100T.  See
+Currently this is `54` collected items on the checked-in Arty reference
+suite: `47` passing tests and `7` optional UART tests skipped unless
+their separate UART loopback bitstream is enabled, plus `13` subtests.
+Wall-clock time is about 4-5 minutes on Arty A7-100T.  See
 [`../CONTRIBUTING.md`](../CONTRIBUTING.md) for environment variables
 that gate the optional UART loopback tests.
 

--- a/docs/04_rtl_integration.md
+++ b/docs/04_rtl_integration.md
@@ -163,7 +163,17 @@ fcapz_ejtagaxi_xilinx7 #(
 
 The checked-in [Arty top](../examples/arty_a7/arty_a7_top.v) enables more
 ELA options (`DECIM_EN`, `EXT_TRIG_EN`, `TIMESTAMP_W`, `NUM_SEGMENTS`) and
-ties `trigger_in` to an EIO output for hardware tests.
+ties `trigger_in` to an EIO-controlled fabric signal for hardware tests.
+In that reference top:
+
+- `probe_out[4]` is a manual external-trigger bit
+- `probe_out[5]` requests an early one-shot trigger 2 sample clocks
+  after the ELA enters `ARMED`
+- `probe_out[6]` requests a late trigger source beginning 8 sample
+  clocks after the ELA enters `ARMED`
+
+That deterministic trigger-test plumbing is specific to the Arty
+reference design, not a requirement of the generic wrappers.
 
 Each core uses a different USER chain so they don't collide.  The
 default chain assignments are:
@@ -208,6 +218,7 @@ module fcapz_ela_xilinx7 #(
     parameter TIMESTAMP_W  = 0,      // 0=off, 32 or 48
     parameter NUM_SEGMENTS = 1,      // number of memory segments
     parameter PROBE_MUX_W  = 0,      // total bus width for runtime probe mux (0=off)
+    parameter STARTUP_ARM  = 0,      // 1=come up armed after reset/configuration
     parameter BURST_W      = 256,    // USER2 burst DR width (don't change)
     parameter CTRL_CHAIN   = 1,      // BSCANE2 USER chain for control
     parameter DATA_CHAIN   = 2       // BSCANE2 USER chain for burst data
@@ -227,6 +238,7 @@ module fcapz_ela_xilinx7 #(
 | `TIMESTAMP_W` | int | 0, 32, 48 | Per-sample timestamp counter width.  `0` = off (no timestamps in capture results); `32` or `48` enable a parallel timestamp BRAM the same depth as the sample BRAM.  +1 BRAM.  The wrapper propagates `TIMESTAMP_W` into both `fcapz_ela` and `jtag_burst_read` so the USER2 burst engine knows how many timestamps fit per 256-bit scan and can serve timestamp bursts when `BURST_PTR[31]=1`. |
 | `NUM_SEGMENTS` | int | 1..16, **power of 2 dividing DEPTH** | Splits the buffer into N segments and auto-rearms after each segment fills.  Useful for capturing multiple trigger events in one run. |
 | `PROBE_MUX_W` | int | 0 or N×SAMPLE_W | Runtime probe mux: connect a wide bus and runtime-select a SAMPLE_W slice via the `PROBE_SEL` register.  `0` disables the feature. |
+| `STARTUP_ARM` | bit | 0/1 | Power-up default for the `STARTUP_ARM` register. When `1`, the core leaves reset already armed, which is handy for captures that need to begin immediately after configuration. |
 | `BURST_W` | int | 256 | USER2 burst DR width.  Don't change unless you know exactly what you're doing. |
 | `CTRL_CHAIN` | int | 1..4 | BSCANE2 USER chain for the control register interface. |
 | `DATA_CHAIN` | int | 1..4 | BSCANE2 USER chain for the burst data readback. |

--- a/docs/04_rtl_integration.md
+++ b/docs/04_rtl_integration.md
@@ -231,7 +231,7 @@ module fcapz_ela_xilinx7 #(
 | `DEPTH` | int | 16..16M, **power of 2** | Buffer depth.  Stored in dual-port BRAM; ~512 LUTs at depth=1024.  Larger means more BRAM. |
 | `TRIG_STAGES` | int | 1..4 | Number of trigger sequencer stages.  `1` = single-stage simple trigger; `2..4` = multi-stage state machine.  Each extra stage adds two comparators and ~50 LUTs. |
 | `STOR_QUAL` | bit | 0/1 | Storage qualification: filter which samples get stored based on a comparator.  +21 LUTs.  Up to ~10× effective depth on sparse signals. |
-| `INPUT_PIPE` | int | 0..N | Pipeline registers between `probe_in` and the comparators.  Use this if your fabric has tight timing on the probe path; each stage adds 1 cycle of latency. |
+| `INPUT_PIPE` | int | 0..N | Pipeline registers between `probe_in` and the comparators.  Use this if your fabric has tight timing on the probe path; each stage adds 1 cycle of latency.  With `INPUT_PIPE>=1`, the ELA also registers the BRAM write command so write enable, address, data, and optional timestamp reach the inferred RAM together. |
 | `NUM_CHANNELS` | int | 1..256 | Channel mux: lets one ELA observe `N` separate buses, one selected at arm time.  Probe input width becomes `SAMPLE_W * NUM_CHANNELS` bits. |
 | `DECIM_EN` | bit | 0/1 | Enables the `--decimation` runtime option.  +24-bit divider.  Free if disabled. |
 | `EXT_TRIG_EN` | bit | 0/1 | Enables `trigger_in` / `trigger_out` ports.  Free if disabled. |

--- a/docs/04_rtl_integration.md
+++ b/docs/04_rtl_integration.md
@@ -219,6 +219,7 @@ module fcapz_ela_xilinx7 #(
     parameter NUM_SEGMENTS = 1,      // number of memory segments
     parameter PROBE_MUX_W  = 0,      // total bus width for runtime probe mux (0=off)
     parameter STARTUP_ARM  = 0,      // 1=come up armed after reset/configuration
+    parameter DEFAULT_TRIG_EXT = 0,  // reset/default external trigger mode
     parameter BURST_W      = 256,    // USER2 burst DR width (don't change)
     parameter CTRL_CHAIN   = 1,      // BSCANE2 USER chain for control
     parameter DATA_CHAIN   = 2       // BSCANE2 USER chain for burst data
@@ -239,6 +240,7 @@ module fcapz_ela_xilinx7 #(
 | `NUM_SEGMENTS` | int | 1..16, **power of 2 dividing DEPTH** | Splits the buffer into N segments and auto-rearms after each segment fills.  Useful for capturing multiple trigger events in one run. |
 | `PROBE_MUX_W` | int | 0 or N×SAMPLE_W | Runtime probe mux: connect a wide bus and runtime-select a SAMPLE_W slice via the `PROBE_SEL` register.  `0` disables the feature. |
 | `STARTUP_ARM` | bit | 0/1 | Power-up default for the `STARTUP_ARM` register. When `1`, the core leaves reset already armed, which is handy for captures that need to begin immediately after configuration. |
+| `DEFAULT_TRIG_EXT` | int | 0..3 | Power-up/reset default for `TRIG_EXT`. Useful with `STARTUP_ARM=1` when you want the bitstream to come up armed but wait for an external trigger condition instead of immediately matching the default internal comparator. |
 | `BURST_W` | int | 256 | USER2 burst DR width.  Don't change unless you know exactly what you're doing. |
 | `CTRL_CHAIN` | int | 1..4 | BSCANE2 USER chain for the control register interface. |
 | `DATA_CHAIN` | int | 1..4 | BSCANE2 USER chain for the burst data readback. |

--- a/docs/05_ela_core.md
+++ b/docs/05_ela_core.md
@@ -461,6 +461,11 @@ This is intentionally different from `trigger_delay`: holdoff suppresses
 
 Hardware validation status on the checked-in Arty A7 reference design:
 
+- Configuration/GSR startup is validated by programming the Arty bitstream
+  built with `STARTUP_ARM=1`, then reading `STATUS` before issuing any host
+  reset/config write.  The reference bitstream uses `DEFAULT_TRIG_EXT=2`
+  so the core remains `armed=1` while waiting for the EIO-driven external
+  trigger input.
 - `startup_arm` is validated deterministically by checking the ELA
   status register after `RESET`: with `startup_arm=True`, the core
   comes back `armed=1`; with `startup_arm=False`, it stays idle.

--- a/docs/05_ela_core.md
+++ b/docs/05_ela_core.md
@@ -37,6 +37,13 @@ dual-port BRAM continuously.  When the trigger fires, it captures
 shows what was happening *before* the trigger fired, the trigger
 sample itself, and the post-trigger window.
 
+On timing-sensitive builds, especially with `INPUT_PIPE=1`, the BRAM
+write command is itself registered: write enable, address, sample data,
+and timestamp data are captured together before they drive the inferred
+RAM.  That keeps the trigger/store decision off the same-cycle BRAM
+write path, while preserving the externally visible capture window and
+trigger-sample alignment.
+
 The trigger sample sits at index `pretrigger` in the captured array
 (0-indexed).  So if you `--pretrigger 8 --posttrigger 16`, you get
 25 samples total, and `samples[8]` is the one that caused the

--- a/docs/05_ela_core.md
+++ b/docs/05_ela_core.md
@@ -3,7 +3,8 @@
 > **Goal**: deep dive on the Embedded Logic Analyzer.  By the end of
 > this chapter you will understand every trigger mode, every storage
 > option, and how the runtime knobs (decimation, segments, probe mux,
-> trigger delay) interact with the basic capture flow.
+> startup arm, trigger holdoff, trigger delay) interact with the basic
+> capture flow.
 >
 > **Pre-reads**: [01_overview](01_overview.md),
 > [03_first_capture](03_first_capture.md),
@@ -281,9 +282,9 @@ cfg = CaptureConfig(
 )
 ```
 
-The reference Arty A7 design ties `trigger_in` to `btn[1]` so you
-can manually fire the trigger by pressing the button — try it from
-the GUI or the CLI:
+The reference Arty A7 design ties `trigger_in` to an EIO-controlled
+fabric signal, so you can manually fire the trigger from the host
+without rebuilding the bitstream — try it from the GUI or the CLI:
 
 ```bash
 fcapz capture \
@@ -296,7 +297,8 @@ fcapz capture \
 ```
 
 (`0xFF` is unlikely to ever match the counter at the moment you arm,
-so the OR-with-button behavior is the only way the trigger fires.)
+so the OR-with-external-trigger behavior is the only way the trigger
+fires.)
 
 ## Per-sample timestamps (`TIMESTAMP_W=32` or `48`)
 
@@ -413,7 +415,56 @@ cfg = CaptureConfig(
 )
 ```
 
-## Configurable trigger delay (new in v0.3.0)
+## Startup arm and trigger holdoff
+
+Two closely related knobs control **when the core is allowed to start
+listening** for a trigger:
+
+- `startup_arm`: if enabled, RESET leaves the core armed instead of idle.
+  The RTL parameter `STARTUP_ARM=1` makes that behavior the power-up
+  default, so a bitstream can come up ready to capture immediately after
+  configuration.
+- `trigger_holdoff`: ignore trigger hits for N sample-clock cycles after
+  `ARM` and after each segmented auto-rearm.
+
+`trigger_holdoff` is useful when the interesting trigger condition is
+real, but the first few cycles after arming are noisy or guaranteed to
+contain a false positive.
+
+```python
+cfg = CaptureConfig(
+    ...,
+    startup_arm=True,
+    trigger_holdoff=8,
+)
+```
+
+What happens at runtime:
+
+1. The core arms (explicit `ARM`, segmented auto-rearm, or RESET with
+   `startup_arm` enabled).
+2. Samples still flow into the circular buffer normally.
+3. Trigger comparators and sequencer transitions are ignored for
+   `trigger_holdoff` cycles.
+4. After that window expires, normal trigger evaluation resumes.
+
+This is intentionally different from `trigger_delay`: holdoff suppresses
+*early trigger acceptance*, while delay accepts the trigger and moves the
+*committed trigger sample* later.
+
+Hardware validation status on the checked-in Arty A7 reference design:
+
+- `startup_arm` is validated deterministically by checking the ELA
+  status register after `RESET`: with `startup_arm=True`, the core
+  comes back `armed=1`; with `startup_arm=False`, it stays idle.
+- `trigger_holdoff` is validated deterministically with an on-chip
+  trigger-test hook that generates a known external-trigger stimulus
+  a fixed number of sample clocks after the ELA enters `ARMED`.
+  The hardware tests confirm that a pulse 2 cycles after arm is
+  blocked by `trigger_holdoff=4`, while a stimulus beginning 8 cycles
+  after arm is accepted normally.
+
+## Configurable trigger delay
 
 Sometimes the cause of a problem and the moment you want to look at
 are **not the same cycle**.  Example: a state machine asserts an

--- a/docs/06_eio_core.md
+++ b/docs/06_eio_core.md
@@ -21,8 +21,12 @@ sticking a multimeter probe on a signal, except for digital values
 and with the ability to drive a signal as well as observe it.
 
 The reference Arty A7 design wires `probe_in` to the pushbuttons plus
-a 1 Hz low-nibble counter, and wires `probe_out` to the LEDs.  After programming, you
-can:
+a 1 Hz low-nibble counter, and wires `probe_out[3:0]` to the LEDs.
+Higher `probe_out` bits are used as fabric-side debug controls for the
+hardware tests: bit 4 is the manual ELA external trigger, bit 5 asks
+the Arty top to emit an early one-shot trigger 2 cycles after the ELA
+enters `ARMED`, and bit 6 asks it to assert a late trigger starting 8
+cycles after `ARMED`.  After programming, you can:
 
 ```bash
 $ fcapz eio-read
@@ -43,7 +47,9 @@ first (chain **3** for [`arty_a7_top.v`](../examples/arty_a7/arty_a7_top.v)).
 If the LEDs still ignore writes, confirm the FPGA is programmed with
 that reference bitstream and rebuild if you changed the top-level
 (after programming, `fcapz eio-write 0x0F` from the CLI is a quick
-sanity check).
+sanity check).  On this reference top, EIO bits above 3 do **not**
+drive LEDs; they are intentionally reserved for internal trigger-test
+plumbing used by the Arty hardware integration suite.
 
 ## Architecture
 
@@ -368,6 +374,19 @@ exercise EIO end-to-end:
 | `test_set_clear_bit` | `set_bit()` modifies one bit without disturbing others |
 | `test_output_roundtrip_all_bits` | every bit position works |
 | `test_write_zero_outputs` | clears all bits |
+
+The same Arty reference EIO outputs are also used by the ELA hardware
+tests as deterministic control hooks:
+
+- `probe_out[4]`: manual external trigger source for the ELA
+- `probe_out[5]`: request a one-shot external trigger 2 sample clocks
+  after the ELA enters `ARMED`
+- `probe_out[6]`: request an external trigger level beginning 8 sample
+  clocks after the ELA enters `ARMED`
+
+Those bits are not part of the generic EIO core contract; they are
+just how the checked-in Arty top-level chooses to use its spare output
+bits for board-level validation.
 
 The unit tests in [`../tests/test_host_stack.py`](../tests/test_host_stack.py)
 cover the controller against a `FakeVioTransport` (no hardware

--- a/docs/09_python_api.md
+++ b/docs/09_python_api.md
@@ -197,6 +197,8 @@ cfg = CaptureConfig(
     stor_qual_mode  = 0,
     stor_qual_value = 0,
     stor_qual_mask  = 0,
+    startup_arm     = False,       # leave the core armed after RESET
+    trigger_holdoff = 0,           # ignore triggers for N cycles after arm/re-arm
     trigger_delay   = 0,           # new in v0.3.0
 )
 a.configure(cfg)
@@ -280,7 +282,9 @@ get one giant `sample` blob.  See [chapter 15](15_export_formats.md).
 ### `reset() -> None`
 
 Asserts the RESET bit, clearing armed/triggered/done.  Use it to
-abort an in-progress capture or recover from a stuck state.
+abort an in-progress capture or recover from a stuck state.  If
+`CaptureConfig.startup_arm` is enabled, a later RESET leaves the
+core armed again instead of idle.
 
 ## `CaptureConfig` and friends
 
@@ -304,6 +308,8 @@ class CaptureConfig:
     stor_qual_mode:   int = 0       # 0/1/2
     stor_qual_value:  int = 0
     stor_qual_mask:   int = 0
+    startup_arm:      bool = False  # RESET leaves the core armed
+    trigger_holdoff:  int = 0       # 0..65535 cycles after arm/re-arm
     trigger_delay:    int = 0       # 0..65535 sample-clock cycles
 ```
 

--- a/docs/12_gui.md
+++ b/docs/12_gui.md
@@ -143,7 +143,9 @@ Top section — **trigger**:
 | **Trigger mode** dropdown | `trigger.mode` (`value_match` / `edge_detect` / `both`) |
 | **Trigger value** + radix (default **Hex**; also Dec / Oct / Bin) | `trigger.value` (parsed in the selected base) |
 | **Trigger mask** hex input | `trigger.mask` |
-| **Trigger delay** spinner (0..65535) | `trigger_delay` (new in v0.3.0) |
+| **Startup arm** checkbox | `startup_arm` |
+| **Trigger holdoff** spinner (0..65535) | `trigger_holdoff` |
+| **Trigger delay** spinner (0..65535) | `trigger_delay` |
 | **Decimation** spinner | `decimation` |
 | **Ext-trigger mode** dropdown | `ext_trigger_mode` |
 

--- a/docs/specs/register_map.md
+++ b/docs/specs/register_map.md
@@ -59,6 +59,8 @@ in that bridge’s section.
 - `0x0030`: `SQ_MODE` (rw) - Storage qualification mode (0=off, 1=value, 2=edge, 3=both; STOR_QUAL=1 only)
 - `0x0034`: `SQ_VALUE` (rw) - Storage qualification match value
 - `0x0038`: `SQ_MASK` (rw) - Storage qualification match mask
+- `0x00D8`: `STARTUP_ARM` (rw) - Bit 0. When set, RESET leaves the core armed instead of idle. `STARTUP_ARM=1` in RTL changes the power-up default of this register so the bitstream can come up pre-armed immediately after configuration.
+- `0x00DC`: `TRIG_HOLDOFF` (rw) - Trigger holdoff in sample-clock cycles (0..65535). Trigger hits are ignored for N cycles after ARM and after each segmented auto-rearm. Distinct from `TRIG_DELAY`.
 - `0x00D4`: `TRIG_DELAY` (rw) - Post-trigger delay in sample-clock cycles (0..65535). When non-zero, the committed trigger sample is shifted N cycles after the trigger event, compensating for upstream pipeline latency. The pre/post-trigger sample counts and the buffer wrap behavior are unchanged — only the position of the "trigger" anchor moves forward.
 - `0x003C`: `FEATURES` (ro) - Feature flags: `[3:0]`=TRIG_STAGES, `[4]`=STOR_QUAL
 - `0x0040+N*20+0`:  `SEQ_STAGE_N_CFG` (rw) - See encoding below

--- a/examples/arty_a7/arty_a7_top.v
+++ b/examples/arty_a7/arty_a7_top.v
@@ -14,6 +14,8 @@
 //     EXT_TRIG_EN=1    external trigger input from EIO probe_out[4]
 //     TIMESTAMP_W=32   per-sample timestamp RAM/readback
 //     NUM_SEGMENTS=4   segmented capture with auto-rearm
+//     STARTUP_ARM=1    prove Xilinx configuration/GSR startup auto-arm
+//     DEFAULT_TRIG_EXT=2 keeps the default startup arm waiting for EIO trigger_in
 //   Baseline trigger sequencer/storage qualification settings stay at
 //   wrapper defaults unless overridden in the wrapper parameters.
 //
@@ -53,12 +55,14 @@ module arty_a7_top (
     wire [7:0] eio_probe_out;
     reg [7:0] eio_out_sync1;
     reg [7:0] eio_out_sync2;
-    reg ela_armed_d;
+    reg ela_pretrigger_d;
     reg [3:0] armed_test_count;
     reg armed_test_active;
     reg armed_test_pulse;
     reg armed_test_gate;
     wire trigger_in_w;
+    wire ela_pretrigger_phase_w;
+    wire ela_fresh_arm_phase_w;
 
     // EIO probe_out updates on jtag_clk; resync into sys_clk before using it
     // for LEDs or deterministic trigger-test controls.
@@ -107,24 +111,33 @@ module arty_a7_top (
         end
     end
 
+    assign ela_pretrigger_phase_w = u_ela.g_ela_only.u_ela.armed &&
+                                    !u_ela.g_ela_only.u_ela.triggered;
+    assign ela_fresh_arm_phase_w = u_ela.g_ela_only.u_ela.any_arm_pulse ||
+                                   (ela_pretrigger_phase_w && !ela_pretrigger_d);
+
     // ---- Deterministic trigger test hook ----
     // eio_probe_out[4]: manual external trigger (legacy host-driven)
-    // eio_probe_out[5]: emit one pulse 2 cycles after ELA enters ARMED
-    // eio_probe_out[6]: emit one pulse 8 cycles after ELA enters ARMED
+    // eio_probe_out[5]: emit one pulse immediately when ELA enters a fresh
+    //                   armed/not-triggered phase
+    // eio_probe_out[6]: emit one pulse 8 cycles after ELA enters a fresh
+    //                   armed/not-triggered phase
     always @(posedge clk) begin
         if (rst) begin
-            ela_armed_d       <= 1'b0;
+            ela_pretrigger_d  <= 1'b0;
             armed_test_count  <= 4'd0;
             armed_test_active <= 1'b0;
             armed_test_pulse  <= 1'b0;
             armed_test_gate   <= 1'b0;
         end else begin
-            ela_armed_d       <= ela_armed_w;
+            ela_pretrigger_d  <= ela_pretrigger_phase_w;
             armed_test_pulse  <= 1'b0;
 
-            if (ela_armed_w && !ela_armed_d) begin
+            if (ela_fresh_arm_phase_w) begin
                 armed_test_count  <= 4'd0;
-                armed_test_active <= eio_out_sync2[5] | eio_out_sync2[6];
+                armed_test_active <= eio_out_sync2[6];
+                if (eio_out_sync2[5])
+                    armed_test_pulse <= 1'b1;
                 armed_test_gate   <= 1'b0;
             end else if (!ela_armed_w) begin
                 armed_test_count  <= 4'd0;
@@ -132,8 +145,6 @@ module arty_a7_top (
                 armed_test_gate   <= 1'b0;
             end else if (armed_test_active) begin
                 armed_test_count <= armed_test_count + 1'b1;
-                if (eio_out_sync2[5] && (armed_test_count == 4'd1))
-                    armed_test_pulse <= 1'b1;
                 if (eio_out_sync2[6] && (armed_test_count == 4'd7))
                     armed_test_gate <= 1'b1;
                 if (armed_test_count == 4'd7)
@@ -148,10 +159,13 @@ module arty_a7_top (
     fcapz_ela_xilinx7 #(
         .SAMPLE_W     (SAMPLE_W),
         .DEPTH        (DEPTH),
+        .INPUT_PIPE   (1),
         .DECIM_EN     (1),
         .EXT_TRIG_EN  (1),
         .TIMESTAMP_W  (32),
-        .NUM_SEGMENTS (NUM_SEGMENTS)
+        .NUM_SEGMENTS (NUM_SEGMENTS),
+        .STARTUP_ARM  (1),
+        .DEFAULT_TRIG_EXT(2)
     ) u_ela (
         .sample_clk (clk),
         .sample_rst (rst),

--- a/examples/arty_a7/arty_a7_top.v
+++ b/examples/arty_a7/arty_a7_top.v
@@ -48,11 +48,20 @@ module arty_a7_top (
     reg [3:0] slow_counter;
     reg [26:0] sec_divider;
     wire trigger_out_w;
+    wire ela_armed_w;
     wire [7:0] eio_probe_in;
     wire [7:0] eio_probe_out;
+    reg [7:0] eio_out_sync1;
+    reg [7:0] eio_out_sync2;
+    reg ela_armed_d;
+    reg [3:0] armed_test_count;
+    reg armed_test_active;
+    reg armed_test_pulse;
+    reg armed_test_gate;
+    wire trigger_in_w;
 
-    // EIO probe_out updates on jtag_clk; LEDs are static I/O on the fabric clock domain.
-    // Resync into sys_clk so the pins see clean levels (matches CDC note in docs/06_eio_core.md).
+    // EIO probe_out updates on jtag_clk; resync into sys_clk before using it
+    // for LEDs or deterministic trigger-test controls.
     (* ASYNC_REG = "TRUE" *) reg [3:0] led_sync1;
     (* ASYNC_REG = "TRUE" *) reg [3:0] led_sync2;
 
@@ -87,6 +96,54 @@ module arty_a7_top (
         end
     end
 
+    // ---- EIO output resynchronization ----
+    always @(posedge clk) begin
+        if (rst) begin
+            eio_out_sync1 <= 8'h00;
+            eio_out_sync2 <= 8'h00;
+        end else begin
+            eio_out_sync1 <= eio_probe_out;
+            eio_out_sync2 <= eio_out_sync1;
+        end
+    end
+
+    // ---- Deterministic trigger test hook ----
+    // eio_probe_out[4]: manual external trigger (legacy host-driven)
+    // eio_probe_out[5]: emit one pulse 2 cycles after ELA enters ARMED
+    // eio_probe_out[6]: emit one pulse 8 cycles after ELA enters ARMED
+    always @(posedge clk) begin
+        if (rst) begin
+            ela_armed_d       <= 1'b0;
+            armed_test_count  <= 4'd0;
+            armed_test_active <= 1'b0;
+            armed_test_pulse  <= 1'b0;
+            armed_test_gate   <= 1'b0;
+        end else begin
+            ela_armed_d       <= ela_armed_w;
+            armed_test_pulse  <= 1'b0;
+
+            if (ela_armed_w && !ela_armed_d) begin
+                armed_test_count  <= 4'd0;
+                armed_test_active <= eio_out_sync2[5] | eio_out_sync2[6];
+                armed_test_gate   <= 1'b0;
+            end else if (!ela_armed_w) begin
+                armed_test_count  <= 4'd0;
+                armed_test_active <= 1'b0;
+                armed_test_gate   <= 1'b0;
+            end else if (armed_test_active) begin
+                armed_test_count <= armed_test_count + 1'b1;
+                if (eio_out_sync2[5] && (armed_test_count == 4'd1))
+                    armed_test_pulse <= 1'b1;
+                if (eio_out_sync2[6] && (armed_test_count == 4'd7))
+                    armed_test_gate <= 1'b1;
+                if (armed_test_count == 4'd7)
+                    armed_test_active <= 1'b0;
+            end
+        end
+    end
+
+    assign trigger_in_w = eio_out_sync2[4] | armed_test_pulse | armed_test_gate;
+
     // ---- ELA (all features enabled for HW validation) ----
     fcapz_ela_xilinx7 #(
         .SAMPLE_W     (SAMPLE_W),
@@ -99,8 +156,9 @@ module arty_a7_top (
         .sample_clk (clk),
         .sample_rst (rst),
         .probe_in   (counter),
-        .trigger_in (eio_probe_out[4]), // JTAG-driven manual trigger via EIO
-        .trigger_out(trigger_out_w)
+        .trigger_in (trigger_in_w),
+        .trigger_out(trigger_out_w),
+        .armed_out  (ela_armed_w)
     );
 
     // ---- EJTAGAXI: JTAG-to-AXI4 bridge (USER4) ----
@@ -166,7 +224,7 @@ module arty_a7_top (
             led_sync1 <= 4'b0;
             led_sync2 <= 4'b0;
         end else begin
-            led_sync1 <= eio_probe_out[3:0];
+            led_sync1 <= eio_out_sync2[3:0];
             led_sync2 <= led_sync1;
         end
     end

--- a/examples/arty_a7/build_arty.tcl
+++ b/examples/arty_a7/build_arty.tcl
@@ -88,6 +88,9 @@ if {[file exists $project_xpr]} {
         set_property is_global_include true \
             [get_files $root/rtl/fcapz_version.vh]
     }
+    if {[llength [get_files -quiet $root/rtl/reset_sync.v]] == 0} {
+        add_files $root/rtl/reset_sync.v
+    }
 } else {
     # No .xpr but partial peripheral dirs may exist from a killed build.
     # Use -force to clear them now that we've removed the stale locks.
@@ -96,6 +99,7 @@ if {[file exists $project_xpr]} {
     # ── Sources (only added on initial creation) ──────────────
     add_files [list \
         $root/rtl/fcapz_version.vh \
+        $root/rtl/reset_sync.v \
         $root/rtl/dpram.v \
         $root/rtl/trig_compare.v \
         $root/rtl/fcapz_ela.v \

--- a/examples/arty_a7/test_hw_integration.py
+++ b/examples/arty_a7/test_hw_integration.py
@@ -137,6 +137,36 @@ class TestProbe(unittest.TestCase):
 
 
 @unittest.skipIf(_SKIP, "FPGACAP_SKIP_HW is set")
+@unittest.skipIf(_BACKEND != "hw_server", "requires hw_server programming on connect")
+class TestStartupArmGsr(unittest.TestCase):
+    """Configuration-time startup arm validation for the Arty bitstream."""
+
+    def test_bitstream_powers_up_armed_after_gsr(self):
+        """After FPGA programming, STARTUP_ARM=1 should arm without host reset."""
+        t = _make_transport()
+        try:
+            t.connect()
+            self.assertEqual(t.read_reg(0x00D8) & 0x1, 1)
+            self.assertEqual(t.read_reg(0x00B4) & 0x3, 2)
+
+            status = t.read_reg(0x0008)
+            self.assertTrue(
+                status & 0x1,
+                f"expected armed after configuration/GSR, got 0x{status:08X}",
+            )
+            self.assertFalse(
+                status & 0x2,
+                f"unexpected triggered after configuration/GSR, got 0x{status:08X}",
+            )
+            self.assertFalse(
+                status & 0x4,
+                f"unexpected done after configuration/GSR, got 0x{status:08X}",
+            )
+        finally:
+            t.close()
+
+
+@unittest.skipIf(_SKIP, "FPGACAP_SKIP_HW is set")
 class TestRegisterRoundTrip(unittest.TestCase):
     """Write/read-back on writable registers."""
 
@@ -438,9 +468,18 @@ class TestStartupArmAndHoldoff(unittest.TestCase):
 
         self.assertFalse(self.a.wait_done(timeout=0.2, poll_interval=0.01))
         status = self.t.read_reg(0x0008)
-        self.assertTrue(status & 0x1, f"expected still armed after blocked early pulse, got 0x{status:08X}")
-        self.assertFalse(status & 0x2, f"unexpected triggered after blocked early pulse, got 0x{status:08X}")
-        self.assertFalse(status & 0x4, f"unexpected done after blocked early pulse, got 0x{status:08X}")
+        self.assertTrue(
+            status & 0x1,
+            f"expected still armed after blocked early pulse, got 0x{status:08X}",
+        )
+        self.assertFalse(
+            status & 0x2,
+            f"unexpected triggered after blocked early pulse, got 0x{status:08X}",
+        )
+        self.assertFalse(
+            status & 0x4,
+            f"unexpected done after blocked early pulse, got 0x{status:08X}",
+        )
 
     def test_trigger_holdoff_allows_late_armed_edge_pulse(self):
         """A pulse 8 cycles after ARMED should pass when holdoff=4."""

--- a/examples/arty_a7/test_hw_integration.py
+++ b/examples/arty_a7/test_hw_integration.py
@@ -339,6 +339,132 @@ class TestCapture(unittest.TestCase):
 
 
 @unittest.skipIf(_SKIP, "FPGACAP_SKIP_HW is set")
+class TestStartupArmAndHoldoff(unittest.TestCase):
+    """Hardware validation for the new startup-arm / holdoff controls."""
+
+    def setUp(self):
+        from fcapz.analyzer import Analyzer
+        from fcapz.eio import EioController
+
+        self.t = _make_transport()
+        self.a = Analyzer(self.t)
+        self.a.connect()
+        self.eio = EioController(self.t, chain=3)
+        self.eio.attach()
+        self._set_eio_outputs(0)
+
+    def tearDown(self):
+        try:
+            self._set_eio_outputs(0)
+        finally:
+            self.a.close()
+
+    def _set_eio_outputs(self, value: int) -> None:
+        self.t.select_chain(3)
+        try:
+            self.eio.write_outputs(value)
+        finally:
+            self.t.select_chain(1)
+
+    def test_register_roundtrip(self):
+        """STARTUP_ARM / TRIG_HOLDOFF read back correctly on silicon."""
+        self.t.write_reg(0x00D8, 1)
+        self.t.write_reg(0x00DC, 23)
+        self.assertEqual(self.t.read_reg(0x00D8) & 0x1, 1)
+        self.assertEqual(self.t.read_reg(0x00DC) & 0xFFFF, 23)
+        self.t.write_reg(0x00D8, 0)
+        self.t.write_reg(0x00DC, 0)
+
+    def test_startup_arm_reset_rearms_deterministically(self):
+        """RESET should leave the core armed when startup_arm is enabled."""
+        from fcapz.analyzer import CaptureConfig, TriggerConfig
+
+        cfg = CaptureConfig(
+            pretrigger=0,
+            posttrigger=2,
+            trigger=TriggerConfig(mode="value_match", value=0, mask=0),
+            sample_width=8,
+            depth=1024,
+            startup_arm=True,
+            ext_trigger_mode=2,
+        )
+        self.a.configure(cfg)
+        self.a.reset()
+
+        status = self.t.read_reg(0x0008)
+        self.assertTrue(status & 0x1, f"expected armed after RESET, got 0x{status:08X}")
+        self.assertFalse(status & 0x2, f"unexpected triggered after RESET, got 0x{status:08X}")
+        self.assertFalse(status & 0x4, f"unexpected done after RESET, got 0x{status:08X}")
+
+    def test_reset_without_startup_arm_stays_idle(self):
+        """RESET should leave the core idle when startup_arm is disabled."""
+        from fcapz.analyzer import CaptureConfig, TriggerConfig
+
+        cfg = CaptureConfig(
+            pretrigger=0,
+            posttrigger=2,
+            trigger=TriggerConfig(mode="value_match", value=0, mask=0),
+            sample_width=8,
+            depth=1024,
+            startup_arm=False,
+            ext_trigger_mode=2,
+        )
+        self.a.configure(cfg)
+        self.a.reset()
+
+        status = self.t.read_reg(0x0008)
+        self.assertFalse(status & 0x1, f"expected idle after RESET, got 0x{status:08X}")
+        self.assertFalse(status & 0x2, f"unexpected triggered after RESET, got 0x{status:08X}")
+        self.assertFalse(status & 0x4, f"unexpected done after RESET, got 0x{status:08X}")
+
+    def test_trigger_holdoff_blocks_early_armed_edge_pulse(self):
+        """A pulse 2 cycles after ARMED should be ignored by holdoff=4."""
+        from fcapz.analyzer import CaptureConfig, TriggerConfig
+
+        cfg = CaptureConfig(
+            pretrigger=0,
+            posttrigger=2,
+            trigger=TriggerConfig(mode="value_match", value=0, mask=0),
+            sample_width=8,
+            depth=1024,
+            startup_arm=False,
+            trigger_holdoff=4,
+            ext_trigger_mode=2,
+        )
+        self.a.configure(cfg)
+        self._set_eio_outputs(1 << 5)
+        self.a.arm()
+
+        self.assertFalse(self.a.wait_done(timeout=0.2, poll_interval=0.01))
+        status = self.t.read_reg(0x0008)
+        self.assertTrue(status & 0x1, f"expected still armed after blocked early pulse, got 0x{status:08X}")
+        self.assertFalse(status & 0x2, f"unexpected triggered after blocked early pulse, got 0x{status:08X}")
+        self.assertFalse(status & 0x4, f"unexpected done after blocked early pulse, got 0x{status:08X}")
+
+    def test_trigger_holdoff_allows_late_armed_edge_pulse(self):
+        """A pulse 8 cycles after ARMED should pass when holdoff=4."""
+        from fcapz.analyzer import CaptureConfig, TriggerConfig
+
+        cfg = CaptureConfig(
+            pretrigger=0,
+            posttrigger=2,
+            trigger=TriggerConfig(mode="value_match", value=0, mask=0),
+            sample_width=8,
+            depth=1024,
+            startup_arm=False,
+            trigger_holdoff=4,
+            ext_trigger_mode=2,
+        )
+        self.a.configure(cfg)
+        self._set_eio_outputs(1 << 6)
+        self.a.arm()
+
+        result = self.a.capture(timeout=5.0)
+        self.assertEqual(len(result.samples), 3)
+        self.assertFalse(result.overflow)
+
+
+@unittest.skipIf(_SKIP, "FPGACAP_SKIP_HW is set")
 class TestExportFormats(unittest.TestCase):
     """Capture and export to all three formats."""
 

--- a/examples/arty_a7/test_hw_integration.py
+++ b/examples/arty_a7/test_hw_integration.py
@@ -55,6 +55,7 @@ _ROOT = Path(__file__).resolve().parents[2]
 # RTL and design sources that feed the bitstream (must match build_arty.tcl)
 _BITSTREAM_SOURCES = [
     _ROOT / "rtl" / "fcapz_version.vh",
+    _ROOT / "rtl" / "reset_sync.v",
     _ROOT / "rtl" / "dpram.v",
     _ROOT / "rtl" / "trig_compare.v",
     _ROOT / "rtl" / "fcapz_ela.v",

--- a/host/fcapz/analyzer.py
+++ b/host/fcapz/analyzer.py
@@ -63,6 +63,8 @@ _SEQ_STRIDE = 20
 _ADDR_PROBE_SEL = 0x00AC
 _ADDR_PROBE_MUX_W = 0x00D0
 _ADDR_TRIG_DELAY = 0x00D4
+_ADDR_STARTUP_ARM = 0x00D8
+_ADDR_TRIG_HOLDOFF = 0x00DC
 
 # Order matches :meth:`Analyzer.probe` field extraction (hw_server pipelined read).
 _ELA_PROBE_ADDRS: tuple[int, ...] = (
@@ -149,6 +151,8 @@ class CaptureConfig:
     stor_qual_mode: int = 0    # 0=disabled; 1=store when match, 2=store when no match
     stor_qual_value: int = 0   # storage qualification comparison value
     stor_qual_mask: int = 0    # storage qualification mask
+    startup_arm: bool = False  # if True, reset leaves the core armed
+    trigger_holdoff: int = 0   # sample-clock cycles to ignore triggers after arm/re-arm
     trigger_delay: int = 0     # post-trigger delay in sample-clock cycles
                                # (0..65535) — shifts the committed trigger
                                # sample N cycles after the trigger event,
@@ -247,6 +251,10 @@ class Analyzer:
             raise ValueError(
                 f"trigger_delay must be 0..65535, got {config.trigger_delay}"
             )
+        if not (0 <= config.trigger_holdoff <= 0xFFFF):
+            raise ValueError(
+                f"trigger_holdoff must be 0..65535, got {config.trigger_holdoff}"
+            )
 
         self._validate_probes(config.probes, config.sample_width)
 
@@ -298,6 +306,8 @@ class Analyzer:
         self.transport.write_reg(_ADDR_DECIM, config.decimation)
         self.transport.write_reg(_ADDR_TRIG_EXT, config.ext_trigger_mode)
         self.transport.write_reg(_ADDR_PROBE_SEL, config.probe_sel)
+        self.transport.write_reg(_ADDR_STARTUP_ARM, int(bool(config.startup_arm)))
+        self.transport.write_reg(_ADDR_TRIG_HOLDOFF, config.trigger_holdoff)
         self.transport.write_reg(_ADDR_TRIG_DELAY, config.trigger_delay)
         if config.stor_qual_mode:
             self.transport.write_reg(_ADDR_SQ_MODE, config.stor_qual_mode)

--- a/host/fcapz/cli.py
+++ b/host/fcapz/cli.py
@@ -134,6 +134,8 @@ def _build_config(args: argparse.Namespace) -> CaptureConfig:
         stor_qual_mode=getattr(args, "stor_qual_mode", 0),
         stor_qual_value=getattr(args, "stor_qual_value", 0),
         stor_qual_mask=getattr(args, "stor_qual_mask", 0),
+        startup_arm=getattr(args, "startup_arm", False),
+        trigger_holdoff=getattr(args, "trigger_holdoff", 0),
         trigger_delay=getattr(args, "trigger_delay", 0),
     )
 
@@ -288,6 +290,25 @@ def build_parser() -> argparse.ArgumentParser:
             type=lambda x: int(x, 0),
             default=0,
             help="Storage qualification mask (hex or decimal)",
+        )
+        parser.add_argument(
+            "--startup-arm",
+            action="store_true",
+            help=(
+                "Leave the ELA armed after reset / configuration recovery. "
+                "Useful with bitstreams that want to begin capturing immediately "
+                "after startup or after an explicit RESET."
+            ),
+        )
+        parser.add_argument(
+            "--trigger-holdoff",
+            type=_uint16,
+            default=0,
+            help=(
+                "Ignore trigger hits for N sample-clock cycles after arm or "
+                "segmented auto-rearm. Distinct from --trigger-delay, which "
+                "moves the committed trigger sample later."
+            ),
         )
         parser.add_argument(
             "--trigger-delay",

--- a/host/fcapz/gui/app_window.py
+++ b/host/fcapz/gui/app_window.py
@@ -482,6 +482,10 @@ class MainWindow(QMainWindow):
     ) -> None:
         QApplication.restoreOverrideCursor()
         conn = self._conn.connection_settings()
+        hw_attach_only = (
+            conn.backend == "hw_server"
+            and (not bool(conn.program_on_connect) or not bool(conn.program))
+        )
         self._ela_present = info is not None
         if info is not None:
             _log.info(
@@ -506,14 +510,22 @@ class MainWindow(QMainWindow):
         self._eio_panel.set_transport(analyzer.transport)
         self._axi_panel.set_transport_available(True)
         self._uart_panel.set_transport_available(True)
-        if info is not None:
-            self._conn.set_connected(True, "Connected — ELA identity OK.")
-        else:
-            self._conn.set_connected(
-                True,
-                "Connected — JTAG OK; no ELA on USER1 (EIO/AXI/UART still available).",
+        if info is not None and hw_attach_only:
+            msg = (
+                "Connected — JTAG only; FPGA was not programmed on connect, so ELA captures "
+                "reflect the image already loaded on the board."
             )
-        self.statusBar().showMessage("Connected")
+        elif info is not None:
+            msg = "Connected — ELA identity OK."
+        elif hw_attach_only:
+            msg = (
+                "Connected — JTAG only; FPGA was not programmed on connect, and no ELA was "
+                "found on USER1 in the currently loaded image."
+            )
+        else:
+            msg = "Connected — JTAG OK; no ELA on USER1 (EIO/AXI/UART still available)."
+        self._conn.set_connected(True, msg)
+        self.statusBar().showMessage(msg)
 
         gui = load_gui_settings(self._config_path)
         gui.connection = conn

--- a/host/fcapz/gui/capture_panel.py
+++ b/host/fcapz/gui/capture_panel.py
@@ -228,9 +228,6 @@ class CapturePanel(QGroupBox):
         self._stor_val = QLineEdit("0")
         self._stor_mask = QLineEdit("0")
 
-        self._startup_arm = QCheckBox("Arm after reset")
-        self._startup_arm.setObjectName("fcapz_capture_startup_arm")
-
         self._trig_holdoff = QSpinBox()
         self._trig_holdoff.setObjectName("fcapz_capture_trig_holdoff")
         self._trig_holdoff.setRange(0, 65535)
@@ -326,7 +323,6 @@ class CapturePanel(QGroupBox):
         form_adv.addRow("Storage qual mode", self._stor_mode)
         form_adv.addRow("Storage qual value", self._stor_val)
         form_adv.addRow("Storage qual mask", self._stor_mask)
-        form_adv.addRow("Startup arm", self._startup_arm)
         form_adv.addRow("Trigger holdoff", self._trig_holdoff)
         form_adv.addRow("Trigger delay", self._trig_delay)
         form_adv.addRow("Probes", self._probes)
@@ -607,8 +603,6 @@ class CapturePanel(QGroupBox):
                     spin.setValue(int(entry[key]))
                 except (TypeError, ValueError):
                     spin.setValue(default)
-        if "startup_arm" in entry:
-            self._startup_arm.setChecked(bool(entry["startup_arm"]))
         ext = entry.get("ext_trigger_mode", "disabled")
         if isinstance(ext, int):
             ext = {0: "disabled", 1: "or", 2: "and"}.get(ext, "disabled")
@@ -989,7 +983,7 @@ class CapturePanel(QGroupBox):
             stor_qual_mode=stor_m,
             stor_qual_value=sqv,
             stor_qual_mask=sqm,
-            startup_arm=bool(self._startup_arm.isChecked()),
+            startup_arm=False,
             trigger_holdoff=int(self._trig_holdoff.value()),
             trigger_delay=int(self._trig_delay.value()),
         )

--- a/host/fcapz/gui/capture_panel.py
+++ b/host/fcapz/gui/capture_panel.py
@@ -228,6 +228,14 @@ class CapturePanel(QGroupBox):
         self._stor_val = QLineEdit("0")
         self._stor_mask = QLineEdit("0")
 
+        self._startup_arm = QCheckBox("Arm after reset")
+        self._startup_arm.setObjectName("fcapz_capture_startup_arm")
+
+        self._trig_holdoff = QSpinBox()
+        self._trig_holdoff.setObjectName("fcapz_capture_trig_holdoff")
+        self._trig_holdoff.setRange(0, 65535)
+        self._trig_holdoff.setValue(0)
+
         self._trig_delay = QSpinBox()
         self._trig_delay.setRange(0, 65535)
         self._trig_delay.setValue(0)
@@ -318,6 +326,8 @@ class CapturePanel(QGroupBox):
         form_adv.addRow("Storage qual mode", self._stor_mode)
         form_adv.addRow("Storage qual value", self._stor_val)
         form_adv.addRow("Storage qual mask", self._stor_mask)
+        form_adv.addRow("Startup arm", self._startup_arm)
+        form_adv.addRow("Trigger holdoff", self._trig_holdoff)
         form_adv.addRow("Trigger delay", self._trig_delay)
         form_adv.addRow("Probes", self._probes)
         self._adv_section = CollapsibleSection(
@@ -589,6 +599,7 @@ class CapturePanel(QGroupBox):
             ("decimation", self._decim, 0),
             ("probe_sel", self._probe_sel, 0),
             ("stor_qual_mode", self._stor_mode, 0),
+            ("trigger_holdoff", self._trig_holdoff, 0),
             ("trigger_delay", self._trig_delay, 0),
         ):
             if key in entry:
@@ -596,6 +607,8 @@ class CapturePanel(QGroupBox):
                     spin.setValue(int(entry[key]))
                 except (TypeError, ValueError):
                     spin.setValue(default)
+        if "startup_arm" in entry:
+            self._startup_arm.setChecked(bool(entry["startup_arm"]))
         ext = entry.get("ext_trigger_mode", "disabled")
         if isinstance(ext, int):
             ext = {0: "disabled", 1: "or", 2: "and"}.get(ext, "disabled")
@@ -976,6 +989,8 @@ class CapturePanel(QGroupBox):
             stor_qual_mode=stor_m,
             stor_qual_value=sqv,
             stor_qual_mask=sqm,
+            startup_arm=bool(self._startup_arm.isChecked()),
+            trigger_holdoff=int(self._trig_holdoff.value()),
             trigger_delay=int(self._trig_delay.value()),
         )
 

--- a/host/fcapz/gui/connection_panel.py
+++ b/host/fcapz/gui/connection_panel.py
@@ -58,7 +58,8 @@ class ConnectionPanel(QGroupBox):
         self._program_on_connect.setChecked(ConnectionSettings().program_on_connect)
         self._program_on_connect.setToolTip(
             "When checked, Connect runs XSDB fpga -file on the path below. "
-            "Uncheck to attach over JTAG only (FPGA must already hold the right image)."
+            "Uncheck to attach over JTAG only (FPGA must already hold the right image, "
+            "and captures will reflect whatever image is already loaded)."
         )
         self._program_on_connect.stateChanged.connect(lambda _s: self._refresh_timeout_row_state())
 

--- a/host/fcapz/gui/settings.py
+++ b/host/fcapz/gui/settings.py
@@ -335,6 +335,8 @@ def trigger_history_entry_from_config(
         "stor_qual_mode": int(cfg.stor_qual_mode),
         "stor_qual_value": int(cfg.stor_qual_value),
         "stor_qual_mask": int(cfg.stor_qual_mask),
+        "startup_arm": bool(cfg.startup_arm),
+        "trigger_holdoff": int(cfg.trigger_holdoff),
         "trigger_delay": int(cfg.trigger_delay),
         "probes": probes,
         "trigger_sequence": [

--- a/host/fcapz/gui/settings.py
+++ b/host/fcapz/gui/settings.py
@@ -335,7 +335,6 @@ def trigger_history_entry_from_config(
         "stor_qual_mode": int(cfg.stor_qual_mode),
         "stor_qual_value": int(cfg.stor_qual_value),
         "stor_qual_mask": int(cfg.stor_qual_mask),
-        "startup_arm": bool(cfg.startup_arm),
         "trigger_holdoff": int(cfg.trigger_holdoff),
         "trigger_delay": int(cfg.trigger_delay),
         "probes": probes,

--- a/host/fcapz/gui/worker.py
+++ b/host/fcapz/gui/worker.py
@@ -161,12 +161,16 @@ class ConnectWorker(QObject):
                 if c.program_on_connect and c.program:
                     _conn_log.info("hw_server: will program bitfile on connect: %s", c.program)
                 elif c.program and not c.program_on_connect:
-                    _conn_log.info(
-                        "hw_server: program on connect is off (bitfile path kept for later): %s",
+                    _conn_log.warning(
+                        "hw_server: connecting without programming; captures reflect the "
+                        "bitstream already loaded on the FPGA, not the saved path: %s",
                         c.program,
                     )
                 else:
-                    _conn_log.info("hw_server: no bitfile path; connect without fpga -file")
+                    _conn_log.warning(
+                        "hw_server: no bitfile path; connecting without programming, "
+                        "so captures reflect the image already loaded on the FPGA",
+                    )
             analyzer.connect()
             t_connect = time.monotonic()
             if self._cancel_requested:

--- a/host/fcapz/rpc.py
+++ b/host/fcapz/rpc.py
@@ -98,6 +98,29 @@ class RpcServer:
             raise ValueError(f"trigger_delay must be 0..65535, got {delay}")
         return delay
 
+    @staticmethod
+    def _validated_trigger_holdoff(delay: int) -> int:
+        if not (0 <= delay <= 0xFFFF):
+            raise ValueError(f"trigger_holdoff must be 0..65535, got {delay}")
+        return delay
+
+    @staticmethod
+    def _validated_bool(value: Any, *, field: str) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, int):
+            if value in (0, 1):
+                return bool(value)
+            raise ValueError(f"{field} must be a boolean, got {value}")
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in ("0", "false", "no", "off"):
+                return False
+            if lowered in ("1", "true", "yes", "on"):
+                return True
+            raise ValueError(f"{field} must be a boolean, got {value!r}")
+        raise ValueError(f"{field} must be a boolean, got {value!r}")
+
     @classmethod
     def _build_config(cls, req: Dict[str, Any]) -> CaptureConfig:
         return CaptureConfig(
@@ -118,6 +141,12 @@ class RpcServer:
             stor_qual_mode=cls._validated_sq_mode(int(req.get("stor_qual_mode", 0))),
             stor_qual_value=int(req.get("stor_qual_value", 0)),
             stor_qual_mask=int(req.get("stor_qual_mask", 0)),
+            startup_arm=cls._validated_bool(
+                req.get("startup_arm", False), field="startup_arm"
+            ),
+            trigger_holdoff=cls._validated_trigger_holdoff(
+                int(req.get("trigger_holdoff", 0))
+            ),
             trigger_delay=cls._validated_trigger_delay(int(req.get("trigger_delay", 0))),
         )
 

--- a/rtl/fcapz_ela.v
+++ b/rtl/fcapz_ela.v
@@ -38,7 +38,8 @@ module fcapz_ela #(
     parameter TIMESTAMP_W = 0,      // timestamp width (0=off, 32 or 48)
     parameter NUM_SEGMENTS = 1,     // capture segments (1 = normal)
     parameter PROBE_MUX_W = 0,      // 0=disabled, >0=total probe width for runtime mux
-    parameter STARTUP_ARM = 0       // 1 = arm automatically after reset/programming
+    parameter STARTUP_ARM = 0,      // 1 = arm automatically after reset/programming
+    parameter DEFAULT_TRIG_EXT = 0  // reset/default external trigger mode
 ) (
     input  wire                              sample_clk,
     input  wire                              sample_rst,
@@ -118,6 +119,7 @@ module fcapz_ela #(
                                              // sample-clock cycles after arm/re-arm
 
     localparam ADDR_DATA_BASE   = 16'h0100;
+    localparam [1:0] DEFAULT_TRIG_EXT_MODE = DEFAULT_TRIG_EXT[1:0];
 
     // ---- Parameter assertions (simulation) ------------------------------------
     initial begin
@@ -131,6 +133,8 @@ module fcapz_ela #(
             $error("fcapz_ela: SAMPLE_W must be >= 1");
         if (SAMPLE_W > 256)
             $error("fcapz_ela: SAMPLE_W must be <= 256 (got %0d)", SAMPLE_W);
+        if (DEFAULT_TRIG_EXT < 0 || DEFAULT_TRIG_EXT > 3)
+            $error("fcapz_ela: DEFAULT_TRIG_EXT must be 0-3 (got %0d)", DEFAULT_TRIG_EXT);
     end
 
     // Synthesis-safe upper-bound trap for SAMPLE_W
@@ -352,6 +356,18 @@ module fcapz_ela #(
     reg [15:0] trig_holdoff_count;
     reg        trig_holdoff_active;
     reg        startup_arm_pending;
+
+    // Xilinx GSR loads flip-flop INIT values at configuration time.  Keep the
+    // startup-arm path explicit so a bitstream can come up armed without first
+    // relying on a user reset pulse.
+    initial begin
+        jtag_startup_arm   = (STARTUP_ARM != 0);
+        jtag_trig_ext      = DEFAULT_TRIG_EXT_MODE;
+        startup_arm_pending = (STARTUP_ARM != 0);
+        armed              = 1'b0;
+        triggered          = 1'b0;
+        done               = 1'b0;
+    end
 
     // Phase 1: decimation state (sample domain)
     // When DECIM_EN=0, decim_tick is tied high and all counter logic optimizes away.
@@ -580,7 +596,7 @@ module fcapz_ela #(
             jtag_sq_mask       <= 32'h0;
             jtag_chan_sel      <= 8'h0;
             jtag_decim         <= 24'h0;
-            jtag_trig_ext      <= 2'h0;
+            jtag_trig_ext      <= DEFAULT_TRIG_EXT_MODE;
             jtag_seg_sel       <= {SEG_IDX_W{1'b0}};
             jtag_probe_sel     <= 8'h0;
             jtag_startup_arm   <= (STARTUP_ARM != 0);
@@ -779,7 +795,7 @@ module fcapz_ela #(
             chan_sel         <= 8'h0;
             probe_sel        <= 8'h0;
             decim_ratio      <= 24'h0;
-            ext_trig_mode    <= 2'h0;
+            ext_trig_mode    <= DEFAULT_TRIG_EXT_MODE;
             trig_delay       <= 16'h0;
             for (si = 0; si < TRIG_STAGES; si = si + 1) begin
                 seq_mode_a[si]       <= 4'd0;

--- a/rtl/fcapz_ela.v
+++ b/rtl/fcapz_ela.v
@@ -376,16 +376,29 @@ module fcapz_ela #(
     reg [PTR_W-1:0] seg_start_ptr [0:NUM_SEGMENTS-1];
 
     // ---- Sample buffer (dual-port RAM) -------------------------------------
+    localparam TS_DATA_W = (TIMESTAMP_W > 0) ? TIMESTAMP_W : 1;
+    reg                  mem_we_a_q;
+    reg  [PTR_W-1:0]     mem_wr_addr_q;
+    reg  [SAMPLE_W-1:0]  mem_wr_data_q;
+    reg  [TS_DATA_W-1:0] mem_wr_ts_q;
+    reg  [PTR_W-1:0]     mem_addr_a;
+    wire [SAMPLE_W-1:0]  mem_dout_a;
+    wire [SAMPLE_W-1:0]  mem_dout_b;
     wire                 mem_we_a;
-    reg  [PTR_W-1:0]    mem_addr_a;
-    wire [SAMPLE_W-1:0] mem_dout_a;
-    wire [SAMPLE_W-1:0] mem_dout_b;
+    wire                 mem_we_a_ram;
+    wire [SAMPLE_W-1:0]  mem_din_a_ram;
+    wire [TS_DATA_W-1:0] mem_ts_din_a_ram;
+    wire [TS_DATA_W-1:0] ts_counter_cur;
+
+    assign mem_we_a_ram   = (INPUT_PIPE >= 1) ? mem_we_a_q : mem_we_a;
+    assign mem_din_a_ram  = (INPUT_PIPE >= 1) ? mem_wr_data_q : active_probe;
+    assign mem_ts_din_a_ram = (INPUT_PIPE >= 1) ? mem_wr_ts_q : ts_counter_cur;
 
     dpram #(.WIDTH(SAMPLE_W), .DEPTH(DEPTH)) u_samplebuf (
         .clk_a  (sample_clk),
-        .we_a   (mem_we_a),
+        .we_a   (mem_we_a_ram),
         .addr_a (mem_addr_a),
-        .din_a  (active_probe),
+        .din_a  (mem_din_a_ram),
         .dout_a (mem_dout_a),
         .clk_b  (jtag_clk),
         .addr_b (burst_rd_addr),
@@ -396,9 +409,9 @@ module fcapz_ela #(
     generate
         if (TIMESTAMP_W > 0) begin : g_ts
             reg [TIMESTAMP_W-1:0] ts_counter;
-            reg [PTR_W-1:0]      ts_addr_a;
             wire [TIMESTAMP_W-1:0] ts_dout_a;
             wire [TIMESTAMP_W-1:0] ts_dout_b;
+            assign ts_counter_cur = ts_counter;
 
             // Free-running counter in sample_clk
             always @(posedge sample_clk or posedge sample_rst) begin
@@ -410,9 +423,9 @@ module fcapz_ela #(
 
             dpram #(.WIDTH(TIMESTAMP_W), .DEPTH(DEPTH)) u_tsbuf (
                 .clk_a  (sample_clk),
-                .we_a   (mem_we_a),
+                .we_a   (mem_we_a_ram),
                 .addr_a (mem_addr_a),
-                .din_a  (ts_counter),
+                .din_a  (mem_ts_din_a_ram[TIMESTAMP_W-1:0]),
                 .dout_a (ts_dout_a),
                 .clk_b  (jtag_clk),
                 .addr_b (burst_rd_addr),
@@ -420,6 +433,7 @@ module fcapz_ela #(
             );
             assign burst_rd_ts_data = ts_dout_b;
         end else begin : g_no_ts
+            assign ts_counter_cur = {TS_DATA_W{1'b0}};
             assign burst_rd_ts_data = 1'b0;
         end
     endgenerate
@@ -456,7 +470,6 @@ module fcapz_ela #(
     integer word_index, sample_index;
 
     // Phase 3: timestamp readback CDC registers
-    localparam TS_DATA_W = (TIMESTAMP_W > 0) ? TIMESTAMP_W : 1;
     reg [TS_DATA_W-1:0] ts_rd_data_sample, ts_rd_data_sync1, ts_rd_data_sync2;
     reg [TS_DATA_W-1:0] ts_rd_data_jtag;
 
@@ -867,10 +880,31 @@ module fcapz_ela #(
     assign mem_we_a = pre_store_now || post_store_now;
     wire [PTR_W-1:0] post_store_limit = posttrig_len;
     always @(*) begin
-        if (mem_rd_pending)
+        if ((INPUT_PIPE >= 1) && mem_we_a_q)
+            mem_addr_a = mem_wr_addr_q;
+        else if (mem_rd_pending)
             mem_addr_a = idx;
         else
             mem_addr_a = wr_ptr;
+    end
+
+    // Register the RAM write command so address, data, and enable stay
+    // aligned and the trigger/WEA path does not have to reach the BRAM in
+    // the same cycle as trigger evaluation.
+    always @(posedge sample_clk or posedge sample_rst) begin
+        if (sample_rst) begin
+            mem_we_a_q     <= 1'b0;
+            mem_wr_addr_q  <= {PTR_W{1'b0}};
+            mem_wr_data_q  <= {SAMPLE_W{1'b0}};
+            mem_wr_ts_q    <= {TS_DATA_W{1'b0}};
+        end else begin
+            mem_we_a_q <= mem_we_a;
+            if (mem_we_a) begin
+                mem_wr_addr_q <= wr_ptr;
+                mem_wr_data_q <= active_probe;
+                mem_wr_ts_q   <= ts_counter_cur;
+            end
+        end
     end
 
     // Phase 2: trigger_out pulse

--- a/rtl/fcapz_ela.v
+++ b/rtl/fcapz_ela.v
@@ -37,7 +37,8 @@ module fcapz_ela #(
     parameter EXT_TRIG_EN = 0,      // 0 = no ext trigger ports, 1 = enable
     parameter TIMESTAMP_W = 0,      // timestamp width (0=off, 32 or 48)
     parameter NUM_SEGMENTS = 1,     // capture segments (1 = normal)
-    parameter PROBE_MUX_W = 0       // 0=disabled, >0=total probe width for runtime mux
+    parameter PROBE_MUX_W = 0,      // 0=disabled, >0=total probe width for runtime mux
+    parameter STARTUP_ARM = 0       // 1 = arm automatically after reset/programming
 ) (
     input  wire                              sample_clk,
     input  wire                              sample_rst,
@@ -46,6 +47,7 @@ module fcapz_ela #(
     // External trigger I/O
     input  wire                 trigger_in,
     output wire                 trigger_out,
+    output wire                 armed_out,
 
     input  wire                 jtag_clk,
     input  wire                 jtag_rst,
@@ -111,6 +113,9 @@ module fcapz_ela #(
                                              // (sample-clock cycles between
                                              // trigger event and committed
                                              // trigger sample; default 0)
+    localparam ADDR_STARTUP_ARM = 16'h00D8;  // RW: [0] auto-arm after reset
+    localparam ADDR_TRIG_HOLDOFF = 16'h00DC; // RW: [15:0] ignore triggers for
+                                             // sample-clock cycles after arm/re-arm
 
     localparam ADDR_DATA_BASE   = 16'h0100;
 
@@ -178,6 +183,8 @@ module fcapz_ela #(
     reg [31:0] jtag_trig_mode;   // legacy: [0]=value_match [1]=edge_detect
     reg [31:0] jtag_trig_value;  // legacy: comparator A value (stage 0)
     reg [31:0] jtag_trig_mask;   // legacy: comparator A mask (stage 0)
+    reg        jtag_startup_arm;
+    reg [15:0] jtag_trig_holdoff;
     reg [15:0] jtag_trig_delay;  // post-trigger delay (sample clocks)
     // Zero-extended to SAMPLE_W for sync pipeline.
     // SAMPLE_W <= 32: direct truncation (Verilog replication count cannot be 0,
@@ -268,6 +275,8 @@ module fcapz_ela #(
     reg [SAMPLE_W-1:0] trig_mask_sync1,    trig_mask_sync2;
     reg [7:0]          chan_sel_sync1,     chan_sel_sync2;
     reg [7:0]          probe_sel_sync1,   probe_sel_sync2;
+    reg                startup_arm_sync1, startup_arm_sync2;
+    reg [15:0]         trig_holdoff_sync1, trig_holdoff_sync2;
     reg [15:0]         trig_delay_sync1,   trig_delay_sync2;
 
     // ---- Channel mux (sample_clk domain) -----------------------------------
@@ -326,6 +335,10 @@ module fcapz_ela #(
     reg [15:0] trig_delay;
     reg [15:0] trig_delay_count;
     reg        trig_delay_pending;
+    reg [15:0] trig_holdoff;
+    reg [15:0] trig_holdoff_count;
+    reg        trig_holdoff_active;
+    reg        startup_arm_pending;
 
     // Phase 1: decimation state (sample domain)
     // When DECIM_EN=0, decim_tick is tied high and all counter logic optimizes away.
@@ -340,6 +353,7 @@ module fcapz_ela #(
     reg [1:0] ext_trig_mode;
     reg trigger_out_r;
     assign trigger_out = (EXT_TRIG_EN != 0) ? trigger_out_r : 1'b0;
+    assign armed_out = armed;
 
     // Phase 4: segmented memory state
     reg [SEG_IDX_W-1:0] cur_segment;
@@ -435,6 +449,8 @@ module fcapz_ela #(
 
     // ---- Trigger logic (combinational) -------------------------------------
     wire arm_pulse   = arm_toggle_sync1 ^ arm_toggle_sync2;
+    wire startup_arm_pulse = startup_arm_pending;
+    wire any_arm_pulse = arm_pulse | startup_arm_pulse;
     wire reset_pulse = reset_toggle_sync1 ^ reset_toggle_sync2;
 
     // Simple trigger: uses stage-0 comparators (backward compatible)
@@ -485,6 +501,7 @@ module fcapz_ela #(
     wire seq_count_reached = (seq_count_target[seq_state] == 16'h0) ||
                              ((seq_counter + 16'h1) >= seq_count_target[seq_state]);
     wire pretrigger_ready = pre_count >= {1'b0, pretrig_len};
+    wire trigger_holdoff_done = !trig_holdoff_active;
 
     // Internal trigger signal (before ext trigger combination)
     wire internal_trigger_hit = (TRIG_STAGES == 1) ? simple_trigger_hit :
@@ -540,6 +557,8 @@ module fcapz_ela #(
             jtag_trig_ext      <= 2'h0;
             jtag_seg_sel       <= {SEG_IDX_W{1'b0}};
             jtag_probe_sel     <= 8'h0;
+            jtag_startup_arm   <= (STARTUP_ARM != 0);
+            jtag_trig_holdoff  <= 16'h0;
             jtag_trig_delay    <= 16'h0;
             arm_toggle_jtag    <= 1'b0;
             reset_toggle_jtag  <= 1'b0;
@@ -577,6 +596,8 @@ module fcapz_ela #(
                     ADDR_DECIM:      jtag_decim        <= jtag_wdata[23:0];
                     ADDR_TRIG_EXT:   jtag_trig_ext     <= jtag_wdata[1:0];
                     ADDR_PROBE_SEL:  jtag_probe_sel    <= jtag_wdata[7:0];
+                    ADDR_STARTUP_ARM: jtag_startup_arm <= jtag_wdata[0];
+                    ADDR_TRIG_HOLDOFF: jtag_trig_holdoff <= jtag_wdata[15:0];
                     ADDR_TRIG_DELAY: jtag_trig_delay   <= jtag_wdata[15:0];
                     ADDR_SEG_SEL:    jtag_seg_sel      <= jtag_wdata[SEG_IDX_W-1:0];
                     ADDR_BURST_PTR: begin
@@ -618,11 +639,16 @@ module fcapz_ela #(
         if (sample_rst) begin
             arm_toggle_sync1   <= 1'b0; arm_toggle_sync2   <= 1'b0;
             reset_toggle_sync1 <= 1'b0; reset_toggle_sync2 <= 1'b0;
+            startup_arm_pending <= (STARTUP_ARM != 0);
         end else begin
             arm_toggle_sync1   <= arm_toggle_jtag;
             arm_toggle_sync2   <= arm_toggle_sync1;
             reset_toggle_sync1 <= reset_toggle_jtag;
             reset_toggle_sync2 <= reset_toggle_sync1;
+            if (reset_pulse)
+                startup_arm_pending <= startup_arm_sync2;
+            else if (startup_arm_pulse)
+                startup_arm_pending <= 1'b0;
         end
     end
 
@@ -636,6 +662,8 @@ module fcapz_ela #(
             trig_mask_sync1    <= 0; trig_mask_sync2    <= 0;
             chan_sel_sync1     <= 0; chan_sel_sync2     <= 0;
             probe_sel_sync1   <= 0; probe_sel_sync2   <= 0;
+            startup_arm_sync1 <= (STARTUP_ARM != 0); startup_arm_sync2 <= (STARTUP_ARM != 0);
+            trig_holdoff_sync1 <= 0; trig_holdoff_sync2 <= 0;
             trig_delay_sync1  <= 0; trig_delay_sync2  <= 0;
         end else begin
             pretrig_len_sync1  <= jtag_pretrig_len[PTR_W-1:0];
@@ -652,6 +680,10 @@ module fcapz_ela #(
             chan_sel_sync2     <= chan_sel_sync1;
             probe_sel_sync1   <= jtag_probe_sel;
             probe_sel_sync2   <= probe_sel_sync1;
+            startup_arm_sync1 <= jtag_startup_arm;
+            startup_arm_sync2 <= startup_arm_sync1;
+            trig_holdoff_sync1 <= jtag_trig_holdoff;
+            trig_holdoff_sync2 <= trig_holdoff_sync1;
             trig_delay_sync1  <= jtag_trig_delay;
             trig_delay_sync2  <= trig_delay_sync1;
         end
@@ -702,7 +734,7 @@ module fcapz_ela #(
                 seq_next_state[si]   <= {SEQ_STATE_W{1'b0}};
                 seq_is_final[si]     <= 1'b0;
             end
-        end else if (arm_pulse) begin
+        end else if (any_arm_pulse) begin
             pretrig_len      <= pretrig_len_sync2;
             posttrig_len     <= posttrig_len_sync2;
             trig_value       <= trig_value_sync2;
@@ -735,6 +767,7 @@ module fcapz_ela #(
             decim_ratio      <= jtag_decim;
             // Phase 2: external trigger
             ext_trig_mode    <= jtag_trig_ext;
+            trig_holdoff     <= trig_holdoff_sync2;
             // Trigger delay (sample clocks) — latched on arm
             trig_delay       <= trig_delay_sync2;
             // Sequencer stages
@@ -764,7 +797,7 @@ module fcapz_ela #(
         if (sample_rst) begin
             decim_count <= 24'h0;
         end else begin
-            if (arm_pulse) begin
+            if (any_arm_pulse) begin
                 decim_count <= 24'h0;
             end else if (armed && !done) begin
                 if (decim_count >= decim_ratio)
@@ -778,6 +811,7 @@ module fcapz_ela #(
     // ---- Capture state machine ---------------------------------------------
     reg mem_rd_pending;
     wire trigger_commit_now = armed && !done && !triggered && pretrigger_ready &&
+        trigger_holdoff_done &&
         ((trig_delay_pending && (trig_delay_count == 16'h0)) ||
          (!trig_delay_pending && trigger_hit && (trig_delay == 16'h0)));
     wire post_store_now = armed && !done && triggered && store_enable &&
@@ -798,7 +832,8 @@ module fcapz_ela #(
         if (sample_rst)
             trigger_out_r <= 1'b0;
         else
-            trigger_out_r <= (armed && !triggered && pretrigger_ready && trigger_hit) ? 1'b1 : 1'b0;
+            trigger_out_r <= (armed && !triggered && pretrigger_ready &&
+                              trigger_holdoff_done && trigger_hit) ? 1'b1 : 1'b0;
     end
 
     // Phase 4: segment base address
@@ -820,6 +855,9 @@ module fcapz_ela #(
             capture_len <= {PTR_W+1{1'b0}};
             seq_state   <= {SEQ_STATE_W{1'b0}};
             seq_counter <= 16'h0;
+            trig_holdoff       <= 16'h0;
+            trig_holdoff_active <= 1'b0;
+            trig_holdoff_count  <= 16'h0;
             trig_delay_pending <= 1'b0;
             trig_delay_count   <= 16'h0;
             cur_segment <= {SEG_IDX_W{1'b0}};
@@ -837,6 +875,8 @@ module fcapz_ela #(
                 post_count  <= {PTR_W{1'b0}};
                 pre_count   <= {PTR_W+1{1'b0}};
                 capture_len <= {PTR_W+1{1'b0}};
+                trig_holdoff_active <= 1'b0;
+                trig_holdoff_count  <= 16'h0;
                 trig_delay_pending <= 1'b0;
                 trig_delay_count   <= 16'h0;
                 cur_segment <= {SEG_IDX_W{1'b0}};
@@ -846,7 +886,7 @@ module fcapz_ela #(
                     seg_start_ptr[seg_i] <= {PTR_W{1'b0}};
             end
 
-            if (arm_pulse) begin
+            if (any_arm_pulse) begin
                 armed       <= 1'b1;
                 triggered   <= 1'b0;
                 done        <= 1'b0;
@@ -855,6 +895,9 @@ module fcapz_ela #(
                 pre_count   <= {PTR_W+1{1'b0}};
                 seq_state   <= {SEQ_STATE_W{1'b0}};
                 seq_counter <= 16'h0;
+                trig_holdoff_active <= (trig_holdoff_sync2 != 16'h0);
+                trig_holdoff_count  <= (trig_holdoff_sync2 != 16'h0)
+                    ? (trig_holdoff_sync2 - 16'h1) : 16'h0;
                 trig_delay_pending <= 1'b0;
                 trig_delay_count   <= 16'h0;
                 cur_segment <= {SEG_IDX_W{1'b0}};
@@ -868,6 +911,12 @@ module fcapz_ela #(
             end
 
             if (armed && !done) begin
+                if (trig_holdoff_active) begin
+                    if (trig_holdoff_count == 16'h0)
+                        trig_holdoff_active <= 1'b0;
+                    else
+                        trig_holdoff_count <= trig_holdoff_count - 16'h1;
+                end
                 // Store sample (qualified + decimated).  A trigger commit
                 // force-stores the anchor sample so samples[pretrig] remains
                 // the committed trigger sample even when decimation or storage
@@ -887,7 +936,10 @@ module fcapz_ela #(
 
                 // Trigger / sequencer evaluation (runs every cycle, NOT gated by decimation)
                 if (!triggered) begin
-                    if (trig_delay_pending) begin
+                    if (trig_holdoff_active) begin
+                        // Ignore trigger / sequencer activity until the
+                        // post-arm holdoff window expires.
+                    end else if (trig_delay_pending) begin
                         // Counting down sample-clock cycles between the
                         // trigger event and the committed trigger sample.
                         // Buffer continues to record (gated by store_enable
@@ -948,6 +1000,9 @@ module fcapz_ela #(
                                 pre_count   <= {PTR_W+1{1'b0}};
                                 seq_state   <= {SEQ_STATE_W{1'b0}};
                                 seq_counter <= 16'h0;
+                                trig_holdoff_active <= (trig_holdoff != 16'h0);
+                                trig_holdoff_count  <= (trig_holdoff != 16'h0)
+                                    ? (trig_holdoff - 16'h1) : 16'h0;
                                 trig_delay_pending <= 1'b0;
                                 trig_delay_count   <= 16'h0;
                                 // Set wr_ptr to next segment base
@@ -983,6 +1038,9 @@ module fcapz_ela #(
                                     pre_count   <= {PTR_W+1{1'b0}};
                                     seq_state   <= {SEQ_STATE_W{1'b0}};
                                     seq_counter <= 16'h0;
+                                    trig_holdoff_active <= (trig_holdoff != 16'h0);
+                                    trig_holdoff_count  <= (trig_holdoff != 16'h0)
+                                        ? (trig_holdoff - 16'h1) : 16'h0;
                                     trig_delay_pending <= 1'b0;
                                     trig_delay_count   <= 16'h0;
                                     // Set wr_ptr to next segment base
@@ -1207,6 +1265,8 @@ module fcapz_ela #(
                                 : {{(32-PTR_W){1'b0}}, start_ptr};
             ADDR_PROBE_SEL:   jtag_rdata = {24'h0, jtag_probe_sel};
             ADDR_PROBE_MUX_W: jtag_rdata = PROBE_MUX_W;
+            ADDR_STARTUP_ARM: jtag_rdata = {31'h0, jtag_startup_arm};
+            ADDR_TRIG_HOLDOFF: jtag_rdata = {16'h0, jtag_trig_holdoff};
             ADDR_TRIG_DELAY:  jtag_rdata = {16'h0, jtag_trig_delay};
             ADDR_TIMESTAMP_W: jtag_rdata = TIMESTAMP_W;
             default: begin

--- a/rtl/fcapz_ela.v
+++ b/rtl/fcapz_ela.v
@@ -278,6 +278,19 @@ module fcapz_ela #(
     reg                startup_arm_sync1, startup_arm_sync2;
     reg [15:0]         trig_holdoff_sync1, trig_holdoff_sync2;
     reg [15:0]         trig_delay_sync1,   trig_delay_sync2;
+    reg [3:0]          sq_mode_sync1, sq_mode_sync2;
+    reg [SAMPLE_W-1:0] sq_value_sync1, sq_value_sync2;
+    reg [SAMPLE_W-1:0] sq_mask_sync1, sq_mask_sync2;
+    reg [31:0]         seq_cfg_sync1     [0:TRIG_STAGES-1];
+    reg [31:0]         seq_cfg_sync2     [0:TRIG_STAGES-1];
+    reg [SAMPLE_W-1:0] seq_value_a_sync1 [0:TRIG_STAGES-1];
+    reg [SAMPLE_W-1:0] seq_value_a_sync2 [0:TRIG_STAGES-1];
+    reg [SAMPLE_W-1:0] seq_mask_a_sync1  [0:TRIG_STAGES-1];
+    reg [SAMPLE_W-1:0] seq_mask_a_sync2  [0:TRIG_STAGES-1];
+    reg [SAMPLE_W-1:0] seq_value_b_sync1 [0:TRIG_STAGES-1];
+    reg [SAMPLE_W-1:0] seq_value_b_sync2 [0:TRIG_STAGES-1];
+    reg [SAMPLE_W-1:0] seq_mask_b_sync1  [0:TRIG_STAGES-1];
+    reg [SAMPLE_W-1:0] seq_mask_b_sync2  [0:TRIG_STAGES-1];
 
     // ---- Channel mux (sample_clk domain) -----------------------------------
     reg [7:0] chan_sel;   // active channel, latched on arm
@@ -665,6 +678,21 @@ module fcapz_ela #(
             startup_arm_sync1 <= (STARTUP_ARM != 0); startup_arm_sync2 <= (STARTUP_ARM != 0);
             trig_holdoff_sync1 <= 0; trig_holdoff_sync2 <= 0;
             trig_delay_sync1  <= 0; trig_delay_sync2  <= 0;
+            sq_mode_sync1     <= 0; sq_mode_sync2     <= 0;
+            sq_value_sync1    <= 0; sq_value_sync2    <= 0;
+            sq_mask_sync1     <= 0; sq_mask_sync2     <= 0;
+            for (si = 0; si < TRIG_STAGES; si = si + 1) begin
+                seq_cfg_sync1[si]     <= 32'h0;
+                seq_cfg_sync2[si]     <= 32'h0;
+                seq_value_a_sync1[si] <= {SAMPLE_W{1'b0}};
+                seq_value_a_sync2[si] <= {SAMPLE_W{1'b0}};
+                seq_mask_a_sync1[si]  <= {SAMPLE_W{1'b0}};
+                seq_mask_a_sync2[si]  <= {SAMPLE_W{1'b0}};
+                seq_value_b_sync1[si] <= {SAMPLE_W{1'b0}};
+                seq_value_b_sync2[si] <= {SAMPLE_W{1'b0}};
+                seq_mask_b_sync1[si]  <= {SAMPLE_W{1'b0}};
+                seq_mask_b_sync2[si]  <= {SAMPLE_W{1'b0}};
+            end
         end else begin
             pretrig_len_sync1  <= jtag_pretrig_len[PTR_W-1:0];
             pretrig_len_sync2  <= pretrig_len_sync1;
@@ -686,6 +714,24 @@ module fcapz_ela #(
             trig_holdoff_sync2 <= trig_holdoff_sync1;
             trig_delay_sync1  <= jtag_trig_delay;
             trig_delay_sync2  <= trig_delay_sync1;
+            sq_mode_sync1     <= jtag_sq_mode[3:0];
+            sq_mode_sync2     <= sq_mode_sync1;
+            sq_value_sync1    <= jtag_sq_value_w;
+            sq_value_sync2    <= sq_value_sync1;
+            sq_mask_sync1     <= jtag_sq_mask_w;
+            sq_mask_sync2     <= sq_mask_sync1;
+            for (si = 0; si < TRIG_STAGES; si = si + 1) begin
+                seq_cfg_sync1[si]     <= jtag_seq_cfg[si];
+                seq_cfg_sync2[si]     <= seq_cfg_sync1[si];
+                seq_value_a_sync1[si] <= jtag_seq_value_a_w[si];
+                seq_value_a_sync2[si] <= seq_value_a_sync1[si];
+                seq_mask_a_sync1[si]  <= jtag_seq_mask_a_w[si];
+                seq_mask_a_sync2[si]  <= seq_mask_a_sync1[si];
+                seq_value_b_sync1[si] <= jtag_seq_value_b_w[si];
+                seq_value_b_sync2[si] <= seq_value_b_sync1[si];
+                seq_mask_b_sync1[si]  <= jtag_seq_mask_b_w[si];
+                seq_mask_b_sync2[si]  <= seq_mask_b_sync1[si];
+            end
         end
     end
 
@@ -740,17 +786,17 @@ module fcapz_ela #(
             trig_value       <= trig_value_sync2;
             trig_mask        <= trig_mask_sync2;
             // Stage-0 compare modes
-            if (jtag_seq_cfg[0][9:0] != 10'd0) begin
-                trig_cmp_mode_a <= jtag_seq_cfg[0][3:0];
-                trig_cmp_mode_b <= jtag_seq_cfg[0][7:4];
-                trig_combine    <= jtag_seq_cfg[0][9:8];
+            if (seq_cfg_sync2[0][9:0] != 10'd0) begin
+                trig_cmp_mode_a <= seq_cfg_sync2[0][3:0];
+                trig_cmp_mode_b <= seq_cfg_sync2[0][7:4];
+                trig_combine    <= seq_cfg_sync2[0][9:8];
             end else begin
                 trig_cmp_mode_a <= trig_mode_sync2[1] ? 4'd8 : 4'd0;
                 trig_cmp_mode_b <= (trig_mode_sync2 == 2'b11) ? 4'd8 : 4'd0;
                 trig_combine    <= (trig_mode_sync2 == 2'b11) ? 2'd3 : 2'd0;
             end
-            trig_value_b     <= jtag_seq_value_b_w[0];
-            trig_mask_b      <= jtag_seq_mask_b_w[0];
+            trig_value_b     <= seq_value_b_sync2[0];
+            trig_mask_b      <= seq_mask_b_sync2[0];
             // Channel select (clamped to valid range)
             chan_sel         <= (chan_sel_sync2 < NUM_CHANNELS) ? chan_sel_sync2 : 8'h0;
             // Probe mux select (clamped when enabled)
@@ -759,10 +805,10 @@ module fcapz_ela #(
             else
                 probe_sel   <= 8'h0;
             // Storage qualification
-            sq_enable        <= (STOR_QUAL != 0) && (jtag_sq_mode[3:0] != 0);
-            sq_cmp_mode      <= jtag_sq_mode[3:0];
-            sq_value         <= jtag_sq_value_w;
-            sq_mask          <= jtag_sq_mask_w;
+            sq_enable        <= (STOR_QUAL != 0) && (sq_mode_sync2 != 0);
+            sq_cmp_mode      <= sq_mode_sync2;
+            sq_value         <= sq_value_sync2;
+            sq_mask          <= sq_mask_sync2;
             // Phase 1: decimation
             decim_ratio      <= jtag_decim;
             // Phase 2: external trigger
@@ -772,16 +818,16 @@ module fcapz_ela #(
             trig_delay       <= trig_delay_sync2;
             // Sequencer stages
             for (si = 0; si < TRIG_STAGES; si = si + 1) begin
-                seq_mode_a[si]       <= jtag_seq_cfg[si][3:0];
-                seq_mode_b[si]       <= jtag_seq_cfg[si][7:4];
-                seq_combine[si]      <= jtag_seq_cfg[si][9:8];
-                seq_next_state[si]   <= jtag_seq_cfg[si][10 +: SEQ_STATE_W];
-                seq_is_final[si]     <= jtag_seq_cfg[si][12];
-                seq_count_target[si] <= jtag_seq_cfg[si][31:16];
-                seq_value_a[si]      <= jtag_seq_value_a_w[si];
-                seq_mask_a[si]       <= jtag_seq_mask_a_w[si];
-                seq_value_b[si]      <= jtag_seq_value_b_w[si];
-                seq_mask_b[si]       <= jtag_seq_mask_b_w[si];
+                seq_mode_a[si]       <= seq_cfg_sync2[si][3:0];
+                seq_mode_b[si]       <= seq_cfg_sync2[si][7:4];
+                seq_combine[si]      <= seq_cfg_sync2[si][9:8];
+                seq_next_state[si]   <= seq_cfg_sync2[si][10 +: SEQ_STATE_W];
+                seq_is_final[si]     <= seq_cfg_sync2[si][12];
+                seq_count_target[si] <= seq_cfg_sync2[si][31:16];
+                seq_value_a[si]      <= seq_value_a_sync2[si];
+                seq_mask_a[si]       <= seq_mask_a_sync2[si];
+                seq_value_b[si]      <= seq_value_b_sync2[si];
+                seq_mask_b[si]       <= seq_mask_b_sync2[si];
             end
         end
     end

--- a/rtl/fcapz_ela_ecp5.v
+++ b/rtl/fcapz_ela_ecp5.v
@@ -75,6 +75,8 @@ module fcapz_ela_ecp5 #(
     wire                burst_start;
     wire                burst_timestamp;
     wire [PTR_W-1:0]    burst_start_ptr;
+    wire                jtag_rst_ctrl;
+    wire                jtag_rst_data;
 
     // ---- TAP wrappers ----
     jtag_tap_ecp5 #(.CHAIN(CTRL_CHAIN)) u_tap_ctrl (
@@ -89,9 +91,21 @@ module fcapz_ela_ecp5 #(
         .update(tap2_update), .sel(tap2_sel)
     );
 
+    reset_sync u_rst_sync_ctrl (
+        .clk(tap1_tck),
+        .arst(sample_rst),
+        .srst(jtag_rst_ctrl)
+    );
+
+    reset_sync u_rst_sync_data (
+        .clk(tap2_tck),
+        .arst(sample_rst),
+        .srst(jtag_rst_data)
+    );
+
     // ---- Register interface ----
     jtag_reg_iface u_reg (
-        .arst(sample_rst),
+        .arst(jtag_rst_ctrl),
         .tck(tap1_tck), .tdi(tap1_tdi), .tdo(tap1_tdo),
         .capture(tap1_capture), .shift_en(tap1_shift),
         .update(tap1_update), .sel(tap1_sel),
@@ -173,7 +187,7 @@ module fcapz_ela_ecp5 #(
         .SAMPLE_W(SAMPLE_W), .TIMESTAMP_W(TIMESTAMP_W),
         .DEPTH(DEPTH), .BURST_W(BURST_W)
     ) u_burst (
-        .arst(sample_rst),
+        .arst(jtag_rst_data),
         .tck(tap2_tck), .tdi(tap2_tdi), .tdo(tap2_tdo),
         .capture(tap2_capture), .shift_en(tap2_shift),
         .update(tap2_update), .sel(tap2_sel),

--- a/rtl/fcapz_ela_gowin.v
+++ b/rtl/fcapz_ela_gowin.v
@@ -58,6 +58,7 @@ module fcapz_ela_gowin #(
     wire        jtag_wr_en, jtag_rd_en;
     wire [15:0] jtag_addr;
     wire [31:0] jtag_wdata, jtag_rdata;
+    wire        jtag_rst_ctrl;
     localparam PTR_W = $clog2(DEPTH);
 
     // Gowin exposes only one user chain here, so USER2 burst readout is not
@@ -77,9 +78,15 @@ module fcapz_ela_gowin #(
         .update(tap_update), .sel(tap_sel)
     );
 
+    reset_sync u_rst_sync_ctrl (
+        .clk(tap_tck),
+        .arst(sample_rst),
+        .srst(jtag_rst_ctrl)
+    );
+
     // ---- Register interface ----
     jtag_reg_iface u_reg (
-        .arst(sample_rst),
+        .arst(jtag_rst_ctrl),
         .tck(tap_tck), .tdi(tap_tdi), .tdo(tap_tdo),
         .capture(tap_capture), .shift_en(tap_shift),
         .update(tap_update), .sel(tap_sel),

--- a/rtl/fcapz_ela_intel.v
+++ b/rtl/fcapz_ela_intel.v
@@ -53,6 +53,8 @@ module fcapz_ela_intel #(
     wire                burst_start;
     wire                burst_timestamp;
     wire [PTR_W-1:0]    burst_start_ptr;
+    wire                jtag_rst_ctrl;
+    wire                jtag_rst_data;
 
     // ---- TAP wrappers ----
     jtag_tap_intel #(.CHAIN(CTRL_CHAIN)) u_tap_ctrl (
@@ -67,9 +69,21 @@ module fcapz_ela_intel #(
         .update(tap2_update), .sel(tap2_sel)
     );
 
+    reset_sync u_rst_sync_ctrl (
+        .clk(tap1_tck),
+        .arst(sample_rst),
+        .srst(jtag_rst_ctrl)
+    );
+
+    reset_sync u_rst_sync_data (
+        .clk(tap2_tck),
+        .arst(sample_rst),
+        .srst(jtag_rst_data)
+    );
+
     // ---- Register interface ----
     jtag_reg_iface u_reg (
-        .arst(sample_rst),
+        .arst(jtag_rst_ctrl),
         .tck(tap1_tck), .tdi(tap1_tdi), .tdo(tap1_tdo),
         .capture(tap1_capture), .shift_en(tap1_shift),
         .update(tap1_update), .sel(tap1_sel),
@@ -103,7 +117,7 @@ module fcapz_ela_intel #(
         .SAMPLE_W(SAMPLE_W), .TIMESTAMP_W(TIMESTAMP_W),
         .DEPTH(DEPTH), .BURST_W(BURST_W)
     ) u_burst (
-        .arst(sample_rst),
+        .arst(jtag_rst_data),
         .tck(tap2_tck), .tdi(tap2_tdi), .tdo(tap2_tdo),
         .capture(tap2_capture), .shift_en(tap2_shift),
         .update(tap2_update), .sel(tap2_sel),

--- a/rtl/fcapz_ela_polarfire.v
+++ b/rtl/fcapz_ela_polarfire.v
@@ -77,6 +77,8 @@ module fcapz_ela_polarfire #(
     wire                burst_start;
     wire                burst_timestamp;
     wire [PTR_W-1:0]    burst_start_ptr;
+    wire                jtag_rst_ctrl;
+    wire                jtag_rst_data;
 
     // ---- TAP wrapper (single UJTAG, dual-chain view) ----
     jtag_tap_polarfire #(
@@ -91,9 +93,21 @@ module fcapz_ela_polarfire #(
         .ch2_update(tap2_update), .ch2_sel(tap2_sel)
     );
 
+    reset_sync u_rst_sync_ctrl (
+        .clk(tap1_tck),
+        .arst(sample_rst),
+        .srst(jtag_rst_ctrl)
+    );
+
+    reset_sync u_rst_sync_data (
+        .clk(tap2_tck),
+        .arst(sample_rst),
+        .srst(jtag_rst_data)
+    );
+
     // ---- Register interface (USER1) ----
     jtag_reg_iface u_reg (
-        .arst(sample_rst),
+        .arst(jtag_rst_ctrl),
         .tck(tap1_tck), .tdi(tap1_tdi), .tdo(tap1_tdo),
         .capture(tap1_capture), .shift_en(tap1_shift),
         .update(tap1_update), .sel(tap1_sel),
@@ -177,7 +191,7 @@ module fcapz_ela_polarfire #(
         .SAMPLE_W(SAMPLE_W), .TIMESTAMP_W(TIMESTAMP_W),
         .DEPTH(DEPTH), .BURST_W(BURST_W)
     ) u_burst (
-        .arst(sample_rst),
+        .arst(jtag_rst_data),
         .tck(tap2_tck), .tdi(tap2_tdi), .tdo(tap2_tdo),
         .capture(tap2_capture), .shift_en(tap2_shift),
         .update(tap2_update), .sel(tap2_sel),

--- a/rtl/fcapz_ela_polarfire.v
+++ b/rtl/fcapz_ela_polarfire.v
@@ -38,6 +38,7 @@ module fcapz_ela_polarfire #(
     parameter INPUT_PIPE   = 0,
     parameter NUM_CHANNELS = 1,
     parameter TIMESTAMP_W  = 0,
+    parameter STARTUP_ARM  = 0,
     parameter BURST_W      = 256,
     // PolarFire UJTAG IR opcodes (override if your BSDL differs).
     parameter [7:0] IR_USER1 = 8'h10,
@@ -125,7 +126,7 @@ module fcapz_ela_polarfire #(
                 .SAMPLE_W(SAMPLE_W), .DEPTH(DEPTH),
                 .TRIG_STAGES(TRIG_STAGES), .STOR_QUAL(STOR_QUAL),
                 .INPUT_PIPE(INPUT_PIPE), .NUM_CHANNELS(NUM_CHANNELS),
-                .TIMESTAMP_W(TIMESTAMP_W)
+                .TIMESTAMP_W(TIMESTAMP_W), .STARTUP_ARM(STARTUP_ARM)
             ) u_ela (
                 .sample_clk(sample_clk), .sample_rst(sample_rst),
                 .probe_in(probe_in),
@@ -152,7 +153,7 @@ module fcapz_ela_polarfire #(
                 .SAMPLE_W(SAMPLE_W), .DEPTH(DEPTH),
                 .TRIG_STAGES(TRIG_STAGES), .STOR_QUAL(STOR_QUAL),
                 .INPUT_PIPE(INPUT_PIPE), .NUM_CHANNELS(NUM_CHANNELS),
-                .TIMESTAMP_W(TIMESTAMP_W)
+                .TIMESTAMP_W(TIMESTAMP_W), .STARTUP_ARM(STARTUP_ARM)
             ) u_ela (
                 .sample_clk(sample_clk), .sample_rst(sample_rst),
                 .probe_in(probe_in),

--- a/rtl/fcapz_ela_xilinx7.v
+++ b/rtl/fcapz_ela_xilinx7.v
@@ -46,6 +46,7 @@ module fcapz_ela_xilinx7 #(
     parameter NUM_SEGMENTS = 1,
     parameter PROBE_MUX_W = 0,
     parameter STARTUP_ARM = 0,
+    parameter DEFAULT_TRIG_EXT = 0,
     parameter BURST_W     = 256,
     parameter CTRL_CHAIN  = 1,   // BSCANE2 USER chain for control
     parameter DATA_CHAIN  = 2,   // BSCANE2 USER chain for burst data
@@ -156,7 +157,8 @@ module fcapz_ela_xilinx7 #(
                 .INPUT_PIPE(INPUT_PIPE), .NUM_CHANNELS(NUM_CHANNELS),
                 .DECIM_EN(DECIM_EN), .EXT_TRIG_EN(EXT_TRIG_EN),
                 .TIMESTAMP_W(TIMESTAMP_W), .NUM_SEGMENTS(NUM_SEGMENTS),
-                .PROBE_MUX_W(PROBE_MUX_W), .STARTUP_ARM(STARTUP_ARM)
+                .PROBE_MUX_W(PROBE_MUX_W), .STARTUP_ARM(STARTUP_ARM),
+                .DEFAULT_TRIG_EXT(DEFAULT_TRIG_EXT)
             ) u_ela (
                 .sample_clk(sample_clk), .sample_rst(sample_rst),
                 .probe_in(probe_in),
@@ -185,7 +187,8 @@ module fcapz_ela_xilinx7 #(
                 .INPUT_PIPE(INPUT_PIPE), .NUM_CHANNELS(NUM_CHANNELS),
                 .DECIM_EN(DECIM_EN), .EXT_TRIG_EN(EXT_TRIG_EN),
                 .TIMESTAMP_W(TIMESTAMP_W), .NUM_SEGMENTS(NUM_SEGMENTS),
-                .PROBE_MUX_W(PROBE_MUX_W), .STARTUP_ARM(STARTUP_ARM)
+                .PROBE_MUX_W(PROBE_MUX_W), .STARTUP_ARM(STARTUP_ARM),
+                .DEFAULT_TRIG_EXT(DEFAULT_TRIG_EXT)
             ) u_ela (
                 .sample_clk(sample_clk), .sample_rst(sample_rst),
                 .probe_in(probe_in),

--- a/rtl/fcapz_ela_xilinx7.v
+++ b/rtl/fcapz_ela_xilinx7.v
@@ -45,6 +45,7 @@ module fcapz_ela_xilinx7 #(
     parameter TIMESTAMP_W = 0,
     parameter NUM_SEGMENTS = 1,
     parameter PROBE_MUX_W = 0,
+    parameter STARTUP_ARM = 0,
     parameter BURST_W     = 256,
     parameter CTRL_CHAIN  = 1,   // BSCANE2 USER chain for control
     parameter DATA_CHAIN  = 2,   // BSCANE2 USER chain for burst data
@@ -59,6 +60,7 @@ module fcapz_ela_xilinx7 #(
     // External trigger I/O
     input  wire                          trigger_in,
     output wire                          trigger_out,
+    output wire                          armed_out,
     // EIO ports (active when EIO_EN=1; ignored / tied-off otherwise)
     input  wire [EIO_IN_W-1:0]           eio_probe_in,
     output wire [EIO_OUT_W-1:0]          eio_probe_out
@@ -140,11 +142,11 @@ module fcapz_ela_xilinx7 #(
                 .INPUT_PIPE(INPUT_PIPE), .NUM_CHANNELS(NUM_CHANNELS),
                 .DECIM_EN(DECIM_EN), .EXT_TRIG_EN(EXT_TRIG_EN),
                 .TIMESTAMP_W(TIMESTAMP_W), .NUM_SEGMENTS(NUM_SEGMENTS),
-                .PROBE_MUX_W(PROBE_MUX_W)
+                .PROBE_MUX_W(PROBE_MUX_W), .STARTUP_ARM(STARTUP_ARM)
             ) u_ela (
                 .sample_clk(sample_clk), .sample_rst(sample_rst),
                 .probe_in(probe_in),
-                .trigger_in(trigger_in), .trigger_out(trigger_out),
+                .trigger_in(trigger_in), .trigger_out(trigger_out), .armed_out(armed_out),
                 .jtag_clk(jtag_clk), .jtag_rst(jtag_rst),
                 .jtag_wr_en(ela_wr_en), .jtag_rd_en(ela_rd_en),
                 .jtag_addr(ela_addr), .jtag_wdata(ela_wdata),
@@ -169,11 +171,11 @@ module fcapz_ela_xilinx7 #(
                 .INPUT_PIPE(INPUT_PIPE), .NUM_CHANNELS(NUM_CHANNELS),
                 .DECIM_EN(DECIM_EN), .EXT_TRIG_EN(EXT_TRIG_EN),
                 .TIMESTAMP_W(TIMESTAMP_W), .NUM_SEGMENTS(NUM_SEGMENTS),
-                .PROBE_MUX_W(PROBE_MUX_W)
+                .PROBE_MUX_W(PROBE_MUX_W), .STARTUP_ARM(STARTUP_ARM)
             ) u_ela (
                 .sample_clk(sample_clk), .sample_rst(sample_rst),
                 .probe_in(probe_in),
-                .trigger_in(trigger_in), .trigger_out(trigger_out),
+                .trigger_in(trigger_in), .trigger_out(trigger_out), .armed_out(armed_out),
                 .jtag_clk(jtag_clk), .jtag_rst(jtag_rst),
                 .jtag_wr_en(jtag_wr_en), .jtag_rd_en(jtag_rd_en),
                 .jtag_addr(jtag_addr), .jtag_wdata(jtag_wdata),

--- a/rtl/fcapz_ela_xilinx7.v
+++ b/rtl/fcapz_ela_xilinx7.v
@@ -91,6 +91,8 @@ module fcapz_ela_xilinx7 #(
     wire                burst_start;
     wire                burst_timestamp;
     wire [PTR_W-1:0]    burst_start_ptr;
+    wire                jtag_rst_ctrl;
+    wire                jtag_rst_data;
 
     // ---- TAP wrappers ----
     jtag_tap_xilinx7 #(.CHAIN(CTRL_CHAIN)) u_tap_ctrl (
@@ -105,9 +107,21 @@ module fcapz_ela_xilinx7 #(
         .update(tap2_update), .sel(tap2_sel)
     );
 
+    reset_sync u_rst_sync_ctrl (
+        .clk(tap1_tck),
+        .arst(sample_rst),
+        .srst(jtag_rst_ctrl)
+    );
+
+    reset_sync u_rst_sync_data (
+        .clk(tap2_tck),
+        .arst(sample_rst),
+        .srst(jtag_rst_data)
+    );
+
     // ---- Register interface ----
     jtag_reg_iface u_reg (
-        .arst(sample_rst),
+        .arst(jtag_rst_ctrl),
         .tck(tap1_tck), .tdi(tap1_tdi), .tdo(tap1_tdo),
         .capture(tap1_capture), .shift_en(tap1_shift),
         .update(tap1_update), .sel(tap1_sel),
@@ -195,7 +209,7 @@ module fcapz_ela_xilinx7 #(
         .SAMPLE_W(SAMPLE_W), .TIMESTAMP_W(TIMESTAMP_W),
         .DEPTH(DEPTH), .BURST_W(BURST_W), .SEG_DEPTH(BURST_SEG_DEPTH)
     ) u_burst (
-        .arst(sample_rst),
+        .arst(jtag_rst_data),
         .tck(tap2_tck), .tdi(tap2_tdi), .tdo(tap2_tdo),
         .capture(tap2_capture), .shift_en(tap2_shift),
         .update(tap2_update), .sel(tap2_sel),

--- a/rtl/fcapz_ela_xilinxus.v
+++ b/rtl/fcapz_ela_xilinxus.v
@@ -33,6 +33,7 @@ module fcapz_ela_xilinxus #(
     parameter TIMESTAMP_W = 0,
     parameter NUM_SEGMENTS = 1,
     parameter PROBE_MUX_W = 0,
+    parameter STARTUP_ARM = 0,
     parameter BURST_W     = 256,
     parameter CTRL_CHAIN  = 1,
     parameter DATA_CHAIN  = 2,
@@ -46,6 +47,7 @@ module fcapz_ela_xilinxus #(
     input  wire [(PROBE_MUX_W > 0 ? PROBE_MUX_W : SAMPLE_W*NUM_CHANNELS)-1:0] probe_in,
     input  wire                          trigger_in,
     output wire                          trigger_out,
+    output wire                          armed_out,
     // EIO ports (active when EIO_EN=1; ignored / tied-off otherwise)
     input  wire [EIO_IN_W-1:0]           eio_probe_in,
     output wire [EIO_OUT_W-1:0]          eio_probe_out
@@ -58,13 +60,13 @@ module fcapz_ela_xilinxus #(
         .INPUT_PIPE(INPUT_PIPE), .NUM_CHANNELS(NUM_CHANNELS),
         .DECIM_EN(DECIM_EN), .EXT_TRIG_EN(EXT_TRIG_EN),
         .TIMESTAMP_W(TIMESTAMP_W), .NUM_SEGMENTS(NUM_SEGMENTS),
-        .PROBE_MUX_W(PROBE_MUX_W), .BURST_W(BURST_W),
+        .PROBE_MUX_W(PROBE_MUX_W), .STARTUP_ARM(STARTUP_ARM), .BURST_W(BURST_W),
         .CTRL_CHAIN(CTRL_CHAIN), .DATA_CHAIN(DATA_CHAIN),
         .EIO_EN(EIO_EN), .EIO_IN_W(EIO_IN_W), .EIO_OUT_W(EIO_OUT_W)
     ) u_inner (
         .sample_clk(sample_clk), .sample_rst(sample_rst),
         .probe_in(probe_in),
-        .trigger_in(trigger_in), .trigger_out(trigger_out),
+        .trigger_in(trigger_in), .trigger_out(trigger_out), .armed_out(armed_out),
         .eio_probe_in(eio_probe_in), .eio_probe_out(eio_probe_out)
     );
 

--- a/rtl/fcapz_ela_xilinxus.v
+++ b/rtl/fcapz_ela_xilinxus.v
@@ -34,6 +34,7 @@ module fcapz_ela_xilinxus #(
     parameter NUM_SEGMENTS = 1,
     parameter PROBE_MUX_W = 0,
     parameter STARTUP_ARM = 0,
+    parameter DEFAULT_TRIG_EXT = 0,
     parameter BURST_W     = 256,
     parameter CTRL_CHAIN  = 1,
     parameter DATA_CHAIN  = 2,
@@ -60,7 +61,8 @@ module fcapz_ela_xilinxus #(
         .INPUT_PIPE(INPUT_PIPE), .NUM_CHANNELS(NUM_CHANNELS),
         .DECIM_EN(DECIM_EN), .EXT_TRIG_EN(EXT_TRIG_EN),
         .TIMESTAMP_W(TIMESTAMP_W), .NUM_SEGMENTS(NUM_SEGMENTS),
-        .PROBE_MUX_W(PROBE_MUX_W), .STARTUP_ARM(STARTUP_ARM), .BURST_W(BURST_W),
+        .PROBE_MUX_W(PROBE_MUX_W), .STARTUP_ARM(STARTUP_ARM),
+        .DEFAULT_TRIG_EXT(DEFAULT_TRIG_EXT), .BURST_W(BURST_W),
         .CTRL_CHAIN(CTRL_CHAIN), .DATA_CHAIN(DATA_CHAIN),
         .EIO_EN(EIO_EN), .EIO_IN_W(EIO_IN_W), .EIO_OUT_W(EIO_OUT_W)
     ) u_inner (

--- a/rtl/reset_sync.v
+++ b/rtl/reset_sync.v
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
+
+`timescale 1ns/1ps
+
+// Asynchronous-assert, synchronous-deassert reset synchronizer.
+//
+// Use this when a reset source may be unrelated to the destination clock
+// domain, but the destination logic expects clean reset release on that clock.
+
+module reset_sync #(
+    parameter STAGES = 2
+) (
+    input  wire clk,
+    input  wire arst,
+    output wire srst
+);
+
+    (* ASYNC_REG = "TRUE" *) reg [STAGES-1:0] sync_ff;
+
+    always @(posedge clk or posedge arst) begin
+        if (arst)
+            sync_ff <= {STAGES{1'b1}};
+        else
+            sync_ff <= {sync_ff[STAGES-2:0], 1'b0};
+    end
+
+    assign srst = sync_ff[STAGES-1];
+
+endmodule

--- a/scripts/resource_comparison.tcl
+++ b/scripts/resource_comparison.tcl
@@ -63,7 +63,7 @@ foreach cfg $configs {
     puts $fp "endmodule"
     close $fp
 
-    add_files [list $root/rtl/dpram.v $root/rtl/fcapz_ela.v $root/rtl/jtag_reg_iface.v $root/rtl/jtag_burst_read.v $root/rtl/jtag_tap/jtag_tap_xilinx7.v $root/vivado/top_${label}.v]
+    add_files [list $root/rtl/dpram.v $root/rtl/reset_sync.v $root/rtl/fcapz_ela.v $root/rtl/jtag_reg_iface.v $root/rtl/jtag_burst_read.v $root/rtl/jtag_tap/jtag_tap_xilinx7.v $root/vivado/top_${label}.v]
     add_files -fileset constrs_1 $root/examples/arty_a7/arty_a7.xdc
     set_property top arty_a7_top [current_fileset]
 

--- a/sim/run_sim.py
+++ b/sim/run_sim.py
@@ -26,6 +26,7 @@ TESTBENCHES = {
     "fcapz_ela": (
         TB / "fcapz_ela_tb.sv",
         [
+            RTL / "reset_sync.v",
             RTL / "fcapz_ela.v",
             RTL / "dpram.v",
             RTL / "trig_compare.v",
@@ -34,6 +35,7 @@ TESTBENCHES = {
     "fcapz_ela_bug_probe": (
         TB / "fcapz_ela_bug_probe_tb.sv",
         [
+            RTL / "reset_sync.v",
             RTL / "fcapz_ela.v",
             RTL / "dpram.v",
             RTL / "trig_compare.v",
@@ -48,6 +50,7 @@ TESTBENCHES = {
     "chan_mux": (
         TB / "chan_mux_tb.sv",
         [
+            RTL / "reset_sync.v",
             RTL / "fcapz_ela.v",
             RTL / "dpram.v",
             RTL / "trig_compare.v",
@@ -64,6 +67,7 @@ DEFAULT_TESTBENCHES = [
 
 LINT_TARGETS = [
     RTL / "dpram.v",
+    RTL / "reset_sync.v",
     RTL / "trig_compare.v",
     RTL / "jtag_reg_iface.v",
     RTL / "jtag_burst_read.v",

--- a/tb/fcapz_ela_bug_probe_tb.sv
+++ b/tb/fcapz_ela_bug_probe_tb.sv
@@ -228,8 +228,56 @@ module fcapz_ela_bug_probe_tb;
         data = rdata_w48;
     endtask
 
+    // ---------------------------------------------------------------------
+    // Regression 6/7: segmented auto-rearm plus external trigger timing.
+    localparam int SEGTRIG_W = 8;
+    localparam int SEGTRIG_DEPTH = 1024;
+    logic [SEGTRIG_W-1:0] probe_segtrig = '0;
+    logic ext_trig_segtrig = 1'b0;
+    logic wr_segtrig = 1'b0, rd_segtrig = 1'b0;
+    logic [15:0] addr_segtrig = '0;
+    logic [31:0] wdata_segtrig = '0, rdata_segtrig;
+    logic [$clog2(SEGTRIG_DEPTH)-1:0] burst_addr_segtrig = '0;
+    wire [SEGTRIG_W-1:0] burst_data_segtrig;
+    wire burst_start_segtrig;
+    wire [$clog2(SEGTRIG_DEPTH)-1:0] burst_start_ptr_segtrig;
+    wire armed_out_segtrig;
+
+    fcapz_ela #(
+        .SAMPLE_W(SEGTRIG_W),
+        .DEPTH(SEGTRIG_DEPTH),
+        .EXT_TRIG_EN(1),
+        .TIMESTAMP_W(32),
+        .NUM_SEGMENTS(4),
+        .INPUT_PIPE(1)
+    ) dut_segtrig (
+        .sample_clk(sample_clk), .sample_rst(sample_rst), .probe_in(probe_segtrig),
+        .trigger_in(ext_trig_segtrig), .trigger_out(), .armed_out(armed_out_segtrig),
+        .jtag_clk(jtag_clk), .jtag_rst(jtag_rst),
+        .jtag_wr_en(wr_segtrig), .jtag_rd_en(rd_segtrig),
+        .jtag_addr(addr_segtrig), .jtag_wdata(wdata_segtrig), .jtag_rdata(rdata_segtrig),
+        .burst_rd_addr(burst_addr_segtrig), .burst_rd_data(burst_data_segtrig),
+        .burst_start(burst_start_segtrig), .burst_start_ptr(burst_start_ptr_segtrig)
+    );
+
+    task automatic write_segtrig(input [15:0] addr, input [31:0] data);
+        @(posedge jtag_clk);
+        addr_segtrig <= addr; wdata_segtrig <= data; wr_segtrig <= 1'b1;
+        @(posedge jtag_clk);
+        wr_segtrig <= 1'b0;
+    endtask
+
+    task automatic read_segtrig(input [15:0] addr, output [31:0] data);
+        @(posedge jtag_clk);
+        addr_segtrig <= addr; rd_segtrig <= 1'b1;
+        @(posedge jtag_clk);
+        rd_segtrig <= 1'b0;
+        repeat (10) @(posedge jtag_clk);
+        data = rdata_segtrig;
+    endtask
+
     initial begin
-        logic [31:0] word0, word1, word2, status;
+        logic [31:0] word0, word1, word2, status, seg_status;
         int i;
 
         repeat (4) @(posedge sample_clk);
@@ -355,6 +403,84 @@ module fcapz_ela_bug_probe_tb;
         $display("  sample[0] chunk0=0x%08x chunk1=0x%08x", word0, word1);
         check("48-bit data low chunk is 0x22223333", word0 === 32'h2222_3333);
         check("48-bit data high chunk is zero-extended", word1 === 32'h0000_1111);
+
+        $display("\n=== Regression 7: single armed-edge pulse source stalls segmented capture ===");
+        write_segtrig(16'h0014, 32'd0);
+        write_segtrig(16'h0018, 32'd2);
+        write_segtrig(16'h0020, 32'h1);
+        write_segtrig(16'h0024, 32'd0);
+        write_segtrig(16'h0028, 32'd0);
+        write_segtrig(16'h00B4, 32'd2);   // EXT_TRIG = AND
+        write_segtrig(16'h00DC, 32'd4);   // TRIG_HOLDOFF = 4
+        write_segtrig(16'h0004, 32'h1);
+        probe_segtrig = '0;
+        ext_trig_segtrig = 1'b0;
+        begin
+            logic prev_armed_only;
+            integer pulse_countdown;
+
+            prev_armed_only = 1'b0;
+            pulse_countdown = -1;
+            repeat (220) begin
+                @(posedge sample_clk);
+                probe_segtrig <= probe_segtrig + 1'b1;
+                ext_trig_segtrig = 1'b0;
+                if (armed_out_segtrig && !prev_armed_only) begin
+                    pulse_countdown = 8;
+                end else if (pulse_countdown >= 0) begin
+                    if (pulse_countdown == 0)
+                        ext_trig_segtrig = 1'b1;
+                    pulse_countdown = pulse_countdown - 1;
+                end
+                prev_armed_only = armed_out_segtrig;
+            end
+        end
+        wait_sample(40);
+        read_segtrig(16'h0008, status);
+        read_segtrig(16'h00BC, seg_status);
+        $display("  old-hook status=0x%08x seg_status=0x%08x", status, seg_status);
+        check("single armed-edge pulse source does not finish all segments",
+              (status[2] == 1'b0) && (seg_status[31] == 1'b0) && (seg_status[1:0] == 2'd1));
+
+        $display("\n=== Regression 8: per-rearm pulse source completes segmented capture ===");
+        write_segtrig(16'h0004, 32'h2);
+        wait_sample(8);
+        write_segtrig(16'h0014, 32'd0);
+        write_segtrig(16'h0018, 32'd2);
+        write_segtrig(16'h0020, 32'h1);
+        write_segtrig(16'h0024, 32'd0);
+        write_segtrig(16'h0028, 32'd0);
+        write_segtrig(16'h00B4, 32'd2);
+        write_segtrig(16'h00DC, 32'd4);
+        write_segtrig(16'h0004, 32'h1);
+        probe_segtrig = '0;
+        ext_trig_segtrig = 1'b0;
+        begin
+            logic prev_pretrigger_phase;
+            integer pulse_countdown;
+
+            prev_pretrigger_phase = 1'b0;
+            pulse_countdown = -1;
+            repeat (320) begin
+                @(posedge sample_clk);
+                probe_segtrig <= probe_segtrig + 1'b1;
+                ext_trig_segtrig = 1'b0;
+                if ((dut_segtrig.armed && !dut_segtrig.triggered) && !prev_pretrigger_phase) begin
+                    pulse_countdown = 8;
+                end else if (pulse_countdown >= 0) begin
+                    if (pulse_countdown == 0)
+                        ext_trig_segtrig = 1'b1;
+                    pulse_countdown = pulse_countdown - 1;
+                end
+                prev_pretrigger_phase = dut_segtrig.armed && !dut_segtrig.triggered;
+            end
+        end
+        wait_sample(40);
+        read_segtrig(16'h0008, status);
+        read_segtrig(16'h00BC, seg_status);
+        $display("  fixed-hook status=0x%08x seg_status=0x%08x", status, seg_status);
+        check("per-rearm pulse source finishes all segments",
+              (status[2] == 1'b1) && (seg_status[31] == 1'b1) && (seg_status[1:0] == 2'd0));
 
         $display("\n=== Regression summary: %0d passed, %0d failed ===",
                  pass_count, fail_count);

--- a/tb/fcapz_ela_tb.sv
+++ b/tb/fcapz_ela_tb.sv
@@ -978,6 +978,79 @@ module fcapz_ela_tb;
         repeat (4) @(posedge sample_clk);
         jtag_write(16'h00D4, 32'd0);
 
+        // ---- Test 26: STARTUP_ARM auto-arms after reset --------------------
+        $display("\n=== Test 26: STARTUP_ARM auto-arms after reset ===");
+        jtag_write(16'h0014, 32'd0);    // PRETRIG_LEN
+        jtag_write(16'h0018, 32'd2);    // POSTTRIG_LEN
+        jtag_write(16'h0020, 32'h1);    // TRIG_MODE: value_match
+        jtag_write(16'h0024, 32'd6);    // TRIG_VALUE
+        jtag_write(16'h0028, 32'hFF);   // TRIG_MASK
+        jtag_write(16'h00D8, 32'd1);    // STARTUP_ARM enable
+        jtag_write(16'h0004, 32'h2);    // RESET -> should auto-arm
+        repeat (12) @(posedge sample_clk);
+        jtag_read(16'h0008, status);
+        check("STARTUP_ARM: armed after reset", status[0] == 1'b1);
+
+        probe_in = '0;
+        repeat (12) begin
+            @(posedge sample_clk);
+            probe_in <= probe_in + 1'b1;
+        end
+        cycles = 0;
+        while (cycles < 100) begin
+            @(posedge sample_clk);
+            cycles++;
+        end
+        jtag_read(16'h0008, status);
+        check("STARTUP_ARM: done after auto-armed capture", status[2] == 1'b1);
+        jtag_write(16'h00D8, 32'd0);    // restore
+
+        // ---- Test 27: TRIG_HOLDOFF blocks early hits, allows later ones ----
+        $display("\n=== Test 27: TRIG_HOLDOFF semantics ===");
+        jtag_write(16'h00DC, 32'd4);
+        jtag_read(16'h00DC, sample_word);
+        check("TRIG_HOLDOFF round-trip = 4", sample_word == 32'd4);
+
+        // First: hit happens only during holdoff -> capture must not trigger.
+        jtag_write(16'h0004, 32'h2);    // RESET
+        repeat (10) @(posedge sample_clk);
+        jtag_write(16'h0014, 32'd0);
+        jtag_write(16'h0018, 32'd2);
+        jtag_write(16'h0020, 32'h1);
+        jtag_write(16'h0024, 32'd3);    // occurs during 4-cycle holdoff
+        jtag_write(16'h0028, 32'hFF);
+        jtag_write(16'h0004, 32'h1);    // ARM
+        probe_in = '0;
+        repeat (16) begin
+            @(posedge sample_clk);
+            probe_in <= probe_in + 1'b1;
+        end
+        jtag_read(16'h0008, status);
+        check("TRIG_HOLDOFF: early hit ignored", status[1] == 1'b0 && status[2] == 1'b0);
+
+        // Second: later hit after holdoff should still trigger normally.
+        jtag_write(16'h0004, 32'h2);    // RESET
+        repeat (10) @(posedge sample_clk);
+        jtag_write(16'h0014, 32'd0);
+        jtag_write(16'h0018, 32'd2);
+        jtag_write(16'h0020, 32'h1);
+        jtag_write(16'h0024, 32'd6);    // occurs after holdoff expires
+        jtag_write(16'h0028, 32'hFF);
+        jtag_write(16'h0004, 32'h1);    // ARM
+        probe_in = '0;
+        repeat (20) begin
+            @(posedge sample_clk);
+            probe_in <= probe_in + 1'b1;
+        end
+        cycles = 0;
+        while (cycles < 100) begin
+            @(posedge sample_clk);
+            cycles++;
+        end
+        jtag_read(16'h0008, status);
+        check("TRIG_HOLDOFF: later hit triggers", status[2] == 1'b1);
+        jtag_write(16'h00DC, 32'd0);    // restore
+
         // ---- Summary -------------------------------------------------------
         $display("\n=== Summary: %0d passed, %0d failed ===",
                  test_pass_count, test_fail_count);

--- a/tb/fcapz_ela_tb.sv
+++ b/tb/fcapz_ela_tb.sv
@@ -16,6 +16,7 @@
 module fcapz_ela_tb;
     localparam int SAMPLE_W = 8;
     localparam int DEPTH    = 16;
+    localparam int PIPE_DEPTH = 1024;
 
     logic sample_clk = 1'b0;
     logic jtag_clk   = 1'b0;
@@ -170,6 +171,46 @@ module fcapz_ela_tb;
         .burst_start_ptr (burst_start_ptr_pmux)
     );
 
+    // ==== DUT5: INPUT_PIPE=1 regression instance ============================
+    logic [31:0] jtag_rdata_pipe;
+    logic        jtag_wr_en_pipe = 1'b0;
+    logic        jtag_rd_en_pipe = 1'b0;
+    logic [15:0] jtag_addr_pipe  = '0;
+    logic [31:0] jtag_wdata_pipe = '0;
+    logic [SAMPLE_W-1:0] probe_in_pipe = '0;
+    logic trigger_in_pipe = 1'b0;
+    logic [$clog2(PIPE_DEPTH)-1:0] burst_rd_addr_pipe = '0;
+    wire  [SAMPLE_W-1:0]           burst_rd_data_pipe;
+    wire                            burst_start_pipe;
+    wire  [$clog2(PIPE_DEPTH)-1:0]  burst_start_ptr_pipe;
+
+    fcapz_ela #(
+        .SAMPLE_W(SAMPLE_W),
+        .DEPTH(PIPE_DEPTH),
+        .DECIM_EN(1),
+        .EXT_TRIG_EN(1),
+        .TIMESTAMP_W(32),
+        .NUM_SEGMENTS(4),
+        .INPUT_PIPE(1)
+    ) dut_pipe (
+        .sample_clk      (sample_clk),
+        .sample_rst      (sample_rst),
+        .probe_in        (probe_in_pipe),
+        .trigger_in      (trigger_in_pipe),
+        .trigger_out     (),
+        .jtag_clk        (jtag_clk),
+        .jtag_rst        (jtag_rst),
+        .jtag_wr_en      (jtag_wr_en_pipe),
+        .jtag_rd_en      (jtag_rd_en_pipe),
+        .jtag_addr       (jtag_addr_pipe),
+        .jtag_wdata      (jtag_wdata_pipe),
+        .jtag_rdata      (jtag_rdata_pipe),
+        .burst_rd_addr   (burst_rd_addr_pipe),
+        .burst_rd_data   (burst_rd_data_pipe),
+        .burst_start     (burst_start_pipe),
+        .burst_start_ptr (burst_start_ptr_pipe)
+    );
+
     // Clocks
     always #5  sample_clk = ~sample_clk; // 100 MHz
     always #7  jtag_clk   = ~jtag_clk;   // ~71 MHz
@@ -253,6 +294,26 @@ module fcapz_ela_tb;
         jtag_rd_en_seg <= 1'b0;
         repeat (8) @(posedge jtag_clk);
         data = jtag_rdata_seg;
+    endtask
+
+    // Helpers for dut_pipe
+    task automatic jtag_write_pipe(input [15:0] addr, input [31:0] data);
+        @(posedge jtag_clk);
+        jtag_addr_pipe  <= addr;
+        jtag_wdata_pipe <= data;
+        jtag_wr_en_pipe <= 1'b1;
+        @(posedge jtag_clk);
+        jtag_wr_en_pipe <= 1'b0;
+    endtask
+
+    task automatic jtag_read_pipe(input [15:0] addr, output [31:0] data);
+        @(posedge jtag_clk);
+        jtag_addr_pipe  <= addr;
+        jtag_rd_en_pipe <= 1'b1;
+        @(posedge jtag_clk);
+        jtag_rd_en_pipe <= 1'b0;
+        repeat (8) @(posedge jtag_clk);
+        data = jtag_rdata_pipe;
     endtask
 
     // ---- Procedural assertions (iverilog-compatible) ------------------------
@@ -1050,6 +1111,127 @@ module fcapz_ela_tb;
         jtag_read(16'h0008, status);
         check("TRIG_HOLDOFF: later hit triggers", status[2] == 1'b1);
         jtag_write(16'h00DC, 32'd0);    // restore
+
+        // ---- Test 28: INPUT_PIPE=1 minimal capture regression -------------
+        $display("\n=== Test 28: INPUT_PIPE=1 minimal capture ===");
+        jtag_write_pipe(16'h0004, 32'h2);    // RESET
+        repeat (10) @(posedge sample_clk);
+        jtag_write_pipe(16'h0014, 32'd0);    // PRETRIG_LEN
+        jtag_write_pipe(16'h0018, 32'd0);    // POSTTRIG_LEN
+        jtag_write_pipe(16'h0020, 32'h1);    // TRIG_MODE: value_match
+        jtag_write_pipe(16'h0024, 32'd0);    // TRIG_VALUE (repeats every 256 cycles)
+        jtag_write_pipe(16'h0028, 32'hFF);   // TRIG_MASK
+        jtag_write_pipe(16'h00B0, 32'd0);    // DECIM=0
+        jtag_write_pipe(16'h0004, 32'h1);    // ARM
+
+        probe_in_pipe = '0;
+        repeat (1200) begin
+            @(posedge sample_clk);
+            probe_in_pipe <= probe_in_pipe + 1'b1;
+        end
+
+        cycles = 0;
+        while (cycles < 160) begin
+            @(posedge sample_clk);
+            cycles++;
+        end
+
+        jtag_read_pipe(16'h0008, status);
+        check("INPUT_PIPE=1 minimal: done", status[2] == 1'b1);
+        check("INPUT_PIPE=1 minimal: armed cleared", status[0] == 1'b0);
+        jtag_read_pipe(16'h001C, cap_len);
+        check($sformatf("INPUT_PIPE=1 minimal: CAPTURE_LEN=1 (got %0d)", cap_len),
+              cap_len == 1);
+        jtag_read_pipe(16'h00BC, seg_status);
+        check("INPUT_PIPE=1 minimal: all segments done", seg_status[31] == 1'b1);
+
+        // ---- Test 29: INPUT_PIPE=1 large capture regression ---------------
+        $display("\n=== Test 29: INPUT_PIPE=1 large capture ===");
+        jtag_write_pipe(16'h0004, 32'h2);    // RESET
+        repeat (10) @(posedge sample_clk);
+        jtag_write_pipe(16'h0014, 32'd50);   // PRETRIG_LEN
+        jtag_write_pipe(16'h0018, 32'd100);  // POSTTRIG_LEN
+        jtag_write_pipe(16'h0020, 32'h1);    // TRIG_MODE: value_match
+        jtag_write_pipe(16'h0024, 32'd64);   // TRIG_VALUE
+        jtag_write_pipe(16'h0028, 32'hFF);   // TRIG_MASK
+        jtag_write_pipe(16'h00B0, 32'd0);    // DECIM=0
+        jtag_write_pipe(16'h0004, 32'h1);    // ARM
+
+        probe_in_pipe = '0;
+        repeat (1400) begin
+            @(posedge sample_clk);
+            probe_in_pipe <= probe_in_pipe + 1'b1;
+        end
+
+        cycles = 0;
+        while (cycles < 200) begin
+            @(posedge sample_clk);
+            cycles++;
+        end
+
+        jtag_read_pipe(16'h0008, status);
+        check("INPUT_PIPE=1 large: done", status[2] == 1'b1);
+        check("INPUT_PIPE=1 large: overflow clear", status[3] == 1'b0);
+        jtag_read_pipe(16'h001C, cap_len);
+        check($sformatf("INPUT_PIPE=1 large: CAPTURE_LEN=151 (got %0d)", cap_len),
+              cap_len == 151);
+        jtag_read_pipe(16'h00BC, seg_status);
+        check("INPUT_PIPE=1 large: all segments done", seg_status[31] == 1'b1);
+
+        // ---- Test 30: INPUT_PIPE=1 holdoff late ext pulse -----------------
+        $display("\n=== Test 30: INPUT_PIPE=1 holdoff late ext pulse ===");
+        jtag_write_pipe(16'h0004, 32'h2);    // RESET
+        repeat (10) @(posedge sample_clk);
+        jtag_write_pipe(16'h0014, 32'd0);
+        jtag_write_pipe(16'h0018, 32'd2);
+        jtag_write_pipe(16'h0020, 32'h1);
+        jtag_write_pipe(16'h0024, 32'd0);    // always true with mask=0
+        jtag_write_pipe(16'h0028, 32'd0);
+        jtag_write_pipe(16'h00B4, 32'd2);    // EXT_TRIG = AND
+        jtag_write_pipe(16'h00DC, 32'd4);    // TRIG_HOLDOFF = 4
+        jtag_write_pipe(16'h0004, 32'h1);    // ARM
+
+        begin
+            logic prev_pretrigger_pipe;
+            integer pulse_countdown;
+
+            probe_in_pipe = '0;
+            trigger_in_pipe = 1'b0;
+            prev_pretrigger_pipe = 1'b0;
+            pulse_countdown = -1;
+            repeat (320) begin
+                @(posedge sample_clk);
+                probe_in_pipe <= probe_in_pipe + 1'b1;
+                trigger_in_pipe = 1'b0;
+
+                if ((dut_pipe.armed && !dut_pipe.triggered) && !prev_pretrigger_pipe) begin
+                    pulse_countdown = 8;
+                end else if (pulse_countdown >= 0) begin
+                    if (pulse_countdown == 0)
+                        trigger_in_pipe = 1'b1;
+                    pulse_countdown = pulse_countdown - 1;
+                end
+
+                prev_pretrigger_pipe = dut_pipe.armed && !dut_pipe.triggered;
+            end
+        end
+
+        cycles = 0;
+        while (cycles < 120) begin
+            @(posedge sample_clk);
+            cycles++;
+        end
+
+        jtag_read_pipe(16'h0008, status);
+        check("INPUT_PIPE=1 holdoff late pulse: done", status[2] == 1'b1);
+        check("INPUT_PIPE=1 holdoff late pulse: triggered", status[1] == 1'b1);
+        jtag_read_pipe(16'h001C, cap_len);
+        check($sformatf("INPUT_PIPE=1 holdoff late pulse: CAPTURE_LEN=3 (got %0d)", cap_len),
+              cap_len == 3);
+        jtag_read_pipe(16'h00BC, seg_status);
+        check("INPUT_PIPE=1 holdoff late pulse: all segments done", seg_status[31] == 1'b1);
+        jtag_write_pipe(16'h00DC, 32'd0);    // restore
+        jtag_write_pipe(16'h00B4, 32'd0);    // restore
 
         // ---- Summary -------------------------------------------------------
         $display("\n=== Summary: %0d passed, %0d failed ===",

--- a/tests/test_cli_rpc_events.py
+++ b/tests/test_cli_rpc_events.py
@@ -475,6 +475,43 @@ class RpcTriggerDelayValidationTests(unittest.TestCase):
                 RpcServer._validated_trigger_delay(v)
 
 
+class RpcTriggerHoldoffValidationTests(unittest.TestCase):
+    """Tests for trigger_holdoff validation in RPC _build_config."""
+
+    def test_valid_values_accepted(self):
+        for v in (0, 1, 1234, 0xFFFF):
+            self.assertEqual(RpcServer._validated_trigger_holdoff(v), v)
+
+    def test_invalid_values_rejected(self):
+        for v in (-1, 0x10000, 0x7FFFFFFF):
+            with self.assertRaises(ValueError):
+                RpcServer._validated_trigger_holdoff(v)
+
+
+class RpcBooleanValidationTests(unittest.TestCase):
+    """Tests for strict boolean parsing in RPC _build_config."""
+
+    def test_valid_startup_arm_values(self):
+        cases = [
+            (False, False),
+            (True, True),
+            (0, False),
+            (1, True),
+            ("false", False),
+            ("true", True),
+            ("off", False),
+            ("on", True),
+        ]
+        for raw, expected in cases:
+            cfg = RpcServer._build_config({"startup_arm": raw})
+            self.assertEqual(cfg.startup_arm, expected)
+
+    def test_invalid_startup_arm_values_rejected(self):
+        for raw in (2, "maybe", object()):
+            with self.assertRaises(ValueError):
+                RpcServer._build_config({"startup_arm": raw})
+
+
 class CliTests(unittest.TestCase):
     def test_capture_parser_accepts_channel_and_probes(self):
         parser = build_parser()
@@ -492,6 +529,22 @@ class CliTests(unittest.TestCase):
         config = _build_config(args)
         self.assertEqual(config.channel, 1)
         self.assertEqual([probe.name for probe in config.probes], ["lo", "hi"])
+
+    def test_capture_parser_accepts_startup_arm_and_trigger_holdoff(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "capture",
+                "--startup-arm",
+                "--trigger-holdoff",
+                "12",
+                "--out",
+                "capture.json",
+            ]
+        )
+        config = _build_config(args)
+        self.assertTrue(config.startup_arm)
+        self.assertEqual(config.trigger_holdoff, 12)
 
 
 class RpcServerHarness(RpcServer):

--- a/tests/test_gui_capture_panel.py
+++ b/tests/test_gui_capture_panel.py
@@ -52,7 +52,6 @@ class TestCapturePanelApplyHistory(unittest.TestCase):
                 "stor_qual_mode": 0,
                 "stor_qual_value": 0,
                 "stor_qual_mask": 0,
-                "startup_arm": True,
                 "trigger_holdoff": 7,
                 "trigger_delay": 2,
                 "probes": "a:2:0",
@@ -66,7 +65,7 @@ class TestCapturePanelApplyHistory(unittest.TestCase):
         self.assertEqual(cfg.trigger.mask, 15)
         self.assertEqual(cfg.sample_clock_hz, 80_000_000)
         self.assertEqual(cfg.ext_trigger_mode, 1)
-        self.assertTrue(cfg.startup_arm)
+        self.assertFalse(cfg.startup_arm)
         self.assertEqual(cfg.trigger_holdoff, 7)
         self.assertEqual(len(cfg.probes), 1)
         self.assertEqual(cfg.probes[0].name, "a")
@@ -172,7 +171,6 @@ class TestCapturePanelApplyHistory(unittest.TestCase):
                 "stor_qual_mode": 0,
                 "stor_qual_value": 0,
                 "stor_qual_mask": 0,
-                "startup_arm": False,
                 "trigger_holdoff": 0,
                 "trigger_delay": 0,
                 "probes": "",

--- a/tests/test_gui_capture_panel.py
+++ b/tests/test_gui_capture_panel.py
@@ -52,6 +52,8 @@ class TestCapturePanelApplyHistory(unittest.TestCase):
                 "stor_qual_mode": 0,
                 "stor_qual_value": 0,
                 "stor_qual_mask": 0,
+                "startup_arm": True,
+                "trigger_holdoff": 7,
                 "trigger_delay": 2,
                 "probes": "a:2:0",
             },
@@ -64,6 +66,8 @@ class TestCapturePanelApplyHistory(unittest.TestCase):
         self.assertEqual(cfg.trigger.mask, 15)
         self.assertEqual(cfg.sample_clock_hz, 80_000_000)
         self.assertEqual(cfg.ext_trigger_mode, 1)
+        self.assertTrue(cfg.startup_arm)
+        self.assertEqual(cfg.trigger_holdoff, 7)
         self.assertEqual(len(cfg.probes), 1)
         self.assertEqual(cfg.probes[0].name, "a")
 
@@ -168,6 +172,8 @@ class TestCapturePanelApplyHistory(unittest.TestCase):
                 "stor_qual_mode": 0,
                 "stor_qual_value": 0,
                 "stor_qual_mask": 0,
+                "startup_arm": False,
+                "trigger_holdoff": 0,
                 "trigger_delay": 0,
                 "probes": "",
                 "trigger_sequence": [

--- a/tests/test_gui_main_window.py
+++ b/tests/test_gui_main_window.py
@@ -180,6 +180,7 @@ def test_connect_and_disconnect_mocked(qtbot: Any, tmp_path: Path) -> None:
 
         qtbot.mouseClick(_button_with_text(w, "Connect"), Qt.MouseButton.LeftButton)
         qtbot.waitUntil(lambda: w._analyzer is not None, timeout=5000)
+        assert "not programmed on connect" in w._conn._status.text()
 
         qtbot.mouseClick(_button_with_text(w, "Disconnect"), Qt.MouseButton.LeftButton)
         QApplication.processEvents()

--- a/tests/test_gui_settings.py
+++ b/tests/test_gui_settings.py
@@ -166,7 +166,6 @@ class TestTriggerHistory(unittest.TestCase):
             stor_qual_mode=0,
             stor_qual_value=0,
             stor_qual_mask=0,
-            startup_arm=False,
             trigger_holdoff=0,
             trigger_delay=0,
         )
@@ -215,7 +214,6 @@ class TestTriggerHistoryEntry(unittest.TestCase):
             stor_qual_mode=0,
             stor_qual_value=0,
             stor_qual_mask=0,
-            startup_arm=True,
             trigger_holdoff=9,
             trigger_delay=3,
         )
@@ -229,7 +227,7 @@ class TestTriggerHistoryEntry(unittest.TestCase):
         self.assertEqual(d["ext_trigger_mode"], "or")
         self.assertEqual(d["probes"], "lo:4:0")
         self.assertEqual(d["probe_sel"], 2)
-        self.assertTrue(d["startup_arm"])
+        self.assertNotIn("startup_arm", d)
         self.assertEqual(d["trigger_holdoff"], 9)
         self.assertEqual(d["trigger_delay"], 3)
         self.assertEqual(d["trigger_sequence"], [])
@@ -267,7 +265,6 @@ class TestTriggerHistoryEntry(unittest.TestCase):
             stor_qual_mode=0,
             stor_qual_value=0,
             stor_qual_mask=0,
-            startup_arm=False,
             trigger_holdoff=0,
             trigger_delay=0,
         )

--- a/tests/test_gui_settings.py
+++ b/tests/test_gui_settings.py
@@ -166,6 +166,8 @@ class TestTriggerHistory(unittest.TestCase):
             stor_qual_mode=0,
             stor_qual_value=0,
             stor_qual_mask=0,
+            startup_arm=False,
+            trigger_holdoff=0,
             trigger_delay=0,
         )
         g = GuiSettings()
@@ -213,6 +215,8 @@ class TestTriggerHistoryEntry(unittest.TestCase):
             stor_qual_mode=0,
             stor_qual_value=0,
             stor_qual_mask=0,
+            startup_arm=True,
+            trigger_holdoff=9,
             trigger_delay=3,
         )
         d = trigger_history_entry_from_config(cfg)
@@ -225,6 +229,8 @@ class TestTriggerHistoryEntry(unittest.TestCase):
         self.assertEqual(d["ext_trigger_mode"], "or")
         self.assertEqual(d["probes"], "lo:4:0")
         self.assertEqual(d["probe_sel"], 2)
+        self.assertTrue(d["startup_arm"])
+        self.assertEqual(d["trigger_holdoff"], 9)
         self.assertEqual(d["trigger_delay"], 3)
         self.assertEqual(d["trigger_sequence"], [])
         self.assertNotIn("trigger_value_radix", d)
@@ -261,6 +267,8 @@ class TestTriggerHistoryEntry(unittest.TestCase):
             stor_qual_mode=0,
             stor_qual_value=0,
             stor_qual_mask=0,
+            startup_arm=False,
+            trigger_holdoff=0,
             trigger_delay=0,
         )
         d = trigger_history_entry_from_config(cfg)

--- a/tests/test_host_stack.py
+++ b/tests/test_host_stack.py
@@ -414,6 +414,23 @@ class SequencerTests(unittest.TestCase):
         analyzer.configure(cfg)
         self.assertEqual(transport.regs[0x00D4], 42)
 
+    def test_trigger_holdoff_and_startup_arm_written(self):
+        transport = FakeTransport()
+        analyzer = Analyzer(transport)
+        analyzer.connect()
+        cfg = CaptureConfig(
+            pretrigger=1,
+            posttrigger=2,
+            trigger=TriggerConfig(mode="value_match", value=0, mask=0xFF),
+            sample_width=8,
+            depth=1024,
+            startup_arm=True,
+            trigger_holdoff=17,
+        )
+        analyzer.configure(cfg)
+        self.assertEqual(transport.regs[0x00D8], 1)
+        self.assertEqual(transport.regs[0x00DC], 17)
+
     def test_trigger_delay_default_zero_written(self):
         transport = FakeTransport()
         analyzer = Analyzer(transport)
@@ -429,6 +446,8 @@ class SequencerTests(unittest.TestCase):
         # Even when not specified, the register is unconditionally written
         # to 0 so a previous run cannot leak in.
         self.assertEqual(transport.regs.get(0x00D4, None), 0)
+        self.assertEqual(transport.regs.get(0x00D8, None), 0)
+        self.assertEqual(transport.regs.get(0x00DC, None), 0)
 
     def test_trigger_delay_out_of_range_rejected(self):
         analyzer = Analyzer(FakeTransport())
@@ -441,6 +460,21 @@ class SequencerTests(unittest.TestCase):
                 sample_width=8,
                 depth=1024,
                 trigger_delay=bad,
+            )
+            with self.assertRaises(ValueError):
+                analyzer.configure(cfg)
+
+    def test_trigger_holdoff_out_of_range_rejected(self):
+        analyzer = Analyzer(FakeTransport())
+        analyzer.connect()
+        for bad in (-1, 0x10000, 0x7FFFFFFF):
+            cfg = CaptureConfig(
+                pretrigger=1,
+                posttrigger=2,
+                trigger=TriggerConfig(mode="value_match", value=0, mask=0xFF),
+                sample_width=8,
+                depth=1024,
+                trigger_holdoff=bad,
             )
             with self.assertRaises(ValueError):
                 analyzer.configure(cfg)


### PR DESCRIPTION
## Summary

This branch adds startup-arm and trigger-holdoff support end-to-end, hardens ELA CDC/timing paths, improves GUI connection-state behavior, and validates the new behavior in RTL simulation and on the Arty A7 hardware reference design.

## Commit Coverage

- `6b43880 Add startup arm and trigger holdoff controls`  
  Adds runtime `startup_arm` and `trigger_holdoff` controls across RTL, Python API, CLI, RPC, GUI config, docs, and tests. The ELA can now re-arm from reset when configured, and can ignore early trigger hits for a programmable number of sample-clock cycles after arm/re-arm.

- `218e754 Fix CDC crossings in ELA config and JTAG reset paths`  
  Tightens ELA config/register CDC handling and propagates reset synchronization into vendor wrappers. Adds `reset_sync`, updates simulation/lint coverage, and ensures wrapper reset behavior is cleaner across Xilinx, ECP5, Gowin, Intel, and PolarFire targets.

- `f0b49ba Clarify GUI hardware connect state`  
  Cleans up GUI connection-state handling so hardware/programming readiness and capture controls are represented more clearly.

- `0c18bc7 Improve ELA RAM write timing`  
  Registers the BRAM write command for timing-sensitive `INPUT_PIPE>=1` builds so write enable, address, sample data, and optional timestamp data reach inferred RAM together. Adds `INPUT_PIPE=1` regression coverage and documents the timing behavior.

- `9bc048d Validate GSR startup arm on Arty`  
  Adds explicit configuration-time startup defaults, threads `DEFAULT_TRIG_EXT` through Xilinx wrappers, updates the Arty reference bitstream to prove post-GSR startup arm, and adds hardware/simulation regressions for startup/re-arm behavior.

## Highlights

- Adds `STARTUP_ARM` register at `0x00D8`.
- Adds `TRIG_HOLDOFF` register at `0x00DC`.
- Adds `DEFAULT_TRIG_EXT`, useful when `STARTUP_ARM=1` and the bitstream should come up armed but wait for an external trigger.
- Validates true configuration/GSR startup behavior on Arty A7 by programming the FPGA and checking `STATUS` before any host reset/config write.
- Tests trigger holdoff for both blocked early pulses and accepted later pulses.
- Covers both `INPUT_PIPE=0` and `INPUT_PIPE=1` in simulation; Arty hardware uses `INPUT_PIPE=1`.

## Validation

- `python -m pytest tests\ -v`
  - `298 passed, 2 skipped, 2 deselected`

- `python sim\run_sim.py`
  - RTL lint passed
  - all 4 testbenches passed

- `python examples\arty_a7\build.py`
  - rebuilt `examples/arty_a7/arty_a7_top.bit`

- `python -m pytest examples\arty_a7\test_hw_integration.py -v`
  - `48 passed, 7 skipped` on connected Arty A7

## Notes

Startup arm is FPGA-safe: the ELA does not depend on `armed` being combinationally high at GSR release. Instead, the bitstream initializes a pending startup-arm state, and the core becomes armed on the first live `sample_clk` edge after configuration/reset release.
