### PR TITLE
Gate JTAG AXI debug logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **EJTAG-AXI RTL:** `DEBUG_EN` parameter on the core and vendor wrappers,
+  defaulting off to prune bridge-only debug buses, capture records, and
+  counters from production builds; RTL reset regression now sweeps
+  `DEBUG_EN=0` and `DEBUG_EN=1`.
+
 - **Docs:** JTAG register map spec — in-document index, ↑ Top anchors, and
   clarified per-core “address map” scope ([`docs/specs/register_map.md`](docs/specs/register_map.md));
   chapter 13 stub updated ([`docs/13_register_map.md`](docs/13_register_map.md)).

--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ from the RTL.
 | Microchip PolarFire-family TAP wrappers | Implemented in RTL, host validation still limited |
 | Runtime channel mux | Implemented in RTL and host API/CLI/RPC |
 | EIO over real transports | Implemented — USER3 on Xilinx; wrapper-shared chain on ECP5, Gowin, and PolarFire-family devices |
-| EJTAG-AXI bridge | Hardware-validated on Arty A7 (single, auto-inc, and burst modes) |
+| EJTAG-AXI bridge | Hardware-validated on Arty A7 (single, auto-inc, and burst modes); `DEBUG_EN=0` reference build is synthesis/place/route validated, hardware rerun pending |
 | EJTAG-UART bridge | Hardware-validated on Arty A7 (loopback: send, recv, recv_line, status) |
 | Sample decimation | Implemented in RTL and host API/CLI |
 | External trigger I/O | Implemented in RTL and host API/CLI |
@@ -624,7 +624,8 @@ the JTAG TAP/register/readout plumbing, not only `fcapz_ela.v`.
 | 8b x 1024, +storage qualification | 2,521 | 1,749 | 0.5 | Same compatibility harness with `STOR_QUAL=1` |
 | 8b x 1024, 4-stage sequencer | 2,954 | 2,788 | 0.5 | `TRIG_STAGES=4`, `STOR_QUAL=0` |
 | 32b x 1024, dual comparator, `REL_COMPARE=0` | 2,472 | 2,099 | 1.0 | Wider samples mainly add BRAM/FFs |
-| **`arty_a7_top` (placed)** | **3,244** | **4,562** | **3.5** | Hardware-validation reference: ELA with `INPUT_PIPE=1`, `DECIM_EN`, `EXT_TRIG_EN`, `TIMESTAMP_W=32`, `NUM_SEGMENTS=4` + EIO 8/8 + EJTAG-AXI + `axi4_test_slave` |
+| `arty_a7_top` (placed, pre-`DEBUG_EN` always-on debug) | 3,244 | 4,562 | 3.5 | Historical baseline for the same validation reference |
+| **`arty_a7_top` (placed, `DEBUG_EN=0`)** | **2,318** | **3,168** | **3.5** | Current reference: ELA with `INPUT_PIPE=1`, `DECIM_EN`, `EXT_TRIG_EN`, `TIMESTAMP_W=32`, `NUM_SEGMENTS=4` + EIO 8/8 + EJTAG-AXI + `axi4_test_slave`; bridge debug telemetry disabled |
 
 Optional ELA parameters (`DECIM_EN`, `EXT_TRIG_EN`, `TIMESTAMP_W`,
 `NUM_SEGMENTS`, channel mux, etc.) add registers, comparators, and
@@ -632,6 +633,11 @@ extra BRAM (e.g. timestamp storage); the reference row above is the
 authoritative “full validation” footprint for that combination.
 Per-core deltas are not additive in synthesis because Vivado optimises
 across hierarchy.
+
+The EJTAG-AXI `DEBUG_EN=0` row comes from the Arty A7-100T Vivado
+2025.2 post-place report after gating bridge-only debug telemetry:
+`-926` slice LUTs and `-1,394` FFs versus the previous always-on
+debug baseline, with BRAM unchanged.
 
 **Fmax (reference build):** `sys_clk` @ 100 MHz with WNS positive after
 route on `arty_a7_top` (xc7a100t, same build). JTAG `tck_bscan` is

--- a/docs/04_rtl_integration.md
+++ b/docs/04_rtl_integration.md
@@ -444,6 +444,7 @@ module fcapz_ejtagaxi_xilinx7 #(
     parameter DATA_W     = 32,
     parameter FIFO_DEPTH = 16,
     parameter TIMEOUT    = 4096,
+    parameter DEBUG_EN   = 0,
     parameter CHAIN      = 4
 ) ( ... );
 ```
@@ -454,6 +455,7 @@ module fcapz_ejtagaxi_xilinx7 #(
 | `DATA_W` | 32 | AXI data width.  Only 32 is supported today. |
 | `FIFO_DEPTH` | 1..256, **power of 2** | Async FIFO depth for burst reads.  Limits the maximum burst length the host can request — the host caches this from `FEATURES[23:16]` and rejects oversized requests at the API boundary.  See [chapter 07](07_ejtag_axi_bridge.md). |
 | `TIMEOUT` | int | AXI handshake timeout in `axi_clk` cycles.  Applies to `wready`/`bvalid`/`arready`/`rvalid` waits, **not** between burst beats. |
+| `DEBUG_EN` | 0, 1 | Enables the 256-bit debug buses and debug CONFIG capture records. Defaults off to let synthesis prune debug-only storage and counters. |
 | `CHAIN` | 1..4 | BSCANE2 USER chain. |
 
 ## EJTAG-UART wrapper parameter reference

--- a/docs/07_ejtag_axi_bridge.md
+++ b/docs/07_ejtag_axi_bridge.md
@@ -323,6 +323,18 @@ register dumps and small block transfers, small enough that the
 LUT/FF cost is negligible (~150 LUTs for the FIFO).  Bumping to
 256 costs ~1200 LUTs but lets you do full AXI4 max bursts.
 
+`DEBUG_EN` defaults to `0` on the core and vendor wrappers. Leave it
+off for production builds so synthesis can prune the 256-bit debug
+buses, capture-record storage, and debug-only counters; enable it only
+when wiring those buses into an on-chip analyzer.
+
+Those debug buses are internal development telemetry, not a stable host
+or register-map API. They expose snapshots of the TCK-side command
+pipeline, AXI-side launch/response state, and a few short capture
+records used while wiring an ILA. The exact bit layout may change with
+the bridge implementation; production designs should use the documented
+JTAG command protocol and CONFIG registers instead.
+
 ## Throughput
 
 Sustained data rate depends on the JTAG adapter, cable, and whether the

--- a/examples/arty_a7/arty_a7_top.v
+++ b/examples/arty_a7/arty_a7_top.v
@@ -187,8 +187,12 @@ module arty_a7_top (
     wire        bridge_wlast, bridge_bvalid, bridge_bready;
     wire        bridge_arvalid, bridge_arready, bridge_rvalid, bridge_rready, bridge_rlast;
 
+    // DEBUG_EN is intentionally off in the shipping reference design:
+    // USER4 validation uses host AXI reads/writes, and no ILA consumes the
+    // bridge's internal 256-bit telemetry buses here.
     fcapz_ejtagaxi_xilinx7 #(
-        .ADDR_W(32), .DATA_W(32), .FIFO_DEPTH(16), .TIMEOUT(4096)
+        .ADDR_W(32), .DATA_W(32), .FIFO_DEPTH(16), .TIMEOUT(4096),
+        .DEBUG_EN(0)
     ) u_ejtagaxi (
         .axi_clk(clk),
         .axi_rst(rst),

--- a/rtl/fcapz_ejtagaxi.v
+++ b/rtl/fcapz_ejtagaxi.v
@@ -29,6 +29,7 @@ module fcapz_ejtagaxi #(
     parameter CMD_FIFO_DEPTH  = FIFO_DEPTH * 2,
     parameter RESP_FIFO_DEPTH = FIFO_DEPTH * 2,
     parameter TIMEOUT    = 4096,
+    parameter DEBUG_EN   = 0,
     parameter USE_BEHAV_ASYNC_FIFO    = 1,
     parameter ASYNC_FIFO_IMPL = (USE_BEHAV_ASYNC_FIFO ? 0 : 1)
 ) (
@@ -438,7 +439,7 @@ module fcapz_ejtagaxi #(
                                cmdq_full || !cmdq_wr_ready || !cmdq_rd_ready;
     wire [3:0]  status_bits  = {fifo_notempty, error_sticky, busy_status, prev_valid};
 
-    assign debug_tck = {
+    assign debug_tck = DEBUG_EN ? {
         sr,
         cmdq_wr_data,
         auto_inc_addr,
@@ -463,9 +464,9 @@ module fcapz_ejtagaxi #(
         prev_valid,
         error_sticky,
         25'd0
-    };
+    } : 256'd0;
 
-    assign debug_tck_edge = {
+    assign debug_tck_edge = DEBUG_EN ? {
         47'd0,
         dbg_tck_enqueue_count,
         dbg_tck_update_count,
@@ -479,7 +480,7 @@ module fcapz_ejtagaxi #(
         sr_wstrb,
         sr_payload,
         sr_addr
-    };
+    } : 256'd0;
 
     assign respq_rd_en = sel && update && resp_pop_pending && respq_rd_ready;
     assign cmdq_rd_en = cmdq_rd_ready &&
@@ -519,9 +520,11 @@ module fcapz_ejtagaxi #(
         cmdq_rst_tck  <= 1'b0;
         respq_rst_tck <= 1'b0;
         fifo_rst_tck  <= 1'b0;
-        if (cmdq_wr_en) begin
+        if (DEBUG_EN && cmdq_wr_en) begin
             cmdq_stage_valid <= 1'b0;
             dbg_tck_enqueue_count <= dbg_tck_enqueue_count + 1'b1;
+        end else if (cmdq_wr_en) begin
+            cmdq_stage_valid <= 1'b0;
         end
         if (sel) begin
             respq_head_seen <= respq_rd_ready && !respq_empty;
@@ -539,7 +542,7 @@ module fcapz_ejtagaxi #(
                     pending_count != {(CMD_FIFO_AW+1){1'b0}}) begin
                     pending_count <= pending_count - 1'b1;
                 end
-                if (capture_resp_data && dbg_resp_cap_rec_count < 3'd4) begin
+                if (DEBUG_EN && capture_resp_data && dbg_resp_cap_rec_count < 3'd4) begin
                     dbg_resp_cap_rec_data[dbg_resp_cap_rec_count] <= capture_rdata;
                     dbg_resp_cap_rec_meta[dbg_resp_cap_rec_count] <= {
                         9'd0,
@@ -567,7 +570,7 @@ module fcapz_ejtagaxi #(
             end else if (update) begin
                 prev_valid <= 1'b0;
                 resp_pop_pending <= 1'b0;
-                if (dbg_rec_count < 3'd4) begin
+                if (DEBUG_EN && dbg_rec_count < 3'd4) begin
                     dbg_rec_sr_addr[dbg_rec_count]    <= sr_addr;
                     dbg_rec_sr_payload[dbg_rec_count] <= sr_payload;
                     dbg_rec_sr_meta[dbg_rec_count]    <= {21'd0, cmdq_stage_valid, cmdq_wr_ready, cmdq_full, sr_cmd, sr_wstrb};
@@ -577,13 +580,15 @@ module fcapz_ejtagaxi #(
                     dbg_rec_cmd_meta[dbg_rec_count]   <= 32'd0;
                     dbg_rec_count <= dbg_rec_count + 1'b1;
                 end
-                dbg_tck_update_sr       <= sr;
-                dbg_tck_update_cmdq     <= cmdq_stage_data;
-                dbg_tck_update_auto_inc <= auto_inc_addr;
-                dbg_tck_update_last_cmd <= last_cmd;
-                dbg_tck_update_fire     <= 1'b0;
-                dbg_tck_update_full     <= cmdq_full;
-                dbg_tck_update_count    <= dbg_tck_update_count + 1'b1;
+                if (DEBUG_EN) begin
+                    dbg_tck_update_sr       <= sr;
+                    dbg_tck_update_cmdq     <= cmdq_stage_data;
+                    dbg_tck_update_auto_inc <= auto_inc_addr;
+                    dbg_tck_update_last_cmd <= last_cmd;
+                    dbg_tck_update_fire     <= 1'b0;
+                    dbg_tck_update_full     <= cmdq_full;
+                    dbg_tck_update_count    <= dbg_tck_update_count + 1'b1;
+                end
 
                 case (sr_cmd)
                     CMD_NOP: begin
@@ -607,21 +612,23 @@ module fcapz_ejtagaxi #(
                             pending_count <= pending_count + 1'b1;
                             burst_cfg_valid <= 1'b0;
                             burst_w_beats_left <= 9'd0;
-                            dbg_rec_cmd_addr[dbg_rec_count]  <= sr_addr[ADDR_W-1:0];
-                            dbg_rec_cmd_wdata[dbg_rec_count] <= sr_payload[DATA_W-1:0];
-                            dbg_rec_cmd_meta[dbg_rec_count]  <= {
-                                10'd0,
-                                CMD_WRITE,
-                                sr_wstrb[DATA_W/8-1:0],
-                                burst_awlen,
-                                burst_awsize,
-                                burst_awburst
-                            };
-                            dbg_tck_update_cmdq <= {CMD_WRITE, sr_addr[ADDR_W-1:0],
-                                                    sr_payload[DATA_W-1:0],
-                                                    sr_wstrb[DATA_W/8-1:0],
-                                                    burst_awlen, burst_awsize, burst_awburst};
-                            dbg_tck_update_fire <= 1'b1;
+                            if (DEBUG_EN) begin
+                                dbg_rec_cmd_addr[dbg_rec_count]  <= sr_addr[ADDR_W-1:0];
+                                dbg_rec_cmd_wdata[dbg_rec_count] <= sr_payload[DATA_W-1:0];
+                                dbg_rec_cmd_meta[dbg_rec_count]  <= {
+                                    10'd0,
+                                    CMD_WRITE,
+                                    sr_wstrb[DATA_W/8-1:0],
+                                    burst_awlen,
+                                    burst_awsize,
+                                    burst_awburst
+                                };
+                                dbg_tck_update_cmdq <= {CMD_WRITE, sr_addr[ADDR_W-1:0],
+                                                        sr_payload[DATA_W-1:0],
+                                                        sr_wstrb[DATA_W/8-1:0],
+                                                        burst_awlen, burst_awsize, burst_awburst};
+                                dbg_tck_update_fire <= 1'b1;
+                            end
                         end else begin
                             error_sticky <= 1'b1;
                         end
@@ -636,20 +643,22 @@ module fcapz_ejtagaxi #(
                             pending_count <= pending_count + 1'b1;
                             burst_cfg_valid <= 1'b0;
                             burst_w_beats_left <= 9'd0;
-                            dbg_rec_cmd_addr[dbg_rec_count]  <= sr_addr[ADDR_W-1:0];
-                            dbg_rec_cmd_wdata[dbg_rec_count] <= {DATA_W{1'b0}};
-                            dbg_rec_cmd_meta[dbg_rec_count]  <= {
-                                10'd0,
-                                CMD_READ,
-                                {(DATA_W/8){1'b0}},
-                                burst_awlen,
-                                burst_awsize,
-                                burst_awburst
-                            };
-                            dbg_tck_update_cmdq <= {CMD_READ, sr_addr[ADDR_W-1:0],
-                                                    {DATA_W{1'b0}}, {(DATA_W/8){1'b0}},
-                                                    burst_awlen, burst_awsize, burst_awburst};
-                            dbg_tck_update_fire <= 1'b1;
+                            if (DEBUG_EN) begin
+                                dbg_rec_cmd_addr[dbg_rec_count]  <= sr_addr[ADDR_W-1:0];
+                                dbg_rec_cmd_wdata[dbg_rec_count] <= {DATA_W{1'b0}};
+                                dbg_rec_cmd_meta[dbg_rec_count]  <= {
+                                    10'd0,
+                                    CMD_READ,
+                                    {(DATA_W/8){1'b0}},
+                                    burst_awlen,
+                                    burst_awsize,
+                                    burst_awburst
+                                };
+                                dbg_tck_update_cmdq <= {CMD_READ, sr_addr[ADDR_W-1:0],
+                                                        {DATA_W{1'b0}}, {(DATA_W/8){1'b0}},
+                                                        burst_awlen, burst_awsize, burst_awburst};
+                                dbg_tck_update_fire <= 1'b1;
+                            end
                         end else begin
                             error_sticky <= 1'b1;
                         end
@@ -666,21 +675,23 @@ module fcapz_ejtagaxi #(
                                                  sr_wstrb[DATA_W/8-1:0],
                                                  burst_awlen, burst_awsize, burst_awburst};
                             pending_count <= pending_count + 1'b1;
-                            dbg_rec_cmd_addr[dbg_rec_count]  <= auto_inc_addr;
-                            dbg_rec_cmd_wdata[dbg_rec_count] <= sr_payload[DATA_W-1:0];
-                            dbg_rec_cmd_meta[dbg_rec_count]  <= {
-                                10'd0,
-                                CMD_WRITE,
-                                sr_wstrb[DATA_W/8-1:0],
-                                burst_awlen,
-                                burst_awsize,
-                                burst_awburst
-                            };
-                            dbg_tck_update_cmdq <= {CMD_WRITE, auto_inc_addr,
-                                                    sr_payload[DATA_W-1:0],
-                                                    sr_wstrb[DATA_W/8-1:0],
-                                                    burst_awlen, burst_awsize, burst_awburst};
-                            dbg_tck_update_fire <= 1'b1;
+                            if (DEBUG_EN) begin
+                                dbg_rec_cmd_addr[dbg_rec_count]  <= auto_inc_addr;
+                                dbg_rec_cmd_wdata[dbg_rec_count] <= sr_payload[DATA_W-1:0];
+                                dbg_rec_cmd_meta[dbg_rec_count]  <= {
+                                    10'd0,
+                                    CMD_WRITE,
+                                    sr_wstrb[DATA_W/8-1:0],
+                                    burst_awlen,
+                                    burst_awsize,
+                                    burst_awburst
+                                };
+                                dbg_tck_update_cmdq <= {CMD_WRITE, auto_inc_addr,
+                                                        sr_payload[DATA_W-1:0],
+                                                        sr_wstrb[DATA_W/8-1:0],
+                                                        burst_awlen, burst_awsize, burst_awburst};
+                                dbg_tck_update_fire <= 1'b1;
+                            end
                             auto_inc_addr <= auto_inc_addr + 4;
                             burst_cfg_valid <= 1'b0;
                             burst_w_beats_left <= 9'd0;
@@ -696,20 +707,22 @@ module fcapz_ejtagaxi #(
                                                  {DATA_W{1'b0}}, {(DATA_W/8){1'b0}},
                                                  burst_awlen, burst_awsize, burst_awburst};
                             pending_count <= pending_count + 1'b1;
-                            dbg_rec_cmd_addr[dbg_rec_count]  <= auto_inc_addr;
-                            dbg_rec_cmd_wdata[dbg_rec_count] <= {DATA_W{1'b0}};
-                            dbg_rec_cmd_meta[dbg_rec_count]  <= {
-                                10'd0,
-                                CMD_READ,
-                                {(DATA_W/8){1'b0}},
-                                burst_awlen,
-                                burst_awsize,
-                                burst_awburst
-                            };
-                            dbg_tck_update_cmdq <= {CMD_READ, auto_inc_addr,
-                                                    {DATA_W{1'b0}}, {(DATA_W/8){1'b0}},
-                                                    burst_awlen, burst_awsize, burst_awburst};
-                            dbg_tck_update_fire <= 1'b1;
+                            if (DEBUG_EN) begin
+                                dbg_rec_cmd_addr[dbg_rec_count]  <= auto_inc_addr;
+                                dbg_rec_cmd_wdata[dbg_rec_count] <= {DATA_W{1'b0}};
+                                dbg_rec_cmd_meta[dbg_rec_count]  <= {
+                                    10'd0,
+                                    CMD_READ,
+                                    {(DATA_W/8){1'b0}},
+                                    burst_awlen,
+                                    burst_awsize,
+                                    burst_awburst
+                                };
+                                dbg_tck_update_cmdq <= {CMD_READ, auto_inc_addr,
+                                                        {DATA_W{1'b0}}, {(DATA_W/8){1'b0}},
+                                                        burst_awlen, burst_awsize, burst_awburst};
+                                dbg_tck_update_fire <= 1'b1;
+                            end
                             auto_inc_addr <= auto_inc_addr + 4;
                             burst_cfg_valid <= 1'b0;
                             burst_w_beats_left <= 9'd0;
@@ -740,21 +753,23 @@ module fcapz_ejtagaxi #(
                                                  sr_wstrb[DATA_W/8-1:0],
                                                  burst_awlen, burst_awsize, burst_awburst};
                             pending_count <= pending_count + 1'b1;
-                            dbg_rec_cmd_addr[dbg_rec_count]  <= burst_addr;
-                            dbg_rec_cmd_wdata[dbg_rec_count] <= sr_payload[DATA_W-1:0];
-                            dbg_rec_cmd_meta[dbg_rec_count]  <= {
-                                10'd0,
-                                CMD_BURST_WDATA,
-                                sr_wstrb[DATA_W/8-1:0],
-                                burst_awlen,
-                                burst_awsize,
-                                burst_awburst
-                            };
-                            dbg_tck_update_cmdq <= {CMD_BURST_WDATA, burst_addr,
-                                                    sr_payload[DATA_W-1:0],
-                                                    sr_wstrb[DATA_W/8-1:0],
-                                                    burst_awlen, burst_awsize, burst_awburst};
-                            dbg_tck_update_fire <= 1'b1;
+                            if (DEBUG_EN) begin
+                                dbg_rec_cmd_addr[dbg_rec_count]  <= burst_addr;
+                                dbg_rec_cmd_wdata[dbg_rec_count] <= sr_payload[DATA_W-1:0];
+                                dbg_rec_cmd_meta[dbg_rec_count]  <= {
+                                    10'd0,
+                                    CMD_BURST_WDATA,
+                                    sr_wstrb[DATA_W/8-1:0],
+                                    burst_awlen,
+                                    burst_awsize,
+                                    burst_awburst
+                                };
+                                dbg_tck_update_cmdq <= {CMD_BURST_WDATA, burst_addr,
+                                                        sr_payload[DATA_W-1:0],
+                                                        sr_wstrb[DATA_W/8-1:0],
+                                                        burst_awlen, burst_awsize, burst_awburst};
+                                dbg_tck_update_fire <= 1'b1;
+                            end
                             if (burst_w_beats_left == 9'd1) begin
                                 burst_cfg_valid <= 1'b0;
                                 burst_w_beats_left <= 9'd0;
@@ -778,20 +793,22 @@ module fcapz_ejtagaxi #(
                             pending_count <= pending_count + 1'b1;
                             burst_cfg_valid <= 1'b0;
                             burst_w_beats_left <= 9'd0;
-                            dbg_rec_cmd_addr[dbg_rec_count]  <= burst_addr;
-                            dbg_rec_cmd_wdata[dbg_rec_count] <= {DATA_W{1'b0}};
-                            dbg_rec_cmd_meta[dbg_rec_count]  <= {
-                                10'd0,
-                                CMD_BURST_RSTART,
-                                {(DATA_W/8){1'b0}},
-                                burst_awlen,
-                                burst_awsize,
-                                burst_awburst
-                            };
-                            dbg_tck_update_cmdq <= {CMD_BURST_RSTART, burst_addr,
-                                                    {DATA_W{1'b0}}, {(DATA_W/8){1'b0}},
-                                                    burst_awlen, burst_awsize, burst_awburst};
-                            dbg_tck_update_fire <= 1'b1;
+                            if (DEBUG_EN) begin
+                                dbg_rec_cmd_addr[dbg_rec_count]  <= burst_addr;
+                                dbg_rec_cmd_wdata[dbg_rec_count] <= {DATA_W{1'b0}};
+                                dbg_rec_cmd_meta[dbg_rec_count]  <= {
+                                    10'd0,
+                                    CMD_BURST_RSTART,
+                                    {(DATA_W/8){1'b0}},
+                                    burst_awlen,
+                                    burst_awsize,
+                                    burst_awburst
+                                };
+                                dbg_tck_update_cmdq <= {CMD_BURST_RSTART, burst_addr,
+                                                        {DATA_W{1'b0}}, {(DATA_W/8){1'b0}},
+                                                        burst_awlen, burst_awsize, burst_awburst};
+                                dbg_tck_update_fire <= 1'b1;
+                            end
                         end else begin
                             error_sticky <= 1'b1;
                         end
@@ -813,62 +830,62 @@ module fcapz_ejtagaxi #(
                                                             FIFO_DEPTH_ENC,
                                                             DATA_W[7:0],
                                                             ADDR_W[7:0]};
-                            CFG_DBG_REC_COUNT: config_rdata <= {29'd0, dbg_rec_count};
-                            CFG_DBG_REC0_SR_ADDR: config_rdata <= dbg_rec_sr_addr[0];
-                            CFG_DBG_REC0_SR_PAYLOAD: config_rdata <= dbg_rec_sr_payload[0];
-                            CFG_DBG_REC0_SR_META: config_rdata <= dbg_rec_sr_meta[0];
-                            CFG_DBG_REC0_AUTO_ADDR: config_rdata <= dbg_rec_auto_addr[0];
-                            CFG_DBG_REC0_CMD_ADDR: config_rdata <= dbg_rec_cmd_addr[0];
-                            CFG_DBG_REC0_CMD_WDATA: config_rdata <= dbg_rec_cmd_wdata[0];
-                            CFG_DBG_REC0_CMD_META: config_rdata <= dbg_rec_cmd_meta[0];
-                            CFG_DBG_REC1_SR_ADDR: config_rdata <= dbg_rec_sr_addr[1];
-                            CFG_DBG_REC1_SR_PAYLOAD: config_rdata <= dbg_rec_sr_payload[1];
-                            CFG_DBG_REC1_SR_META: config_rdata <= dbg_rec_sr_meta[1];
-                            CFG_DBG_REC1_AUTO_ADDR: config_rdata <= dbg_rec_auto_addr[1];
-                            CFG_DBG_REC1_CMD_ADDR: config_rdata <= dbg_rec_cmd_addr[1];
-                            CFG_DBG_REC1_CMD_WDATA: config_rdata <= dbg_rec_cmd_wdata[1];
-                            CFG_DBG_REC1_CMD_META: config_rdata <= dbg_rec_cmd_meta[1];
-                            CFG_DBG_REC2_SR_ADDR: config_rdata <= dbg_rec_sr_addr[2];
-                            CFG_DBG_REC2_SR_PAYLOAD: config_rdata <= dbg_rec_sr_payload[2];
-                            CFG_DBG_REC2_SR_META: config_rdata <= dbg_rec_sr_meta[2];
-                            CFG_DBG_REC2_AUTO_ADDR: config_rdata <= dbg_rec_auto_addr[2];
-                            CFG_DBG_REC2_CMD_ADDR: config_rdata <= dbg_rec_cmd_addr[2];
-                            CFG_DBG_REC2_CMD_WDATA: config_rdata <= dbg_rec_cmd_wdata[2];
-                            CFG_DBG_REC2_CMD_META: config_rdata <= dbg_rec_cmd_meta[2];
-                            CFG_DBG_REC3_SR_ADDR: config_rdata <= dbg_rec_sr_addr[3];
-                            CFG_DBG_REC3_SR_PAYLOAD: config_rdata <= dbg_rec_sr_payload[3];
-                            CFG_DBG_REC3_SR_META: config_rdata <= dbg_rec_sr_meta[3];
-                            CFG_DBG_REC3_AUTO_ADDR: config_rdata <= dbg_rec_auto_addr[3];
-                            CFG_DBG_REC3_CMD_ADDR: config_rdata <= dbg_rec_cmd_addr[3];
-                            CFG_DBG_REC3_CMD_WDATA: config_rdata <= dbg_rec_cmd_wdata[3];
-                            CFG_DBG_REC3_CMD_META: config_rdata <= dbg_rec_cmd_meta[3];
-                            CFG_RESP_WR_REC_COUNT: config_rdata <= {29'd0, dbg_resp_wr_rec_count};
-                            CFG_RESP_WR_REC0_DATA: config_rdata <= dbg_resp_wr_rec_data[0];
-                            CFG_RESP_WR_REC0_META: config_rdata <= dbg_resp_wr_rec_meta[0];
-                            CFG_RESP_WR_REC1_DATA: config_rdata <= dbg_resp_wr_rec_data[1];
-                            CFG_RESP_WR_REC1_META: config_rdata <= dbg_resp_wr_rec_meta[1];
-                            CFG_RESP_WR_REC2_DATA: config_rdata <= dbg_resp_wr_rec_data[2];
-                            CFG_RESP_WR_REC2_META: config_rdata <= dbg_resp_wr_rec_meta[2];
-                            CFG_RESP_WR_REC3_DATA: config_rdata <= dbg_resp_wr_rec_data[3];
-                            CFG_RESP_WR_REC3_META: config_rdata <= dbg_resp_wr_rec_meta[3];
-                            CFG_RESP_CAP_REC_COUNT: config_rdata <= {29'd0, dbg_resp_cap_rec_count};
-                            CFG_RESP_CAP_REC0_DATA: config_rdata <= dbg_resp_cap_rec_data[0];
-                            CFG_RESP_CAP_REC0_META: config_rdata <= dbg_resp_cap_rec_meta[0];
-                            CFG_RESP_CAP_REC1_DATA: config_rdata <= dbg_resp_cap_rec_data[1];
-                            CFG_RESP_CAP_REC1_META: config_rdata <= dbg_resp_cap_rec_meta[1];
-                            CFG_RESP_CAP_REC2_DATA: config_rdata <= dbg_resp_cap_rec_data[2];
-                            CFG_RESP_CAP_REC2_META: config_rdata <= dbg_resp_cap_rec_meta[2];
-                            CFG_RESP_CAP_REC3_DATA: config_rdata <= dbg_resp_cap_rec_data[3];
-                            CFG_RESP_CAP_REC3_META: config_rdata <= dbg_resp_cap_rec_meta[3];
-                            CFG_AXI_DEQ_REC_COUNT: config_rdata <= {29'd0, dbg_axi_deq_rec_count};
-                            CFG_AXI_DEQ_REC0_ADDR: config_rdata <= dbg_axi_deq_rec_addr[0];
-                            CFG_AXI_DEQ_REC0_META: config_rdata <= dbg_axi_deq_rec_meta[0];
-                            CFG_AXI_DEQ_REC1_ADDR: config_rdata <= dbg_axi_deq_rec_addr[1];
-                            CFG_AXI_DEQ_REC1_META: config_rdata <= dbg_axi_deq_rec_meta[1];
-                            CFG_AXI_DEQ_REC2_ADDR: config_rdata <= dbg_axi_deq_rec_addr[2];
-                            CFG_AXI_DEQ_REC2_META: config_rdata <= dbg_axi_deq_rec_meta[2];
-                            CFG_AXI_DEQ_REC3_ADDR: config_rdata <= dbg_axi_deq_rec_addr[3];
-                            CFG_AXI_DEQ_REC3_META: config_rdata <= dbg_axi_deq_rec_meta[3];
+                            CFG_DBG_REC_COUNT: config_rdata <= DEBUG_EN ? {29'd0, dbg_rec_count} : 32'd0;
+                            CFG_DBG_REC0_SR_ADDR: config_rdata <= DEBUG_EN ? dbg_rec_sr_addr[0] : 32'd0;
+                            CFG_DBG_REC0_SR_PAYLOAD: config_rdata <= DEBUG_EN ? dbg_rec_sr_payload[0] : 32'd0;
+                            CFG_DBG_REC0_SR_META: config_rdata <= DEBUG_EN ? dbg_rec_sr_meta[0] : 32'd0;
+                            CFG_DBG_REC0_AUTO_ADDR: config_rdata <= DEBUG_EN ? dbg_rec_auto_addr[0] : 32'd0;
+                            CFG_DBG_REC0_CMD_ADDR: config_rdata <= DEBUG_EN ? dbg_rec_cmd_addr[0] : 32'd0;
+                            CFG_DBG_REC0_CMD_WDATA: config_rdata <= DEBUG_EN ? dbg_rec_cmd_wdata[0] : 32'd0;
+                            CFG_DBG_REC0_CMD_META: config_rdata <= DEBUG_EN ? dbg_rec_cmd_meta[0] : 32'd0;
+                            CFG_DBG_REC1_SR_ADDR: config_rdata <= DEBUG_EN ? dbg_rec_sr_addr[1] : 32'd0;
+                            CFG_DBG_REC1_SR_PAYLOAD: config_rdata <= DEBUG_EN ? dbg_rec_sr_payload[1] : 32'd0;
+                            CFG_DBG_REC1_SR_META: config_rdata <= DEBUG_EN ? dbg_rec_sr_meta[1] : 32'd0;
+                            CFG_DBG_REC1_AUTO_ADDR: config_rdata <= DEBUG_EN ? dbg_rec_auto_addr[1] : 32'd0;
+                            CFG_DBG_REC1_CMD_ADDR: config_rdata <= DEBUG_EN ? dbg_rec_cmd_addr[1] : 32'd0;
+                            CFG_DBG_REC1_CMD_WDATA: config_rdata <= DEBUG_EN ? dbg_rec_cmd_wdata[1] : 32'd0;
+                            CFG_DBG_REC1_CMD_META: config_rdata <= DEBUG_EN ? dbg_rec_cmd_meta[1] : 32'd0;
+                            CFG_DBG_REC2_SR_ADDR: config_rdata <= DEBUG_EN ? dbg_rec_sr_addr[2] : 32'd0;
+                            CFG_DBG_REC2_SR_PAYLOAD: config_rdata <= DEBUG_EN ? dbg_rec_sr_payload[2] : 32'd0;
+                            CFG_DBG_REC2_SR_META: config_rdata <= DEBUG_EN ? dbg_rec_sr_meta[2] : 32'd0;
+                            CFG_DBG_REC2_AUTO_ADDR: config_rdata <= DEBUG_EN ? dbg_rec_auto_addr[2] : 32'd0;
+                            CFG_DBG_REC2_CMD_ADDR: config_rdata <= DEBUG_EN ? dbg_rec_cmd_addr[2] : 32'd0;
+                            CFG_DBG_REC2_CMD_WDATA: config_rdata <= DEBUG_EN ? dbg_rec_cmd_wdata[2] : 32'd0;
+                            CFG_DBG_REC2_CMD_META: config_rdata <= DEBUG_EN ? dbg_rec_cmd_meta[2] : 32'd0;
+                            CFG_DBG_REC3_SR_ADDR: config_rdata <= DEBUG_EN ? dbg_rec_sr_addr[3] : 32'd0;
+                            CFG_DBG_REC3_SR_PAYLOAD: config_rdata <= DEBUG_EN ? dbg_rec_sr_payload[3] : 32'd0;
+                            CFG_DBG_REC3_SR_META: config_rdata <= DEBUG_EN ? dbg_rec_sr_meta[3] : 32'd0;
+                            CFG_DBG_REC3_AUTO_ADDR: config_rdata <= DEBUG_EN ? dbg_rec_auto_addr[3] : 32'd0;
+                            CFG_DBG_REC3_CMD_ADDR: config_rdata <= DEBUG_EN ? dbg_rec_cmd_addr[3] : 32'd0;
+                            CFG_DBG_REC3_CMD_WDATA: config_rdata <= DEBUG_EN ? dbg_rec_cmd_wdata[3] : 32'd0;
+                            CFG_DBG_REC3_CMD_META: config_rdata <= DEBUG_EN ? dbg_rec_cmd_meta[3] : 32'd0;
+                            CFG_RESP_WR_REC_COUNT: config_rdata <= DEBUG_EN ? {29'd0, dbg_resp_wr_rec_count} : 32'd0;
+                            CFG_RESP_WR_REC0_DATA: config_rdata <= DEBUG_EN ? dbg_resp_wr_rec_data[0] : 32'd0;
+                            CFG_RESP_WR_REC0_META: config_rdata <= DEBUG_EN ? dbg_resp_wr_rec_meta[0] : 32'd0;
+                            CFG_RESP_WR_REC1_DATA: config_rdata <= DEBUG_EN ? dbg_resp_wr_rec_data[1] : 32'd0;
+                            CFG_RESP_WR_REC1_META: config_rdata <= DEBUG_EN ? dbg_resp_wr_rec_meta[1] : 32'd0;
+                            CFG_RESP_WR_REC2_DATA: config_rdata <= DEBUG_EN ? dbg_resp_wr_rec_data[2] : 32'd0;
+                            CFG_RESP_WR_REC2_META: config_rdata <= DEBUG_EN ? dbg_resp_wr_rec_meta[2] : 32'd0;
+                            CFG_RESP_WR_REC3_DATA: config_rdata <= DEBUG_EN ? dbg_resp_wr_rec_data[3] : 32'd0;
+                            CFG_RESP_WR_REC3_META: config_rdata <= DEBUG_EN ? dbg_resp_wr_rec_meta[3] : 32'd0;
+                            CFG_RESP_CAP_REC_COUNT: config_rdata <= DEBUG_EN ? {29'd0, dbg_resp_cap_rec_count} : 32'd0;
+                            CFG_RESP_CAP_REC0_DATA: config_rdata <= DEBUG_EN ? dbg_resp_cap_rec_data[0] : 32'd0;
+                            CFG_RESP_CAP_REC0_META: config_rdata <= DEBUG_EN ? dbg_resp_cap_rec_meta[0] : 32'd0;
+                            CFG_RESP_CAP_REC1_DATA: config_rdata <= DEBUG_EN ? dbg_resp_cap_rec_data[1] : 32'd0;
+                            CFG_RESP_CAP_REC1_META: config_rdata <= DEBUG_EN ? dbg_resp_cap_rec_meta[1] : 32'd0;
+                            CFG_RESP_CAP_REC2_DATA: config_rdata <= DEBUG_EN ? dbg_resp_cap_rec_data[2] : 32'd0;
+                            CFG_RESP_CAP_REC2_META: config_rdata <= DEBUG_EN ? dbg_resp_cap_rec_meta[2] : 32'd0;
+                            CFG_RESP_CAP_REC3_DATA: config_rdata <= DEBUG_EN ? dbg_resp_cap_rec_data[3] : 32'd0;
+                            CFG_RESP_CAP_REC3_META: config_rdata <= DEBUG_EN ? dbg_resp_cap_rec_meta[3] : 32'd0;
+                            CFG_AXI_DEQ_REC_COUNT: config_rdata <= DEBUG_EN ? {29'd0, dbg_axi_deq_rec_count} : 32'd0;
+                            CFG_AXI_DEQ_REC0_ADDR: config_rdata <= DEBUG_EN ? dbg_axi_deq_rec_addr[0] : 32'd0;
+                            CFG_AXI_DEQ_REC0_META: config_rdata <= DEBUG_EN ? dbg_axi_deq_rec_meta[0] : 32'd0;
+                            CFG_AXI_DEQ_REC1_ADDR: config_rdata <= DEBUG_EN ? dbg_axi_deq_rec_addr[1] : 32'd0;
+                            CFG_AXI_DEQ_REC1_META: config_rdata <= DEBUG_EN ? dbg_axi_deq_rec_meta[1] : 32'd0;
+                            CFG_AXI_DEQ_REC2_ADDR: config_rdata <= DEBUG_EN ? dbg_axi_deq_rec_addr[2] : 32'd0;
+                            CFG_AXI_DEQ_REC2_META: config_rdata <= DEBUG_EN ? dbg_axi_deq_rec_meta[2] : 32'd0;
+                            CFG_AXI_DEQ_REC3_ADDR: config_rdata <= DEBUG_EN ? dbg_axi_deq_rec_addr[3] : 32'd0;
+                            CFG_AXI_DEQ_REC3_META: config_rdata <= DEBUG_EN ? dbg_axi_deq_rec_meta[3] : 32'd0;
                             default:       config_rdata <= 32'h0;
                         endcase
                     end
@@ -1139,12 +1156,14 @@ module fcapz_ejtagaxi #(
         end else begin
             reset_req_sync1_axi <= reset_req_toggle;
             reset_req_sync2_axi <= reset_req_sync1_axi;
-            dbg_axi_deq_fire <= 1'b0;
-            dbg_axi_cycle_count <= dbg_axi_cycle_count + 1'b1;
+            if (DEBUG_EN) begin
+                dbg_axi_deq_fire <= 1'b0;
+                dbg_axi_cycle_count <= dbg_axi_cycle_count + 1'b1;
+            end
             cmdq_rst_axi <= 1'b0;
             respq_rst_axi <= 1'b0;
             fifo_rst_axi  <= 1'b0;
-            if (respq_wr_en && dbg_resp_wr_rec_count < 3'd4) begin
+            if (DEBUG_EN && respq_wr_en && dbg_resp_wr_rec_count < 3'd4) begin
                 dbg_resp_wr_rec_data[dbg_resp_wr_rec_count] <= respq_wr_data[DATA_W-1:0];
                 dbg_resp_wr_rec_meta[dbg_resp_wr_rec_count] <= {
                     11'd0,
@@ -1157,7 +1176,7 @@ module fcapz_ejtagaxi #(
                 };
                 dbg_resp_wr_rec_count <= dbg_resp_wr_rec_count + 1'b1;
             end
-            if (cmdq_rd_en) begin
+            if (DEBUG_EN && cmdq_rd_en) begin
                 dbg_axi_deq_cmdq  <= cmdq_rd_data;
                 dbg_axi_deq_cmd   <= cmdq_cmd;
                 dbg_axi_deq_addr  <= cmdq_addr;
@@ -1201,8 +1220,10 @@ module fcapz_ejtagaxi #(
                 cmdq_rst_axi           <= 1'b1;
                 respq_rst_axi          <= 1'b1;
                 fifo_rst_axi           <= 1'b1;
-                dbg_resp_wr_rec_count  <= 3'd0;
-                dbg_axi_deq_rec_count  <= 3'd0;
+                if (DEBUG_EN) begin
+                    dbg_resp_wr_rec_count  <= 3'd0;
+                    dbg_axi_deq_rec_count  <= 3'd0;
+                end
             end else case (axi_state)
 
                 // ---- Idle: consume next queued command ----
@@ -1512,7 +1533,7 @@ module fcapz_ejtagaxi #(
     assign fifo_wr_en = (axi_state == ST_BURST_R_FILL) &&
                         m_axi_rvalid && !fifo_full;
 
-    assign debug_axi = {
+    assign debug_axi = DEBUG_EN ? {
         cmdq_rd_data,
         launch_addr,
         launch_wdata,
@@ -1544,9 +1565,9 @@ module fcapz_ejtagaxi #(
         m_axi_arvalid,
         m_axi_bresp,
         24'd0
-    };
+    } : 256'd0;
 
-    assign debug_axi_edge = {
+    assign debug_axi_edge = DEBUG_EN ? {
         48'd0,
         dbg_axi_deq_count,
         dbg_axi_cycle_count,
@@ -1564,6 +1585,6 @@ module fcapz_ejtagaxi #(
         launch_wdata,
         launch_addr,
         cmdq_rd_data
-    };
+    } : 256'd0;
 
 endmodule

--- a/rtl/fcapz_ejtagaxi_intel.v
+++ b/rtl/fcapz_ejtagaxi_intel.v
@@ -20,6 +20,7 @@ module fcapz_ejtagaxi_intel #(
     parameter DATA_W     = 32,
     parameter FIFO_DEPTH = 16,
     parameter TIMEOUT    = 4096,
+    parameter DEBUG_EN   = 0,
     parameter ASYNC_FIFO_IMPL = 0, // 0=portable behavioral
     parameter CHAIN      = 4       // sld_instance_index (1-3 used by ELA+EIO)
 ) (
@@ -79,6 +80,7 @@ module fcapz_ejtagaxi_intel #(
     fcapz_ejtagaxi #(
         .ADDR_W(ADDR_W), .DATA_W(DATA_W),
         .FIFO_DEPTH(FIFO_DEPTH), .TIMEOUT(TIMEOUT),
+        .DEBUG_EN(DEBUG_EN),
         .ASYNC_FIFO_IMPL(ASYNC_FIFO_IMPL)
     ) u_ejtagaxi (
         .tck(tap_tck), .tdi(tap_tdi), .tdo(tap_tdo),

--- a/rtl/fcapz_ejtagaxi_xilinx7.v
+++ b/rtl/fcapz_ejtagaxi_xilinx7.v
@@ -20,6 +20,7 @@ module fcapz_ejtagaxi_xilinx7 #(
     parameter DATA_W     = 32,
     parameter FIFO_DEPTH = 16,
     parameter TIMEOUT    = 4096,
+    parameter DEBUG_EN   = 0,
     parameter ASYNC_FIFO_IMPL = 1, // 1=AMD/Xilinx XPM, 0=portable behavioral
     parameter CHAIN      = 4       // USER4 (USER1-3 used by ELA+EIO)
 ) (
@@ -79,6 +80,7 @@ module fcapz_ejtagaxi_xilinx7 #(
     fcapz_ejtagaxi #(
         .ADDR_W(ADDR_W), .DATA_W(DATA_W),
         .FIFO_DEPTH(FIFO_DEPTH), .TIMEOUT(TIMEOUT),
+        .DEBUG_EN(DEBUG_EN),
         .USE_BEHAV_ASYNC_FIFO(0),
         .ASYNC_FIFO_IMPL(ASYNC_FIFO_IMPL)
     ) u_ejtagaxi (

--- a/rtl/fcapz_ejtagaxi_xilinxus.v
+++ b/rtl/fcapz_ejtagaxi_xilinxus.v
@@ -22,6 +22,7 @@ module fcapz_ejtagaxi_xilinxus #(
     parameter DATA_W     = 32,
     parameter FIFO_DEPTH = 16,
     parameter TIMEOUT    = 4096,
+    parameter DEBUG_EN   = 0,
     parameter ASYNC_FIFO_IMPL = 1,
     parameter CHAIN      = 4
 ) (
@@ -69,6 +70,7 @@ module fcapz_ejtagaxi_xilinxus #(
     fcapz_ejtagaxi_xilinx7 #(
         .ADDR_W(ADDR_W), .DATA_W(DATA_W),
         .FIFO_DEPTH(FIFO_DEPTH), .TIMEOUT(TIMEOUT),
+        .DEBUG_EN(DEBUG_EN),
         .ASYNC_FIFO_IMPL(ASYNC_FIFO_IMPL),
         .CHAIN(CHAIN)
     ) u_inner (

--- a/tb/fcapz_ejtagaxi_reset_regression_tb.sv
+++ b/tb/fcapz_ejtagaxi_reset_regression_tb.sv
@@ -13,7 +13,9 @@
 //
 // The slave memory is not reset by CMD_RESET, only the bridge state is.
 
-module fcapz_ejtagaxi_reset_regression_tb;
+module fcapz_ejtagaxi_reset_regression_tb #(
+    parameter DEBUG_EN = 0
+);
 
     logic tck     = 1'b0;
     logic axi_clk = 1'b0;
@@ -56,6 +58,10 @@ module fcapz_ejtagaxi_reset_regression_tb;
     wire        m_axi_rvalid;
     wire        m_axi_rlast;
     wire        m_axi_rready;
+    wire [255:0] debug_tck;
+    wire [255:0] debug_tck_edge;
+    wire [255:0] debug_axi;
+    wire [255:0] debug_axi_edge;
 
     integer pass_count = 0;
     integer fail_count = 0;
@@ -71,7 +77,8 @@ module fcapz_ejtagaxi_reset_regression_tb;
         .ADDR_W     (32),
         .DATA_W     (32),
         .FIFO_DEPTH (16),
-        .TIMEOUT    (4096)
+        .TIMEOUT    (4096),
+        .DEBUG_EN   (DEBUG_EN)
     ) dut (
         .tck           (tck),
         .tdi           (tdi),
@@ -108,7 +115,11 @@ module fcapz_ejtagaxi_reset_regression_tb;
         .m_axi_rresp   (m_axi_rresp),
         .m_axi_rvalid  (m_axi_rvalid),
         .m_axi_rlast   (m_axi_rlast),
-        .m_axi_rready  (m_axi_rready)
+        .m_axi_rready  (m_axi_rready),
+        .debug_tck     (debug_tck),
+        .debug_tck_edge(debug_tck_edge),
+        .debug_axi     (debug_axi),
+        .debug_axi_edge(debug_axi_edge)
     );
 
     axi4_test_slave #(
@@ -372,6 +383,16 @@ module fcapz_ejtagaxi_reset_regression_tb;
         resp  = get_resp(scan_out);
         check("first post-reset read_inc resp=OKAY", resp == 2'b00);
         check("first post-reset read_inc data correct", rdata == 32'h89AB_CDEF);
+
+        if (DEBUG_EN) begin
+            check("DEBUG_EN=1 exposes debug activity",
+                  (debug_tck != 256'd0) || (debug_tck_edge != 256'd0) ||
+                  (debug_axi != 256'd0) || (debug_axi_edge != 256'd0));
+        end else begin
+            check("DEBUG_EN=0 ties debug buses low",
+                  debug_tck == 256'd0 && debug_tck_edge == 256'd0 &&
+                  debug_axi == 256'd0 && debug_axi_edge == 256'd0);
+        end
 
         if (fail_count == 0) begin
             $display("PASS: reset regression (%0d checks)", pass_count);

--- a/tests/test_ejtagaxi_reset_rtl.py
+++ b/tests/test_ejtagaxi_reset_rtl.py
@@ -16,9 +16,9 @@ ROOT = Path(__file__).resolve().parent.parent
 class EjtagAxiResetRtlTests(unittest.TestCase):
     """Focused RTL regression for reset bookkeeping and first post-reset read."""
 
-    def test_reset_drain_and_first_read_regression(self):
+    def _run_reset_regression(self, debug_en: int):
         with tempfile.TemporaryDirectory(prefix="ejtagaxi-reset-") as tmpdir:
-            vvp = Path(tmpdir) / "ejtagaxi_reset_regression_tb.vvp"
+            vvp = Path(tmpdir) / f"ejtagaxi_reset_regression_debug{debug_en}.vvp"
             sources = [
                 str(ROOT / "tb" / "fcapz_ejtagaxi_reset_regression_tb.sv"),
                 str(ROOT / "tb" / "axi4_test_slave.v"),
@@ -27,14 +27,23 @@ class EjtagAxiResetRtlTests(unittest.TestCase):
                 str(ROOT / "tb" / "xpm_fifo_async_stub.v"),
             ]
             compile_result = subprocess.run(
-                ["iverilog", "-g2012", "-o", str(vvp)] + sources,
+                [
+                    "iverilog",
+                    "-g2012",
+                    "-P",
+                    f"fcapz_ejtagaxi_reset_regression_tb.DEBUG_EN={debug_en}",
+                    "-o",
+                    str(vvp),
+                ]
+                + sources,
                 capture_output=True,
                 text=True,
             )
             self.assertEqual(
                 compile_result.returncode,
                 0,
-                f"iverilog compilation failed:\n{compile_result.stderr}",
+                f"iverilog compilation failed for DEBUG_EN={debug_en}:\n"
+                f"{compile_result.stderr}",
             )
 
             sim_result = subprocess.run(
@@ -47,10 +56,16 @@ class EjtagAxiResetRtlTests(unittest.TestCase):
             self.assertEqual(
                 sim_result.returncode,
                 0,
-                f"reset regression simulation failed:\n{output}",
+                f"reset regression simulation failed for DEBUG_EN={debug_en}:\n{output}",
             )
             self.assertIn(
                 "PASS: reset regression",
                 output,
-                f"expected PASS banner in simulation output:\n{output}",
+                f"expected PASS banner in DEBUG_EN={debug_en} simulation output:\n{output}",
             )
+
+    def test_reset_drain_and_first_read_regression_debug_disabled(self):
+        self._run_reset_regression(0)
+
+    def test_reset_drain_and_first_read_regression_debug_enabled(self):
+        self._run_reset_regression(1)


### PR DESCRIPTION
## Summary

This branch adds a `DEBUG_EN` parameter to the EJTAG-AXI bridge and vendor wrappers, defaulting it off so production/reference builds can prune bridge-only debug telemetry logic.

The Arty A7 reference design now explicitly builds with `DEBUG_EN=0`, while keeping the public debug bus ports stable and tied low when disabled.

## What Changed

- Added `DEBUG_EN = 0` to:
  - `rtl/fcapz_ejtagaxi.v`
  - `rtl/fcapz_ejtagaxi_xilinx7.v`
  - `rtl/fcapz_ejtagaxi_xilinxus.v`
  - `rtl/fcapz_ejtagaxi_intel.v`

- Gated EJTAG-AXI debug-only logic when `DEBUG_EN=0`:
  - 256-bit debug bus contents
  - TCK-side debug counters
  - AXI-side dequeue/response debug counters
  - short capture-record arrays
  - debug CONFIG readback records

- Preserved functional behavior when debug is disabled:
  - command enqueue/dequeue behavior remains unchanged
  - `cmdq_stage_valid` clearing on `cmdq_wr_en` is preserved
  - debug CONFIG registers return zero when debug is disabled

- Updated Arty A7 reference design:
  - explicitly passes `.DEBUG_EN(0)`
  - documents that no ILA consumes the bridge telemetry buses in the reference bitstream

- Expanded RTL regression coverage:
  - reset/first-read regression now runs both `DEBUG_EN=0` and `DEBUG_EN=1`
  - checks debug buses are tied low when disabled
  - checks debug activity is present when enabled

- Updated docs:
  - RTL integration parameter table
  - EJTAG-AXI bridge documentation
  - README support/resource status
  - CHANGELOG

## Resource Impact

Arty A7-100T post-place utilization with the current `DEBUG_EN=0` reference build:

| Build | Slice LUTs | FFs | BRAM |
|---|---:|---:|---:|
| Previous always-on debug baseline | 3,244 | 4,562 | 3.5 |
| Current `DEBUG_EN=0` build | 2,318 | 3,168 | 3.5 |

Delta:

- `-926` Slice LUTs
- `-1,394` FFs
- BRAM unchanged

## Validation

Software / RTL:

```text
python -m pytest tests\test_ejtagaxi.py tests\test_transport.py tests\test_ejtagaxi_reset_rtl.py -q
90 passed
