### PR TITLE
Fix ELA rolling pretrigger history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **ELA pre-trigger capture:** sample memory now maintains a rolling
+  pre-arm history in single-segment mode, so a trigger shortly after
+  `arm()` captures the actual early event with valid pre-trigger samples
+  instead of waiting for a post-arm prefill window or exposing stale/zero
+  entries. Segmented capture mode is unchanged and remains tracked
+  separately. The pre-trigger window may include samples from before the
+  latest `arm()` call, including the previous capture tail; pulse
+  `sample_rst` between captures if each capture must be independent.
 - **Arty / EJTAG-AXI host path:** `EjtagAxiController` now prefers
   batched USER4 raw-scan sequences for bridge probe, single
   transactions, block traffic, and bursts when running over Xilinx

--- a/docs/05_ela_core.md
+++ b/docs/05_ela_core.md
@@ -37,6 +37,16 @@ dual-port BRAM continuously.  When the trigger fires, it captures
 shows what was happening *before* the trigger fired, the trigger
 sample itself, and the post-trigger window.
 
+In single-segment builds, pre-trigger history rolls even before `arm()`,
+so a trigger that arrives immediately after arming can still return real
+history. Segmented capture mode has separate per-segment bookkeeping and
+does not use this rolling pre-arm path. That single-segment history is
+not reset by `arm()`: back-to-back captures can include samples from
+before the latest arm, including the previous capture tail, until new
+samples overwrite them. Pulse `sample_rst` between captures if each
+capture must be fully independent. The rolling writes also mean the BRAM
+write port has idle sample-clock activity in single-segment builds.
+
 On timing-sensitive builds, especially with `INPUT_PIPE=1`, the BRAM
 write command is itself registered: write enable, address, sample data,
 and timestamp data are captured together before they drive the inferred
@@ -213,6 +223,12 @@ fcapz capture --trigger-sequence my_sequence.json ...
 See [chapter 10](10_cli_reference.md) for the full JSON schema.
 
 ## Storage qualification (`STOR_QUAL=1`)
+
+The single-segment rolling pre-trigger buffer respects storage
+qualification and decimation even before `arm()`. If `STOR_QUAL=1`,
+the pre-arm history contains only samples that satisfy the current
+qualification registers; update those registers before relying on the
+rolling window.
 
 Sometimes you don't care about every sample — you only want to
 record the ones where some condition is true.  Storage qualification

--- a/rtl/fcapz_ela.v
+++ b/rtl/fcapz_ela.v
@@ -149,6 +149,9 @@ module fcapz_ela #(
     endgenerate
 
     localparam PTR_W = $clog2(DEPTH);
+    // Used by the single-segment pre-arm rolling buffer. Keep this explicit
+    // instead of slicing DEPTH, because power-of-two DEPTH would truncate to 0.
+    localparam [PTR_W-1:0] DEPTH_LAST = DEPTH - 1;
     localparam WORDS_PER_SAMPLE = (SAMPLE_W + 31) / 32;
     localparam SEQ_STATE_W = (TRIG_STAGES > 1) ? $clog2(TRIG_STAGES) : 1;
     // INPUT_PIPE also registers compare hits so REL_COMPARE comparators stay
@@ -1033,7 +1036,7 @@ module fcapz_ela #(
          (!trig_delay_pending && trigger_hit && (trig_delay == 16'h0)));
     wire post_store_now = armed && !done && triggered && store_enable &&
                           (post_count < post_store_limit);
-    wire pre_store_now = armed && !done && !triggered &&
+    wire pre_store_now = !done && !triggered &&
                          (store_enable || trigger_commit_now);
     assign mem_we_a = pre_store_now || post_store_now;
     always @(*) begin
@@ -1135,9 +1138,11 @@ module fcapz_ela #(
                 armed       <= 1'b1;
                 triggered   <= 1'b0;
                 done        <= 1'b0;
-                wr_ptr      <= {PTR_W{1'b0}};
+                if (HAS_SEGMENTS)
+                    wr_ptr  <= {PTR_W{1'b0}};
                 post_count  <= {PTR_W{1'b0}};
-                pre_count   <= {PTR_W+1{1'b0}};
+                if (HAS_SEGMENTS)
+                    pre_count <= {PTR_W+1{1'b0}};
                 seq_state   <= {SEQ_STATE_W{1'b0}};
                 seq_counter <= 16'h0;
                 trig_holdoff_active <= (trig_holdoff_sync2 != 16'h0);
@@ -1154,6 +1159,19 @@ module fcapz_ela #(
                     overflow <= (pretrig_len_sync2 + posttrig_len_sync2 + 1 > SEG_DEPTH);
                 else
                     overflow <= (pretrig_len_sync2 + posttrig_len_sync2 + 1 > DEPTH);
+            end
+
+            // Issue #10: in single-segment mode, keep BRAM populated before
+            // arm so a fast trigger can use real pre-arm history instead of
+            // waiting for a post-arm prefill window.
+            if (!armed && !done) begin
+                if (mem_we_a) begin
+                    wr_ptr <= wr_ptr + 1'b1;
+                    if (wr_ptr >= DEPTH_LAST)
+                        wr_ptr <= {PTR_W{1'b0}};
+                end
+                if (store_enable && !pretrigger_ready)
+                    pre_count <= pre_count + 1'b1;
             end
 
             if (armed && !done) begin

--- a/tb/fcapz_ela_bug_probe_tb.sv
+++ b/tb/fcapz_ela_bug_probe_tb.sv
@@ -276,6 +276,52 @@ module fcapz_ela_bug_probe_tb;
         data = rdata_segtrig;
     endtask
 
+    // ---------------------------------------------------------------------
+    // Regression 9: pretrigger history is a rolling buffer before arm.
+    localparam int ROLL_W = 8;
+    localparam int ROLL_DEPTH = 16;
+    logic [ROLL_W-1:0] probe_roll = '0;
+    logic ext_trig_roll = 1'b0;
+    logic wr_roll = 1'b0, rd_roll = 1'b0;
+    logic [15:0] addr_roll = '0;
+    logic [31:0] wdata_roll = '0, rdata_roll;
+    logic [$clog2(ROLL_DEPTH)-1:0] burst_addr_roll = '0;
+    wire [ROLL_W-1:0] burst_data_roll;
+    wire burst_start_roll;
+    wire [$clog2(ROLL_DEPTH)-1:0] burst_start_ptr_roll;
+    wire armed_out_roll;
+
+    fcapz_ela #(
+        .SAMPLE_W(ROLL_W),
+        .DEPTH(ROLL_DEPTH),
+        .EXT_TRIG_EN(1),
+        .INPUT_PIPE(1)
+    ) dut_roll (
+        .sample_clk(sample_clk), .sample_rst(sample_rst), .probe_in(probe_roll),
+        .trigger_in(ext_trig_roll), .trigger_out(), .armed_out(armed_out_roll),
+        .jtag_clk(jtag_clk), .jtag_rst(jtag_rst),
+        .jtag_wr_en(wr_roll), .jtag_rd_en(rd_roll),
+        .jtag_addr(addr_roll), .jtag_wdata(wdata_roll), .jtag_rdata(rdata_roll),
+        .burst_rd_addr(burst_addr_roll), .burst_rd_data(burst_data_roll),
+        .burst_start(burst_start_roll), .burst_start_ptr(burst_start_ptr_roll)
+    );
+
+    task automatic write_roll(input [15:0] addr, input [31:0] data);
+        @(posedge jtag_clk);
+        addr_roll <= addr; wdata_roll <= data; wr_roll <= 1'b1;
+        @(posedge jtag_clk);
+        wr_roll <= 1'b0;
+    endtask
+
+    task automatic read_roll(input [15:0] addr, output [31:0] data);
+        @(posedge jtag_clk);
+        addr_roll <= addr; rd_roll <= 1'b1;
+        @(posedge jtag_clk);
+        rd_roll <= 1'b0;
+        repeat (10) @(posedge jtag_clk);
+        data = rdata_roll;
+    endtask
+
     initial begin
         logic [31:0] word0, word1, word2, status, seg_status;
         int i;
@@ -481,6 +527,120 @@ module fcapz_ela_bug_probe_tb;
         $display("  fixed-hook status=0x%08x seg_status=0x%08x", status, seg_status);
         check("per-rearm pulse source finishes all segments",
               (status[2] == 1'b1) && (seg_status[31] == 1'b1) && (seg_status[1:0] == 2'd0));
+
+        $display("\n=== Regression 9: fast trigger uses rolling pre-arm history ===");
+        write_roll(16'h0014, 32'd8);    // PRETRIG
+        write_roll(16'h0018, 32'd2);    // POSTTRIG
+        write_roll(16'h0020, 32'h1);    // value-match, made unreachable below
+        write_roll(16'h0024, 32'd255);
+        write_roll(16'h0028, 32'hFF);
+        write_roll(16'h00B4, 32'd1);    // EXT_TRIG = OR
+        probe_roll = 8'd0;
+        ext_trig_roll = 1'b0;
+        repeat (24) begin
+            @(posedge sample_clk);
+            probe_roll <= probe_roll + 1'b1;
+        end
+        write_roll(16'h0004, 32'h1);    // ARM after history is already full
+        begin
+            integer pulse_delay;
+            integer pulse_width;
+            logic pulse_armed;
+            pulse_delay = -1;
+            pulse_width = 0;
+            pulse_armed = 1'b0;
+            repeat (40) begin
+                @(posedge sample_clk);
+                probe_roll <= probe_roll + 1'b1;
+                ext_trig_roll = 1'b0;
+                if (armed_out_roll && !pulse_armed) begin
+                    pulse_delay = 2;
+                    pulse_armed = 1'b1;
+                end else if (pulse_delay >= 0) begin
+                    if (pulse_delay == 0) begin
+                        ext_trig_roll = 1'b1;
+                        pulse_width = 3;
+                        pulse_delay = -1;
+                    end else begin
+                        pulse_delay = pulse_delay - 1;
+                    end
+                end else if (pulse_width > 0) begin
+                    ext_trig_roll = 1'b1;
+                    pulse_width = pulse_width - 1;
+                end
+            end
+        end
+        wait_sample(40);
+        read_roll(16'h0008, status);
+        read_roll(16'h0100, word0);
+        read_roll(16'h0100 + 8*4, word1);
+        read_roll(16'h0100 + 9*4, word2);
+        $display("  status=0x%08x pre_count=%0d pre_ready=%0d wr_ptr=%0d samples[0,8,9]=0x%02x 0x%02x 0x%02x",
+                 status, dut_roll.pre_count, dut_roll.pretrigger_ready, dut_roll.wr_ptr,
+                 word0[7:0], word1[7:0], word2[7:0]);
+        check("fast external trigger completes without post-arm prefill delay",
+              status[2] == 1'b1);
+        check("rolling prehistory start is the expected prior sample",
+              word0[7:0] == 8'd25);
+        check("trigger sample is anchored at pretrigger index",
+              word1[7:0] == 8'd33);
+        check("post-trigger sample follows trigger sample",
+              word2[7:0] == 8'd34);
+
+        $display("\n=== Regression 10: re-arm keeps rolling history coherent ===");
+        probe_roll = 8'd80;
+        ext_trig_roll = 1'b0;
+        repeat (6) begin
+            @(posedge sample_clk);
+            probe_roll <= probe_roll + 1'b1;
+        end
+        // Re-arm directly after the previous DONE. The frozen previous
+        // capture tail is allowed to be part of the next pre-trigger history
+        // until enough new samples overwrite it.
+        write_roll(16'h0004, 32'h1);
+        begin
+            integer pulse_delay2;
+            integer pulse_width2;
+            logic pulse_armed2;
+            pulse_delay2 = -1;
+            pulse_width2 = 0;
+            pulse_armed2 = 1'b0;
+            repeat (40) begin
+                @(posedge sample_clk);
+                probe_roll <= probe_roll + 1'b1;
+                ext_trig_roll = 1'b0;
+                if (armed_out_roll && !pulse_armed2) begin
+                    pulse_delay2 = 2;
+                    pulse_armed2 = 1'b1;
+                end else if (pulse_delay2 >= 0) begin
+                    if (pulse_delay2 == 0) begin
+                        ext_trig_roll = 1'b1;
+                        pulse_width2 = 3;
+                        pulse_delay2 = -1;
+                    end else begin
+                        pulse_delay2 = pulse_delay2 - 1;
+                    end
+                end else if (pulse_width2 > 0) begin
+                    ext_trig_roll = 1'b1;
+                    pulse_width2 = pulse_width2 - 1;
+                end
+            end
+        end
+        wait_sample(40);
+        read_roll(16'h0008, status);
+        read_roll(16'h0100, word0);
+        read_roll(16'h0100 + 8*4, word1);
+        read_roll(16'h0100 + 9*4, word2);
+        $display("  status=0x%08x samples[0,8,9]=0x%02x 0x%02x 0x%02x",
+                 status, word0[7:0], word1[7:0], word2[7:0]);
+        check("second fast external trigger completes",
+              status[2] == 1'b1);
+        check("second rolling prehistory includes previous capture tail",
+              word0[7:0] == 8'd33);
+        check("second trigger sample is anchored at pretrigger index",
+              word1[7:0] == 8'd92);
+        check("second post-trigger sample follows trigger sample",
+              word2[7:0] == 8'd93);
 
         $display("\n=== Regression summary: %0d passed, %0d failed ===",
                  pass_count, fail_count);

--- a/tests/test_ela_bug_probe_rtl.py
+++ b/tests/test_ela_bug_probe_rtl.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+@unittest.skipUnless(shutil.which("iverilog"), "iverilog not on PATH")
+@unittest.skipUnless(shutil.which("vvp"), "vvp not on PATH")
+class ElaBugProbeRtlTests(unittest.TestCase):
+    def test_focused_ela_regressions(self):
+        with tempfile.TemporaryDirectory(prefix="ela-bug-probe-") as tmpdir:
+            vvp = Path(tmpdir) / "fcapz_ela_bug_probe_tb.vvp"
+            sources = [
+                str(ROOT / "tb" / "fcapz_ela_bug_probe_tb.sv"),
+                str(ROOT / "rtl" / "fcapz_ela.v"),
+                str(ROOT / "rtl" / "dpram.v"),
+                str(ROOT / "rtl" / "trig_compare.v"),
+            ]
+
+            compile_result = subprocess.run(
+                ["iverilog", "-g2012", "-I", str(ROOT / "rtl"), "-o", str(vvp)]
+                + sources,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(
+                compile_result.returncode,
+                0,
+                f"iverilog compilation failed:\n{compile_result.stderr}",
+            )
+
+            sim_result = subprocess.run(
+                ["vvp", str(vvp)],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            output = sim_result.stdout + sim_result.stderr
+            self.assertEqual(
+                sim_result.returncode,
+                0,
+                f"ELA bug-probe simulation failed:\n{output}",
+            )
+            self.assertIn(
+                "Regression summary:",
+                output,
+                f"expected regression summary in simulation output:\n{output}",
+            )
+            self.assertIn(
+                "0 failed",
+                output,
+                f"expected all focused ELA regressions to pass:\n{output}",
+            )


### PR DESCRIPTION
Keep single-segment pretrigger memory rolling before arm so fast triggers can capture valid pre-arm history instead of waiting for post-arm prefill. Add focused RTL regression coverage for first arm and re-arm behavior.

Refs: Issue #10