### PR TITLE
Fix bridge ready probe chain selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Host / hw_server:** `EjtagAxiController.connect()` and
+  `EjtagUartController.connect()` now skip the generic 49-bit register
+  ready probe during programming and poll their native streaming
+  `CMD_CONFIG` identities instead. `EioController.connect()` selects its
+  USER chain before the transport-level ready probe, so USER3 EIO connects
+  no longer depend on USER1/ELA responding first.
+
 ### Added
 
 - **EJTAG-AXI RTL:** Vendor wrappers now expose `CMD_FIFO_DEPTH` and

--- a/host/fcapz/eio.py
+++ b/host/fcapz/eio.py
@@ -82,6 +82,9 @@ class EioController:
         cached on the instance for the caller; they should match
         ``fcapz.__version__``.
         """
+        # XilinxHwServerTransport may run a 49-bit VERSION ready probe during
+        # connect(), so select EIO's USER chain before opening the session.
+        self._t.select_chain(self._chain)
         self._t.connect()
         self._t.select_chain(self._chain)
         version = int(self._t.read_reg(self._abs(_ADDR_VERSION)))

--- a/host/fcapz/ejtagaxi.py
+++ b/host/fcapz/ejtagaxi.py
@@ -13,6 +13,7 @@ DR format (72 bits, LSB first):
 
 from __future__ import annotations
 
+import time
 import warnings
 
 from .transport import Transport
@@ -235,16 +236,36 @@ class EjtagAxiController:
         bridge with RESET + NOP drain so the first real command starts from a
         fully-idle state.
         """
-        self._transport.connect()
         self._transport.select_chain(self._chain)
-        decoded = self._scan_batch(
-            [
-                (CMD_CONFIG, 0x0000, 0, 0),
-                (CMD_CONFIG, 0x0004, 0, 0),
-                (CMD_CONFIG, 0x002C, 0, 0),
-                (CMD_NOP, 0, 0, 0),
-            ]
+        old_ready_probe_addr = getattr(self._transport, "ready_probe_addr", None)
+        if hasattr(self._transport, "ready_probe_addr"):
+            # The generic hw_server ready probe uses the 49-bit ELA/EIO
+            # register protocol. EJTAG-AXI uses a 72-bit streaming DR, so
+            # readiness must be checked with CMD_CONFIG after connect().
+            self._transport.ready_probe_addr = None
+        try:
+            self._transport.connect()
+        finally:
+            if hasattr(self._transport, "ready_probe_addr"):
+                self._transport.ready_probe_addr = old_ready_probe_addr
+        self._transport.select_chain(self._chain)
+        deadline = time.monotonic() + float(
+            getattr(self._transport, "ready_probe_timeout", 2.0)
         )
+        decoded = []
+        while True:
+            decoded = self._scan_batch(
+                [
+                    (CMD_CONFIG, 0x0000, 0, 0),
+                    (CMD_CONFIG, 0x0004, 0, 0),
+                    (CMD_CONFIG, 0x002C, 0, 0),
+                    (CMD_NOP, 0, 0, 0),
+                ]
+            )
+            _, _, bridge_id, _ = decoded[1]
+            if bridge_id == _BRIDGE_ID or time.monotonic() >= deadline:
+                break
+            time.sleep(0.02)
         _, _, bridge_id, _ = decoded[1]
         _, _, version, _ = decoded[2]
         _, _, features, _ = decoded[3]
@@ -482,5 +503,3 @@ class EjtagAxiController:
                 stacklevel=2,
             )
         self._transport.close()
-
-

--- a/host/fcapz/ejtaguart.py
+++ b/host/fcapz/ejtaguart.py
@@ -70,10 +70,28 @@ class EjtagUartController:
                 wrong bitstream, or core not loaded).
             RuntimeError: If the transport cannot connect.
         """
-        self._transport.connect()
+        self._transport.select_chain(self._chain)
+        old_ready_probe_addr = getattr(self._transport, "ready_probe_addr", None)
+        if hasattr(self._transport, "ready_probe_addr"):
+            # The generic hw_server ready probe uses the 49-bit ELA/EIO
+            # register protocol. EJTAG-UART uses a 32-bit streaming DR, so
+            # readiness must be checked with CMD_CONFIG after connect().
+            self._transport.ready_probe_addr = None
+        try:
+            self._transport.connect()
+        finally:
+            if hasattr(self._transport, "ready_probe_addr"):
+                self._transport.ready_probe_addr = old_ready_probe_addr
         self._transport.select_chain(self._chain)
         try:
-            uid = self._config_read_u32(0x00)
+            deadline = time.monotonic() + float(
+                getattr(self._transport, "ready_probe_timeout", 2.0)
+            )
+            while True:
+                uid = self._config_read_u32(0x00)
+                if uid == self.UART_ID or time.monotonic() >= deadline:
+                    break
+                time.sleep(0.02)
             if uid != self.UART_ID:
                 # XSDB can occasionally return one stale DR result right
                 # after a fresh session/chain selection. Flush a couple of
@@ -273,4 +291,3 @@ class EjtagUartController:
         _, _, b2 = self._scan(cmd=self.CMD_CONFIG, tx_byte=base_addr + 3)
         _, _, b3 = self._scan(cmd=self.CMD_NOP)  # drain
         return b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)
-

--- a/tests/test_ejtagaxi.py
+++ b/tests/test_ejtagaxi.py
@@ -43,7 +43,7 @@ class FakeBridgeTransport(Transport):
         0x002C: (0x0F << 16) | 0x2020,
     }
 
-    def __init__(self):
+    def __init__(self, *, stale_config_id_reads: int = 0):
         self.regs: list[int] = [0] * 16
         self.auto_inc_addr: int = 0
         self.prev_valid: bool = False
@@ -56,13 +56,20 @@ class FakeBridgeTransport(Transport):
         self.busy_count: int = 0
         self.fifo_stall_count: int = 0
         self._active_chain: int = 1
+        self.connect_chain: int | None = None
+        self.ready_probe_addr: int | None = 0x0000
+        self.ready_probe_timeout: float = 0.1
+        self.connect_ready_probe_addr: int | None = None
         self._config_regs: dict[int, int] = dict(self._CONFIG_REGS)
+        self.stale_config_id_reads = stale_config_id_reads
         self._last_cmd: int = CMD_NOP  # track last command for FIFO priming
         self.scan_log: list[int] = []
 
     # --- Transport ABC implementation ---
 
     def connect(self) -> None:
+        self.connect_chain = self._active_chain
+        self.connect_ready_probe_addr = self.ready_probe_addr
         pass
 
     def close(self) -> None:
@@ -195,7 +202,11 @@ class FakeBridgeTransport(Transport):
 
         elif cmd == CMD_CONFIG:
             # Return config register value; pipelined so sets prev_rdata
-            self.prev_rdata = self._config_regs.get(addr, 0)
+            if addr == 0x0000 and self.stale_config_id_reads > 0:
+                self.stale_config_id_reads -= 1
+                self.prev_rdata = 0
+            else:
+                self.prev_rdata = self._config_regs.get(addr, 0)
             self.prev_valid = True
             self.prev_resp = RESP_OKAY
 
@@ -457,6 +468,23 @@ class EjtagAxiTests(unittest.TestCase):
         ctrl = EjtagAxiController(t, chain=4)
         ctrl.connect()
         self.assertEqual(t._active_chain, 4)
+        self.assertEqual(t.connect_chain, 4)
+        self.assertIsNone(t.connect_ready_probe_addr)
+        self.assertEqual(t.ready_probe_addr, 0x0000)
+
+    def test_connect_retries_until_bridge_id_is_ready(self):
+        t = FakeBridgeTransport(stale_config_id_reads=2)
+        ctrl = EjtagAxiController(t, chain=4)
+        info = ctrl.connect()
+        self.assertEqual(info["bridge_id"], _BRIDGE_ID)
+        self.assertEqual(t.stale_config_id_reads, 0)
+
+    def test_connect_timeout_with_stale_bridge_id_raises(self):
+        t = FakeBridgeTransport(stale_config_id_reads=100)
+        t.ready_probe_timeout = 0.0
+        ctrl = EjtagAxiController(t, chain=4)
+        with self.assertRaisesRegex(RuntimeError, "Bad BRIDGE_ID: 0x00000000"):
+            ctrl.connect()
 
     def test_batch_only_transport_still_connects_and_moves_data(self):
         ctrl, t = self._make_ctrl(BatchOnlyBridgeTransport())

--- a/tests/test_ejtaguart.py
+++ b/tests/test_ejtaguart.py
@@ -47,14 +47,20 @@ class FakeUartTransport(Transport):
 
     TX_FIFO_DEPTH = 16
 
-    def __init__(self):
+    def __init__(self, *, stale_id_reads: int = 0):
         self.tx_buf: bytearray = bytearray()  # bytes sent via TX_PUSH
         self.rx_buf: bytearray = bytearray()  # bytes available for RX_POP
         self._active_chain: int = 1
+        self.connect_chain: int | None = None
+        self.ready_probe_addr: int | None = 0x0000
+        self.ready_probe_timeout: float = 0.1
+        self.connect_ready_probe_addr: int | None = None
         self._prev_rx_byte: int = 0
         self._prev_rx_valid: bool = False
         self._prev_config_byte: int = 0
         self._prev_config_valid: bool = False
+        self.stale_id_reads = stale_id_reads
+        self._stale_id_active = False
         self._rx_overflow: bool = False
         self._frame_err: bool = False
 
@@ -78,6 +84,8 @@ class FakeUartTransport(Transport):
     # --- Transport ABC implementation ---
 
     def connect(self) -> None:
+        self.connect_chain = self._active_chain
+        self.connect_ready_probe_addr = self.ready_probe_addr
         self._init_config()
 
     def close(self) -> None:
@@ -155,7 +163,15 @@ class FakeUartTransport(Transport):
         elif cmd == CMD_CONFIG:
             self._init_config()
             addr = tx_byte & 0xFF
-            self._prev_config_byte = self._CONFIG_MAP.get(addr, 0)
+            if addr == 0 and self.stale_id_reads > 0:
+                self.stale_id_reads -= 1
+                self._stale_id_active = True
+            if self._stale_id_active and addr < 4:
+                self._prev_config_byte = 0
+                if addr == 3:
+                    self._stale_id_active = False
+            else:
+                self._prev_config_byte = self._CONFIG_MAP.get(addr, 0)
             self._prev_config_valid = True
 
         elif cmd == CMD_RESET:
@@ -303,6 +319,23 @@ class EjtagUartTests(unittest.TestCase):
         ctrl = EjtagUartController(t, chain=4)
         ctrl.connect()
         self.assertEqual(t._active_chain, 4)
+        self.assertEqual(t.connect_chain, 4)
+        self.assertIsNone(t.connect_ready_probe_addr)
+        self.assertEqual(t.ready_probe_addr, 0x0000)
+
+    def test_connect_retries_until_uart_id_is_ready(self):
+        t = FakeUartTransport(stale_id_reads=2)
+        ctrl = EjtagUartController(t, chain=4)
+        info = ctrl.connect()
+        self.assertEqual(info["id"], _UART_ID)
+        self.assertEqual(t.stale_id_reads, 0)
+
+    def test_connect_timeout_with_stale_uart_id_raises(self):
+        t = FakeUartTransport(stale_id_reads=100)
+        t.ready_probe_timeout = 0.0
+        ctrl = EjtagUartController(t, chain=4)
+        with self.assertRaisesRegex(RuntimeError, "Bad UART ID: 0x00000000"):
+            ctrl.connect()
 
     def test_connect_failure_closes_transport(self):
         """connect() must close the transport if ID check fails."""

--- a/tests/test_host_stack.py
+++ b/tests/test_host_stack.py
@@ -613,6 +613,7 @@ class FakeVioTransport(Transport):
     def __init__(self, probe_in: int = 0xAB):
         self._probe_in = probe_in
         self._active_chain: int = 1
+        self.connect_chain: int | None = None
         self.regs = {
             # VERSION computed from canonical fcapz.__version__ so this
             # fake stays in sync when VERSION is bumped.
@@ -623,6 +624,7 @@ class FakeVioTransport(Transport):
         }
 
     def connect(self) -> None:
+        self.connect_chain = self._active_chain
         return None
 
     def close(self) -> None:
@@ -1002,12 +1004,14 @@ class ChainSelectionTests(unittest.TestCase):
         eio = EioController(transport, chain=3)
         eio.connect()
         self.assertEqual(transport._active_chain, 3)
+        self.assertEqual(transport.connect_chain, 3)
 
     def test_eio_custom_chain(self):
         transport = FakeVioTransport()
         eio = EioController(transport, chain=4)
         eio.connect()
         self.assertEqual(transport._active_chain, 4)
+        self.assertEqual(transport.connect_chain, 4)
 
     def test_raw_dr_scan_returns_bits(self):
         t = FakeTransport()


### PR DESCRIPTION
## Summary

Fixes host-side bridge readiness detection for EJTAG-AXI, EJTAG-UART, and EIO chain selection.

The hw_server transport can run a generic 49-bit ready probe during `connect()`, but the EJTAG-AXI and EJTAG-UART bridges use native streaming DR protocols instead. This PR disables the generic ready probe for those bridges during transport connect, then polls their native `CMD_CONFIG` identity registers until the bridge responds or times out.

It also selects the EIO USER chain before transport connect so EIO readiness is checked on the intended chain, such as USER3, instead of depending on the default USER1/ELA chain.

## Changes

- Select the requested EJTAG-AXI and EJTAG-UART chain before opening the transport session.
- Temporarily disable `ready_probe_addr` during AXI/UART transport connect, then restore it afterward.
- Poll EJTAG-AXI `BRIDGE_ID` through native `CMD_CONFIG` reads until ready or timeout.
- Poll EJTAG-UART ID through native `CMD_CONFIG` reads until ready or timeout.
- Select the EIO chain before `EioController.connect()` calls transport connect.
- Add fake-transport regressions for:
  - connect-time chain selection
  - disabled generic ready probe during AXI/UART connect
  - `ready_probe_addr` restoration
  - delayed bridge identity readiness
  - timeout behavior when identity never becomes valid
- Update `CHANGELOG.md`.

## Validation

- `python -m pytest tests\test_ejtagaxi.py tests\test_ejtaguart.py tests\test_host_stack.py`

Result:

```text
104 passed
