### PR TITLE
Fix Gowin JTAG TAP support and add Verilator RTL driver lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
   # ── 5. RTL simulation (iverilog + vvp) ───────────────────────────
   lint-rtl-verilator:
     name: RTL driver lint (Verilator)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install Verilator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Run shared RTL lint regression
         run: python sim/run_sim.py --lint-only
 
-  # ── 5. RTL simulation (iverilog + vvp) ───────────────────────────
+  # -- 5. Targeted RTL driver lint (Verilator) ----------------------
   lint-rtl-verilator:
     name: RTL driver lint (Verilator)
     runs-on: ubuntu-24.04
@@ -126,6 +126,7 @@ jobs:
       - name: Run Verilator lint and MULTIDRIVEN self-test
         run: python sim/run_verilator_lint.py --self-test
 
+  # -- 6. RTL simulation (iverilog + vvp) ---------------------------
   sim:
     name: RTL simulation (iverilog + vvp)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Run shared RTL lint regression
         run: python sim/run_sim.py --lint-only
 
-  # -- 5. Targeted RTL driver lint (Verilator) ----------------------
+  # -- 5. Full RTL driver lint (Verilator) --------------------------
   lint-rtl-verilator:
     name: RTL driver lint (Verilator)
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,19 @@ jobs:
         run: python sim/run_sim.py --lint-only
 
   # ── 5. RTL simulation (iverilog + vvp) ───────────────────────────
+  lint-rtl-verilator:
+    name: RTL driver lint (Verilator)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Verilator
+        run: sudo apt-get install -y verilator
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run Verilator lint and MULTIDRIVEN self-test
+        run: python sim/run_verilator_lint.py --self-test
+
   sim:
     name: RTL simulation (iverilog + vvp)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ for details.
 | **Xilinx** | BSCANE2 | 4 (USER1-4) | USER1 control + default burst; optional USER2 legacy burst | USER3 | USER4 | USER4 (shared) |
 | **Intel** | sld_virtual_jtag | Unlimited | inst 0 by default; optional inst 1 | inst 2 | inst 3 | inst 5 |
 | **ECP5** | JTAGG | 2 (ER1+ER2) | ER1 by default; optional ER2 | `EIO_EN=1` on ER1 | *deferred to v2* | *deferred to v2* |
-| **Gowin** | JTAG | 1 | No burst | `EIO_EN=1` | *deferred to v2* | *deferred to v2* |
+| **Gowin** | GW_JTAG | One primitive; wrapper selects ER1 or ER2 | No burst | `EIO_EN=1` | *deferred to v2* | *deferred to v2* |
 | **PolarFire-family** | UJTAG | 2 (USER1+USER2) | USER1 control + USER2 burst | `EIO_EN=1` on USER1 | *deferred to v2* | *deferred to v2* |
 
 **Verified Xilinx 7-series IR codes** (xc7a100t, Arty A7):
@@ -563,9 +563,13 @@ Xilinx ELA wrappers default to `SINGLE_CHAIN_BURST=1`: USER1 carries both
 control and 256-bit burst readout. Set `SINGLE_CHAIN_BURST=0` only for the
 legacy USER2 dual-chain burst path.
 
-On Gowin, the single chain means **no burst readback** — sample data is read
-word-by-word through the sample DATA window (functional but slower). Details
-are in the manual (see below).
+On Gowin, the wrapper keeps readback on the 49-bit register path rather than
+adding a burst readback chain. Sample data is read word-by-word through the
+sample DATA window (functional but slower). Details are in the manual (see
+below).
+Do not instantiate separate Gowin ELA and EIO wrappers in one design: Gowin
+allows one `GW_JTAG` primitive, so use `EIO_EN=1` to share the ELA wrapper's
+register bus instead.
 
 On PolarFire-family devices, UJTAG exposes two user instructions from one
 primitive. To use ELA and EIO together, enable `EIO_EN=1` on the ELA wrapper;

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ python sim/run_sim.py
 `python sim/run_sim.py` runs the shared RTL lint pass (`iverilog -Wall`)
 first, then the default simulation regression.  Use
 `python sim/run_sim.py --lint-only` when you only want the RTL lint check.
-Run `python sim/run_verilator_lint.py --self-test` when changing core RTL; it
-catches stricter driver issues such as one register assigned from two always
-blocks.
+Run `python sim/run_verilator_lint.py --self-test` when changing core ELA or
+Gowin wrapper RTL; it runs targeted Verilator driver lint for issues such as
+one register assigned from two always blocks.
 
 Use the installed `fcapz` entry point for day-to-day ELA work. The legacy
 `python -m fcapz.cli` form still works, but the package install path is
@@ -687,7 +687,7 @@ GitHub Actions runs on every push and pull request to `main` or `master`:
 | `lint-python` | `ruff` E/F/W rules on the whole repo |
 | `test-host` | `pytest tests/ -v --tb=short` with the default `not hw` marker filter, plus an explicit JTAG readback pipeline regression for burst and timestamp stabilization paths |
 | `lint-rtl` | `python sim/run_sim.py --lint-only` — shared `iverilog -Wall` elaboration for the core RTL, vendor wrappers, and simulation stubs |
-| `lint-rtl-verilator` | `python sim/run_verilator_lint.py --self-test` -- Verilator driver lint plus an intentional `MULTIDRIVEN` fixture proving the gate catches one reg driven by multiple always blocks |
+| `lint-rtl-verilator` | `python sim/run_verilator_lint.py --self-test` -- targeted Verilator driver lint for the ELA/Gowin targets plus an intentional `MULTIDRIVEN` fixture proving the gate catches one reg driven by multiple always blocks |
 | `sim` | `python sim/run_sim.py` — runs the same `iverilog -Wall` lint pass, then the default RTL regression: ELA behavior, ELA focused regressions, ELA configuration matrix, burst readout, single-chain pipe readout, EIO, and channel mux testbenches |
 
 Hardware integration tests run manually (require physical Arty A7-100T + hw_server).
@@ -722,9 +722,10 @@ the testbenches. The ELA configuration matrix covers small/scalable build
 shapes such as `DUAL_COMPARE=0`, `USER1_DATA_EN=0`, disabled feature
 registers, and `REL_COMPARE=1` with `INPUT_PIPE=1`. CI uses the same runner
 so local regressions and GitHub Actions exercise the same RTL lint target
-list. The Verilator lint command complements that broad elaboration pass with
-stricter procedural-driver checks; its self-test must fail a deliberately bad
-multi-driver fixture before the job is considered valid.
+list. The targeted Verilator lint command complements that broad elaboration
+pass for the ELA/Gowin targets with stricter procedural-driver checks; its
+self-test must fail a deliberately bad multi-driver fixture before the job is
+considered valid.
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ python sim/run_sim.py
 `python sim/run_sim.py` runs the shared RTL lint pass (`iverilog -Wall`)
 first, then the default simulation regression.  Use
 `python sim/run_sim.py --lint-only` when you only want the RTL lint check.
-Run `python sim/run_verilator_lint.py --self-test` when changing core ELA or
-Gowin wrapper RTL; it runs targeted Verilator driver lint for issues such as
+Run `python sim/run_verilator_lint.py --self-test` when changing RTL; it runs
+the full Verilog RTL matrix through Verilator driver lint for issues such as
 one register assigned from two always blocks.
 
 Use the installed `fcapz` entry point for day-to-day ELA work. The legacy
@@ -687,7 +687,7 @@ GitHub Actions runs on every push and pull request to `main` or `master`:
 | `lint-python` | `ruff` E/F/W rules on the whole repo |
 | `test-host` | `pytest tests/ -v --tb=short` with the default `not hw` marker filter, plus an explicit JTAG readback pipeline regression for burst and timestamp stabilization paths |
 | `lint-rtl` | `python sim/run_sim.py --lint-only` — shared `iverilog -Wall` elaboration for the core RTL, vendor wrappers, and simulation stubs |
-| `lint-rtl-verilator` | `python sim/run_verilator_lint.py --self-test` -- targeted Verilator driver lint for the ELA/Gowin targets plus an intentional `MULTIDRIVEN` fixture proving the gate catches one reg driven by multiple always blocks |
+| `lint-rtl-verilator` | `python sim/run_verilator_lint.py --self-test` -- full-project Verilog RTL driver lint plus an intentional `MULTIDRIVEN` fixture proving the gate catches one reg driven by multiple always blocks |
 | `sim` | `python sim/run_sim.py` — runs the same `iverilog -Wall` lint pass, then the default RTL regression: ELA behavior, ELA focused regressions, ELA configuration matrix, burst readout, single-chain pipe readout, EIO, and channel mux testbenches |
 
 Hardware integration tests run manually (require physical Arty A7-100T + hw_server).
@@ -722,8 +722,8 @@ the testbenches. The ELA configuration matrix covers small/scalable build
 shapes such as `DUAL_COMPARE=0`, `USER1_DATA_EN=0`, disabled feature
 registers, and `REL_COMPARE=1` with `INPUT_PIPE=1`. CI uses the same runner
 so local regressions and GitHub Actions exercise the same RTL lint target
-list. The targeted Verilator lint command complements that broad elaboration
-pass for the ELA/Gowin targets with stricter procedural-driver checks; its
+list. The Verilator lint command complements that broad elaboration pass with
+a full-project Verilog RTL matrix and stricter procedural-driver checks; its
 self-test must fail a deliberately bad multi-driver fixture before the job is
 considered valid.
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ python sim/run_sim.py
 `python sim/run_sim.py` runs the shared RTL lint pass (`iverilog -Wall`)
 first, then the default simulation regression.  Use
 `python sim/run_sim.py --lint-only` when you only want the RTL lint check.
+Run `python sim/run_verilator_lint.py --self-test` when changing core RTL; it
+catches stricter driver issues such as one register assigned from two always
+blocks.
 
 Use the installed `fcapz` entry point for day-to-day ELA work. The legacy
 `python -m fcapz.cli` form still works, but the package install path is
@@ -684,6 +687,7 @@ GitHub Actions runs on every push and pull request to `main` or `master`:
 | `lint-python` | `ruff` E/F/W rules on the whole repo |
 | `test-host` | `pytest tests/ -v --tb=short` with the default `not hw` marker filter, plus an explicit JTAG readback pipeline regression for burst and timestamp stabilization paths |
 | `lint-rtl` | `python sim/run_sim.py --lint-only` — shared `iverilog -Wall` elaboration for the core RTL, vendor wrappers, and simulation stubs |
+| `lint-rtl-verilator` | `python sim/run_verilator_lint.py --self-test` -- Verilator driver lint plus an intentional `MULTIDRIVEN` fixture proving the gate catches one reg driven by multiple always blocks |
 | `sim` | `python sim/run_sim.py` — runs the same `iverilog -Wall` lint pass, then the default RTL regression: ELA behavior, ELA focused regressions, ELA configuration matrix, burst readout, single-chain pipe readout, EIO, and channel mux testbenches |
 
 Hardware integration tests run manually (require physical Arty A7-100T + hw_server).
@@ -710,6 +714,7 @@ Produces `examples/arty_a7/arty_a7_top.bit`.
 ```bash
 python sim/run_sim.py
 python sim/run_sim.py --lint-only
+python sim/run_verilator_lint.py --self-test
 ```
 
 The default command runs `iverilog -Wall` lint before compiling and running
@@ -717,7 +722,9 @@ the testbenches. The ELA configuration matrix covers small/scalable build
 shapes such as `DUAL_COMPARE=0`, `USER1_DATA_EN=0`, disabled feature
 registers, and `REL_COMPARE=1` with `INPUT_PIPE=1`. CI uses the same runner
 so local regressions and GitHub Actions exercise the same RTL lint target
-list.
+list. The Verilator lint command complements that broad elaboration pass with
+stricter procedural-driver checks; its self-test must fail a deliberately bad
+multi-driver fixture before the job is considered valid.
 
 ### Tests
 

--- a/docs/01_overview.md
+++ b/docs/01_overview.md
@@ -194,7 +194,7 @@ needed.  See [chapter 14](14_transports.md) and
 | Xilinx UltraScale / UltraScale+ | `BSCANE2` (unisim) | [`fcapz_*_xilinxus.v`](../rtl/) (thin shims over `_xilinx7`) | ✅ |
 | Lattice ECP5 | `JTAGG` | [`fcapz_*_ecp5.v`](../rtl/) | ❌ |
 | Intel / Altera | `sld_virtual_jtag` | [`fcapz_*_intel.v`](../rtl/) | ❌ |
-| Gowin GW1N / GW2A | Gowin `JTAG` primitive | [`fcapz_*_gowin.v`](../rtl/) | ❌ |
+| Gowin GW1N / GW2A | Gowin `GW_JTAG` primitive | [`fcapz_*_gowin.v`](../rtl/) | ❌ |
 | Xilinx Versal (XCVM/VC/VP/VE/VH) | Different TAP primitive (CIPS / `BSCANE2_INST`) | **Not supported** | — |
 
 The wrappers are all single-instantiation: pick the one for your

--- a/docs/14_transports.md
+++ b/docs/14_transports.md
@@ -213,7 +213,8 @@ swap one for the other without changing the IR table.
 | Xilinx Kintex / Virtex UltraScale (standalone) | `IR_TABLE_XILINX_ULTRASCALE` (alias `IR_TABLE_US`) | none |
 | Xilinx Artix / Kintex / Virtex UltraScale+ (standalone) | `IR_TABLE_XILINX_ULTRASCALE` | none |
 | **Zynq UltraScale+ MPSoC** (Kria xck24/xck26, ZCU+ xczu*) | `IR_TABLE_XILINX_ZYNQUS` | `ir_length=12`, `dr_extra_bits=1`, `dr_extra_position="tdi"` |
-| Lattice ECP5, Intel, Gowin | n/a — those vendors use different TAP primitives, not BSCANE2; the transport's `ir_table` doesn't apply.  See "Adding a new transport" below. | n/a |
+| Lattice ECP5, Intel | n/a — those vendors use different TAP primitives, not BSCANE2; the transport's `ir_table` doesn't apply.  See "Adding a new transport" below. | n/a |
+| Gowin GW-family | `OpenOcdTransport.IR_TABLE_GOWIN` | Auto-selected by the CLI for `--tap GW...`; current RTL wrappers still require one shared `GW_JTAG` primitive per design |
 
 The MPSoC row is not optional padding — the ARM DAP's 1-bit BYPASS
 register sits in series with the PL TAP's DR on the TDI side, so every

--- a/host/fcapz/cli.py
+++ b/host/fcapz/cli.py
@@ -216,7 +216,15 @@ def _chain_shape_kwargs(fpga_name: str) -> dict[str, object]:
 
 def _make_transport(args: argparse.Namespace):
     if args.backend == "openocd":
-        return OpenOcdTransport(host=args.host, port=args.port, tap=args.tap)
+        tap_name = args.tap.removesuffix(".tap")
+        ir_table = (
+            OpenOcdTransport.IR_TABLE_GOWIN
+            if tap_name.lower().startswith("gw")
+            else None
+        )
+        return OpenOcdTransport(
+            host=args.host, port=args.port, tap=args.tap, ir_table=ir_table,
+        )
     fpga_name = args.tap.removesuffix(".tap") if hasattr(args, "tap") else "xc7a100t"
     port = args.port if args.port != 6666 else 3121
     bitfile = getattr(args, "program", None)

--- a/host/fcapz/transport.py
+++ b/host/fcapz/transport.py
@@ -331,7 +331,7 @@ class OpenOcdTransport(Transport):
     def _dr_scan(self, value: int) -> int:
         hex_in = f"0x{value:013x}"
         result = self._cmd(f"drscan {self.tap} 49 {hex_in}")
-        return int(result.split()[0], 16)
+        return self._parse_drscan_result(result, command="drscan", width=49)
 
     def raw_dr_scan(self, bits: int, width: int, *, chain: int | None = None) -> int:
         """Perform a raw DR scan via irscan + drscan on the OpenOCD socket."""
@@ -339,7 +339,17 @@ class OpenOcdTransport(Transport):
         hex_width = (width + 3) // 4
         hex_in = f"0x{bits:0{hex_width}x}"
         result = self._cmd(f"drscan {self.tap} {width} {hex_in}")
-        return int(result.split()[0], 16)
+        return self._parse_drscan_result(result, command="drscan", width=width)
+
+    def _parse_drscan_result(self, result: str, *, command: str, width: int) -> int:
+        token = result.split()[0] if result.split() else ""
+        try:
+            return int(token, 16)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"OpenOCD {command} failed or returned non-hex data "
+                f"for tap {self.tap!r}, width {width}: {result!r}"
+            ) from exc
 
     def write_reg(self, addr: int, value: int) -> None:
         frame = (1 << 48) | ((addr & 0xFFFF) << 32) | (value & 0xFFFFFFFF)

--- a/host/fcapz/transport.py
+++ b/host/fcapz/transport.py
@@ -247,6 +247,10 @@ class OpenOcdTransport(Transport):
     IR_TABLE_XILINX_ULTRASCALE: dict[int, int] = {
         1: 0x24, 2: 0x25, 3: 0x26, 4: 0x27,
     }
+    # Gowin GW_JTAG exposes ER1/ER2 IR opcodes.  Current RTL wrappers still
+    # instantiate one GW_JTAG primitive each, so combining cores should use the
+    # wrapper's address-muxed EIO_EN path unless the design shares the primitive.
+    IR_TABLE_GOWIN: dict[int, int] = {1: 0x42, 2: 0x43}
     # Zynq UltraScale+ MPSoC PL TAP opcodes.  OpenOCD's TCL listener
     # delegates chain walking (IR padding for the ARM DAP + DR BYPASS
     # bits) to the openocd config file rather than to host code, so this

--- a/rtl/fcapz_eio.v
+++ b/rtl/fcapz_eio.v
@@ -102,6 +102,7 @@ module fcapz_eio #(
     // ---- Register read mux --------------------------------------------------
     always @(*) begin : p_rdata
         integer i;
+        i = 0;
         jtag_rdata = 32'h0;
         if (jtag_addr == ADDR_VERSION) begin
             // {major[7:0], minor[7:0], core_id[15:0]="IO"=0x494F}, generated

--- a/rtl/fcapz_eio_gowin.v
+++ b/rtl/fcapz_eio_gowin.v
@@ -5,8 +5,9 @@
 
 // fpgacapZero EIO wrapper for Gowin GW1N / GW2A (standalone).
 //
-// WARNING: Gowin has only 1 user JTAG chain.  This standalone EIO
-// wrapper uses that chain and CANNOT coexist with fcapz_ela_gowin.
+// WARNING: Gowin has limited user JTAG chains.  This standalone EIO
+// wrapper defaults to ER1 and CANNOT coexist with fcapz_ela_gowin on
+// the same chain.
 // To use ELA + EIO together on Gowin, set EIO_EN=1 on the
 // fcapz_ela_gowin wrapper instead.
 //
@@ -20,7 +21,7 @@
 module fcapz_eio_gowin #(
     parameter IN_W  = 32,
     parameter OUT_W = 32,
-    parameter CHAIN = 3    // BSCANE2 USER chain (default USER3)
+    parameter CHAIN = 1    // Gowin ER1 by default (ER2 with CHAIN=2)
 ) (
     input  wire [IN_W-1:0]  probe_in,
     output wire [OUT_W-1:0] probe_out

--- a/rtl/fcapz_ejtaguart.v
+++ b/rtl/fcapz_ejtaguart.v
@@ -160,6 +160,8 @@ module fcapz_ejtaguart #(
     wire [7:0]  tx_fifo_rdata;
     wire        tx_fifo_empty;
     wire [TX_AW:0] tx_fifo_wr_count;
+    wire        tx_fifo_wr_rst_busy_unused;
+    wire        tx_fifo_rd_rst_busy_unused;
 
     reg         tx_wr_pulse;
 
@@ -177,8 +179,10 @@ module fcapz_ejtaguart #(
         .rd_en   (tx_fifo_rd_en_r),
         .rd_data (tx_fifo_rdata),
         .rd_empty(tx_fifo_empty),
+        .rd_rst_busy(tx_fifo_rd_rst_busy_unused),
         .rd_count(),
-        .wr_count(tx_fifo_wr_count)
+        .wr_count(tx_fifo_wr_count),
+        .wr_rst_busy(tx_fifo_wr_rst_busy_unused)
     );
 
     // tx_free: TX_FIFO_DEPTH - wr_count, saturated to 255
@@ -192,6 +196,8 @@ module fcapz_ejtaguart #(
     wire [7:0]  rx_fifo_rdata;
     wire        rx_fifo_empty;
     wire [RX_AW:0] rx_fifo_rd_count;
+    wire        rx_fifo_wr_rst_busy_unused;
+    wire        rx_fifo_rd_rst_busy_unused;
 
     reg         rx_rd_pulse;
     reg         rx_fifo_wr_en_r;
@@ -211,8 +217,10 @@ module fcapz_ejtaguart #(
         .rd_en   (rx_rd_pulse),
         .rd_data (rx_fifo_rdata),
         .rd_empty(rx_fifo_empty),
+        .rd_rst_busy(rx_fifo_rd_rst_busy_unused),
         .rd_count(rx_fifo_rd_count),
-        .wr_count()
+        .wr_count(),
+        .wr_rst_busy(rx_fifo_wr_rst_busy_unused)
     );
 
     wire rx_ready = !rx_fifo_empty;

--- a/rtl/fcapz_ela.v
+++ b/rtl/fcapz_ela.v
@@ -167,6 +167,7 @@ module fcapz_ela #(
     localparam HAS_SEGMENTS = (NUM_SEGMENTS > 1);
     localparam HAS_CHANNEL_MUX = (NUM_CHANNELS > 1);
     localparam HAS_PROBE_MUX = (PROBE_MUX_W > 0);
+    localparam TS_MUX_W = (TIMESTAMP_W > 0) ? TIMESTAMP_W : 1;
 
     // Phase 4: segment derived params
     localparam SEG_DEPTH = DEPTH / NUM_SEGMENTS;
@@ -437,6 +438,7 @@ module fcapz_ela #(
     wire [SAMPLE_W-1:0]  mem_din_a_ram;
     wire [TS_DATA_W-1:0] mem_ts_din_a_ram;
     wire [TS_DATA_W-1:0] ts_counter_cur;
+    wire [TS_MUX_W-1:0] ts_dout_a_mux;
 
     assign mem_we_a_ram   = (INPUT_PIPE >= 1) ? mem_we_a_q : mem_we_a;
     assign mem_din_a_ram  = (INPUT_PIPE >= 1) ? mem_wr_data_q : active_probe;
@@ -479,9 +481,11 @@ module fcapz_ela #(
                 .addr_b (burst_rd_addr),
                 .dout_b (ts_dout_b)
             );
+            assign ts_dout_a_mux = ts_dout_a;
             assign burst_rd_ts_data = ts_dout_b;
         end else begin : g_no_ts
             assign ts_counter_cur = {TS_DATA_W{1'b0}};
+            assign ts_dout_a_mux = 1'b0;
             assign burst_rd_ts_data = 1'b0;
         end
     endgenerate
@@ -1382,7 +1386,7 @@ module fcapz_ela #(
             if (rd_phase == RD_CAPTURE) begin
                 rd_data_sample <= mem_dout_a;
                 if (TIMESTAMP_W > 0 && rd_is_ts)
-                    ts_rd_data_sample <= g_ts.ts_dout_a;
+                    ts_rd_data_sample <= ts_dout_a_mux;
                 mem_rd_pending <= 1'b0;
                 rd_phase <= RD_ACK;
             end else if (rd_phase == RD_ACK) begin

--- a/rtl/fcapz_ela.v
+++ b/rtl/fcapz_ela.v
@@ -974,7 +974,6 @@ module fcapz_ela #(
             decim_ratio      <= HAS_DECIM ? jtag_decim : 24'h0;
             // Phase 2: external trigger
             ext_trig_mode    <= HAS_EXT_TRIG ? jtag_trig_ext : 2'd0;
-            trig_holdoff     <= trig_holdoff_sync2;
             // Trigger delay (sample clocks) — latched on arm
             trig_delay       <= trig_delay_sync2;
             // Sequencer stages
@@ -1145,6 +1144,7 @@ module fcapz_ela #(
                     pre_count <= {PTR_W+1{1'b0}};
                 seq_state   <= {SEQ_STATE_W{1'b0}};
                 seq_counter <= 16'h0;
+                trig_holdoff <= trig_holdoff_sync2;
                 trig_holdoff_active <= (trig_holdoff_sync2 != 16'h0);
                 trig_holdoff_count  <= (trig_holdoff_sync2 != 16'h0)
                     ? (trig_holdoff_sync2 - 16'h1) : 16'h0;

--- a/rtl/fcapz_ela_ecp5.v
+++ b/rtl/fcapz_ela_ecp5.v
@@ -125,15 +125,18 @@ module fcapz_ela_ecp5 #(
             wire [15:0] ela_addr;
             wire [31:0] ela_wdata, ela_rdata;
             wire        eio_wr_en_i;
+            wire        eio_rd_en_unused;
             wire [15:0] eio_addr_i;
             wire [31:0] eio_wdata_i, eio_rdata_i;
+            wire        ela_trigger_out_unused;
+            wire        ela_armed_out_unused;
 
             fcapz_regbus_mux u_mux (
                 .addr(jtag_addr), .wr_en(jtag_wr_en), .rd_en(jtag_rd_en),
                 .wdata(jtag_wdata), .rdata(jtag_rdata),
                 .a_wr_en(ela_wr_en), .a_rd_en(ela_rd_en),
                 .a_addr(ela_addr), .a_wdata(ela_wdata), .a_rdata(ela_rdata),
-                .b_wr_en(eio_wr_en_i), .b_rd_en(),
+                .b_wr_en(eio_wr_en_i), .b_rd_en(eio_rd_en_unused),
                 .b_addr(eio_addr_i), .b_wdata(eio_wdata_i), .b_rdata(eio_rdata_i)
             );
 
@@ -146,6 +149,9 @@ module fcapz_ela_ecp5 #(
             ) u_ela (
                 .sample_clk(sample_clk), .sample_rst(sample_rst),
                 .probe_in(probe_in),
+                .trigger_in(1'b0),
+                .trigger_out(ela_trigger_out_unused),
+                .armed_out(ela_armed_out_unused),
                 .jtag_clk(jtag_clk), .jtag_rst(jtag_rst),
                 .jtag_wr_en(ela_wr_en), .jtag_rd_en(ela_rd_en),
                 .jtag_addr(ela_addr), .jtag_wdata(ela_wdata),
@@ -164,6 +170,9 @@ module fcapz_ela_ecp5 #(
                 .jtag_rdata(eio_rdata_i)
             );
         end else begin : g_ela_only
+            wire ela_trigger_out_unused;
+            wire ela_armed_out_unused;
+
             fcapz_ela #(
                 .SAMPLE_W(SAMPLE_W), .DEPTH(DEPTH),
                 .TRIG_STAGES(TRIG_STAGES), .STOR_QUAL(STOR_QUAL),
@@ -173,6 +182,9 @@ module fcapz_ela_ecp5 #(
             ) u_ela (
                 .sample_clk(sample_clk), .sample_rst(sample_rst),
                 .probe_in(probe_in),
+                .trigger_in(1'b0),
+                .trigger_out(ela_trigger_out_unused),
+                .armed_out(ela_armed_out_unused),
                 .jtag_clk(jtag_clk), .jtag_rst(jtag_rst),
                 .jtag_wr_en(jtag_wr_en), .jtag_rd_en(jtag_rd_en),
                 .jtag_addr(jtag_addr), .jtag_wdata(jtag_wdata),

--- a/rtl/fcapz_ela_gowin.v
+++ b/rtl/fcapz_ela_gowin.v
@@ -128,7 +128,7 @@ module fcapz_ela_gowin #(
                 .DUAL_COMPARE(DUAL_COMPARE), .USER1_DATA_EN(USER1_DATA_EN)
             ) u_ela (
                 .sample_clk(sample_clk), .sample_rst(sample_rst),
-                .probe_in(probe_in),
+                .probe_in(probe_in), .trigger_in(1'b0), .trigger_out(),
                 .jtag_clk(jtag_clk), .jtag_rst(jtag_rst),
                 .jtag_wr_en(ela_wr_en), .jtag_rd_en(ela_rd_en),
                 .jtag_addr(ela_addr), .jtag_wdata(ela_wdata),
@@ -157,7 +157,7 @@ module fcapz_ela_gowin #(
                 .DUAL_COMPARE(DUAL_COMPARE), .USER1_DATA_EN(USER1_DATA_EN)
             ) u_ela (
                 .sample_clk(sample_clk), .sample_rst(sample_rst),
-                .probe_in(probe_in),
+                .probe_in(probe_in), .trigger_in(1'b0), .trigger_out(),
                 .jtag_clk(jtag_clk), .jtag_rst(jtag_rst),
                 .jtag_wr_en(jtag_wr_en), .jtag_rd_en(jtag_rd_en),
                 .jtag_addr(jtag_addr), .jtag_wdata(jtag_wdata),

--- a/rtl/fcapz_ela_gowin.v
+++ b/rtl/fcapz_ela_gowin.v
@@ -108,15 +108,18 @@ module fcapz_ela_gowin #(
             wire [15:0] ela_addr;
             wire [31:0] ela_wdata, ela_rdata;
             wire        eio_wr_en_i;
+            wire        eio_rd_en_unused;
             wire [15:0] eio_addr_i;
             wire [31:0] eio_wdata_i, eio_rdata_i;
+            wire        ela_trigger_out_unused;
+            wire        ela_armed_out_unused;
 
             fcapz_regbus_mux u_mux (
                 .addr(jtag_addr), .wr_en(jtag_wr_en), .rd_en(jtag_rd_en),
                 .wdata(jtag_wdata), .rdata(jtag_rdata),
                 .a_wr_en(ela_wr_en), .a_rd_en(ela_rd_en),
                 .a_addr(ela_addr), .a_wdata(ela_wdata), .a_rdata(ela_rdata),
-                .b_wr_en(eio_wr_en_i), .b_rd_en(),
+                .b_wr_en(eio_wr_en_i), .b_rd_en(eio_rd_en_unused),
                 .b_addr(eio_addr_i), .b_wdata(eio_wdata_i), .b_rdata(eio_rdata_i)
             );
 
@@ -128,7 +131,9 @@ module fcapz_ela_gowin #(
                 .DUAL_COMPARE(DUAL_COMPARE), .USER1_DATA_EN(USER1_DATA_EN)
             ) u_ela (
                 .sample_clk(sample_clk), .sample_rst(sample_rst),
-                .probe_in(probe_in), .trigger_in(1'b0), .trigger_out(),
+                .probe_in(probe_in), .trigger_in(1'b0),
+                .trigger_out(ela_trigger_out_unused),
+                .armed_out(ela_armed_out_unused),
                 .jtag_clk(jtag_clk), .jtag_rst(jtag_rst),
                 .jtag_wr_en(ela_wr_en), .jtag_rd_en(ela_rd_en),
                 .jtag_addr(ela_addr), .jtag_wdata(ela_wdata),
@@ -149,6 +154,9 @@ module fcapz_ela_gowin #(
                 .jtag_rdata(eio_rdata_i)
             );
         end else begin : g_ela_only
+            wire ela_trigger_out_unused;
+            wire ela_armed_out_unused;
+
             fcapz_ela #(
                 .SAMPLE_W(SAMPLE_W), .DEPTH(DEPTH),
                 .TRIG_STAGES(TRIG_STAGES), .STOR_QUAL(STOR_QUAL),
@@ -157,7 +165,9 @@ module fcapz_ela_gowin #(
                 .DUAL_COMPARE(DUAL_COMPARE), .USER1_DATA_EN(USER1_DATA_EN)
             ) u_ela (
                 .sample_clk(sample_clk), .sample_rst(sample_rst),
-                .probe_in(probe_in), .trigger_in(1'b0), .trigger_out(),
+                .probe_in(probe_in), .trigger_in(1'b0),
+                .trigger_out(ela_trigger_out_unused),
+                .armed_out(ela_armed_out_unused),
                 .jtag_clk(jtag_clk), .jtag_rst(jtag_rst),
                 .jtag_wr_en(jtag_wr_en), .jtag_rd_en(jtag_rd_en),
                 .jtag_addr(jtag_addr), .jtag_wdata(jtag_wdata),

--- a/rtl/fcapz_ela_intel.v
+++ b/rtl/fcapz_ela_intel.v
@@ -58,6 +58,8 @@ module fcapz_ela_intel #(
     wire [PTR_W-1:0]    burst_start_ptr;
     wire                jtag_rst_ctrl;
     wire                jtag_rst_data;
+    wire                trigger_out_unused;
+    wire                armed_out_unused;
 
     // ---- TAP wrappers ----
     jtag_tap_intel #(.CHAIN(CTRL_CHAIN)) u_tap_ctrl (
@@ -106,6 +108,9 @@ module fcapz_ela_intel #(
     ) u_ela (
         .sample_clk(sample_clk), .sample_rst(sample_rst),
         .probe_in(probe_in),
+        .trigger_in(1'b0),
+        .trigger_out(trigger_out_unused),
+        .armed_out(armed_out_unused),
         .jtag_clk(jtag_clk), .jtag_rst(jtag_rst),
         .jtag_wr_en(jtag_wr_en), .jtag_rd_en(jtag_rd_en),
         .jtag_addr(jtag_addr), .jtag_wdata(jtag_wdata),

--- a/rtl/fcapz_ela_polarfire.v
+++ b/rtl/fcapz_ela_polarfire.v
@@ -127,15 +127,18 @@ module fcapz_ela_polarfire #(
             wire [15:0] ela_addr;
             wire [31:0] ela_wdata, ela_rdata;
             wire        eio_wr_en_i;
+            wire        eio_rd_en_unused;
             wire [15:0] eio_addr_i;
             wire [31:0] eio_wdata_i, eio_rdata_i;
+            wire        ela_trigger_out_unused;
+            wire        ela_armed_out_unused;
 
             fcapz_regbus_mux u_mux (
                 .addr(jtag_addr), .wr_en(jtag_wr_en), .rd_en(jtag_rd_en),
                 .wdata(jtag_wdata), .rdata(jtag_rdata),
                 .a_wr_en(ela_wr_en), .a_rd_en(ela_rd_en),
                 .a_addr(ela_addr), .a_wdata(ela_wdata), .a_rdata(ela_rdata),
-                .b_wr_en(eio_wr_en_i), .b_rd_en(),
+                .b_wr_en(eio_wr_en_i), .b_rd_en(eio_rd_en_unused),
                 .b_addr(eio_addr_i), .b_wdata(eio_wdata_i), .b_rdata(eio_rdata_i)
             );
 
@@ -149,7 +152,9 @@ module fcapz_ela_polarfire #(
             ) u_ela (
                 .sample_clk(sample_clk), .sample_rst(sample_rst),
                 .probe_in(probe_in),
-                .trigger_in(1'b0), .trigger_out(),
+                .trigger_in(1'b0),
+                .trigger_out(ela_trigger_out_unused),
+                .armed_out(ela_armed_out_unused),
                 .jtag_clk(jtag_clk), .jtag_rst(jtag_rst),
                 .jtag_wr_en(ela_wr_en), .jtag_rd_en(ela_rd_en),
                 .jtag_addr(ela_addr), .jtag_wdata(ela_wdata),
@@ -168,6 +173,9 @@ module fcapz_ela_polarfire #(
                 .jtag_rdata(eio_rdata_i)
             );
         end else begin : g_ela_only
+            wire ela_trigger_out_unused;
+            wire ela_armed_out_unused;
+
             fcapz_ela #(
                 .SAMPLE_W(SAMPLE_W), .DEPTH(DEPTH),
                 .TRIG_STAGES(TRIG_STAGES), .STOR_QUAL(STOR_QUAL),
@@ -178,7 +186,9 @@ module fcapz_ela_polarfire #(
             ) u_ela (
                 .sample_clk(sample_clk), .sample_rst(sample_rst),
                 .probe_in(probe_in),
-                .trigger_in(1'b0), .trigger_out(),
+                .trigger_in(1'b0),
+                .trigger_out(ela_trigger_out_unused),
+                .armed_out(ela_armed_out_unused),
                 .jtag_clk(jtag_clk), .jtag_rst(jtag_rst),
                 .jtag_wr_en(jtag_wr_en), .jtag_rd_en(jtag_rd_en),
                 .jtag_addr(jtag_addr), .jtag_wdata(jtag_wdata),

--- a/rtl/jtag_tap/jtag_tap_gowin.v
+++ b/rtl/jtag_tap/jtag_tap_gowin.v
@@ -6,9 +6,12 @@
 // Gowin JTAG TAP wrapper.
 // Presents the standard fpgacapZero TAP interface.
 //
-// Gowin GW1N/GW2A devices provide a JTAG primitive with up to 4
-// user DR chains (similar to Xilinx BSCANE2).  CHAIN selects which
-// user register (1-4).
+// Gowin devices expose user logic through one GW_JTAG primitive per design.
+// That primitive provides two user DR chains (ER1/ER2, selected by IR
+// 0x42/0x43 on the devices checked so far).  CHAIN selects which ER this
+// wrapper instance routes, but do not instantiate multiple standalone Gowin
+// fcapz wrappers in the same design unless you refactor them to share one
+// GW_JTAG instance.
 
 module jtag_tap_gowin #(
     parameter CHAIN = 1
@@ -22,34 +25,49 @@ module jtag_tap_gowin #(
     output wire sel
 );
 
-    wire jtck, jtdi, jrti, jshift, jupdate, jce;
-    wire jrstn;
+    wire jtck, jtdi;
+    wire jreset;
+    wire jrti1, jrti2;
+    wire jshift_capture, jupdate;
+    wire jpause;
+    wire jce1, jce2;
 
-    JTAG u_jtag (
-        .JTCK    (jtck),
-        .JTDI    (jtdi),
-        .JTDO    (tdo),
-        .JSHIFT  (jshift),
-        .JUPDATE (jupdate),
-        .JRSTN   (jrstn),
-        .JCE     (jce),
-        .JRTI    (jrti)
+    generate
+        if (CHAIN < 1 || CHAIN > 2) begin : g_invalid_chain
+            initial begin
+                $error("jtag_tap_gowin CHAIN must be 1 (ER1) or 2 (ER2)");
+                $finish;
+            end
+        end
+    endgenerate
+
+    GW_JTAG u_jtag (
+        .tck_o                (jtck),
+        .tdi_o                (jtdi),
+        .test_logic_reset_o   (jreset),
+        .run_test_idle_er1_o  (jrti1),
+        .run_test_idle_er2_o  (jrti2),
+        .shift_dr_capture_dr_o(jshift_capture),
+        .pause_dr_o           (jpause),
+        .update_dr_o          (jupdate),
+        .enable_er1_o         (jce1),
+        .enable_er2_o         (jce2),
+        .tdo_er1_i            ((CHAIN == 1) ? tdo : 1'b0),
+        .tdo_er2_i            ((CHAIN == 2) ? tdo : 1'b0)
     );
-
-    // Note: Gowin's JTAG primitive supports a single user DR.
-    // For multi-chain, the user logic must decode the instruction
-    // register (not exposed here for simplicity).  CHAIN > 1 would
-    // require a custom IR decode layer.
 
     assign tck     = jtck;
     assign tdi     = jtdi;
-    assign shift   = jshift;
+    assign shift   = jshift_capture & ~jpause;
     assign update  = jupdate;
-    assign sel     = jce;
+    assign sel     = (CHAIN == 1) ? jce1 : jce2;
 
-    // Derive CAPTURE from CE edge (same approach as ECP5)
+    // GW_JTAG combines CAPTURE-DR and SHIFT-DR into one pulse/level, so
+    // derive the one-cycle capture strobe from the selected chain enable
+    // rising edge.  Gate PAUSE-DR out so a pause/resume sequence cannot
+    // look like a fresh CAPTURE-DR to the register interface.
     reg sel_prev;
     always @(posedge jtck) sel_prev <= sel;
-    assign capture = sel & ~sel_prev & ~jshift;
+    assign capture = sel & ~sel_prev & jshift_capture & ~jpause;
 
 endmodule

--- a/rtl/jtag_tap/jtag_tap_gowin.v
+++ b/rtl/jtag_tap/jtag_tap_gowin.v
@@ -34,6 +34,9 @@ module jtag_tap_gowin #(
 
     generate
         if (CHAIN < 1 || CHAIN > 2) begin : g_invalid_chain
+`ifndef VERILATOR
+            __FCAPZ_GOWIN_CHAIN_MUST_BE_1_OR_2__ u_invalid_chain();
+`endif
             initial begin
                 $error("jtag_tap_gowin CHAIN must be 1 (ER1) or 2 (ER2)");
                 $finish;

--- a/rtl/jtag_tap/jtag_tap_gowin.v
+++ b/rtl/jtag_tap/jtag_tap_gowin.v
@@ -34,6 +34,8 @@ module jtag_tap_gowin #(
 
     generate
         if (CHAIN < 1 || CHAIN > 2) begin : g_invalid_chain
+            // Synthesis/iverilog trip on the unresolved module; Verilator
+            // evaluates the initial $error path during --lint-only.
 `ifndef VERILATOR
             __FCAPZ_GOWIN_CHAIN_MUST_BE_1_OR_2__ u_invalid_chain();
 `endif

--- a/rtl/vhdl/fcapz_eio_gowin.vhd
+++ b/rtl/vhdl/fcapz_eio_gowin.vhd
@@ -19,7 +19,7 @@ entity fcapz_eio_gowin is
     generic (
         IN_W  : positive := 32;
         OUT_W : positive := 32;
-        CHAIN : positive := 3
+        CHAIN : positive := 1
     );
     port (
         probe_in  : in  std_logic_vector(IN_W - 1 downto 0);

--- a/sim/gw_jtag_stub.v
+++ b/sim/gw_jtag_stub.v
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
+
+// Simulation stub for Gowin GW_JTAG primitive.
+// Provides a quiet, inactive TAP for iverilog elaboration/lint.
+`timescale 1ns/1ps
+
+module GW_JTAG (
+    output wire tck_o,
+    output wire tdi_o,
+    output wire test_logic_reset_o,
+    output wire run_test_idle_er1_o,
+    output wire run_test_idle_er2_o,
+    output wire shift_dr_capture_dr_o,
+    output wire pause_dr_o,
+    output wire update_dr_o,
+    output wire enable_er1_o,
+    output wire enable_er2_o,
+    input  wire tdo_er1_i,
+    input  wire tdo_er2_i
+);
+    assign tck_o = 1'b0;
+    assign tdi_o = 1'b0;
+    assign test_logic_reset_o = 1'b0;
+    assign run_test_idle_er1_o = 1'b0;
+    assign run_test_idle_er2_o = 1'b0;
+    assign shift_dr_capture_dr_o = 1'b0;
+    assign pause_dr_o = 1'b0;
+    assign update_dr_o = 1'b0;
+    assign enable_er1_o = 1'b0;
+    assign enable_er2_o = 1'b0;
+
+    wire unused = tdo_er1_i | tdo_er2_i;
+endmodule

--- a/sim/jtagg_stub.v
+++ b/sim/jtagg_stub.v
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
+
+// Simulation stub for Lattice ECP5 JTAGG primitive.
+// Provides a quiet, inactive TAP for RTL elaboration/lint.
+`timescale 1ns/1ps
+
+module JTAGG (
+    output wire JTCK,
+    output wire JTDI,
+    input  wire JTDO1,
+    input  wire JTDO2,
+    output wire JSHIFT,
+    output wire JUPDATE,
+    output wire JRSTN,
+    output wire JCE1,
+    output wire JCE2,
+    output wire JRTI1,
+    output wire JRTI2
+);
+    assign JTCK = 1'b0;
+    assign JTDI = 1'b0;
+    assign JSHIFT = 1'b0;
+    assign JUPDATE = 1'b0;
+    assign JRSTN = 1'b1;
+    assign JCE1 = 1'b0;
+    assign JCE2 = 1'b0;
+    assign JRTI1 = 1'b0;
+    assign JRTI2 = 1'b0;
+
+    wire unused = JTDO1 | JTDO2;
+endmodule

--- a/sim/lint_eio_en_xilinx7.v
+++ b/sim/lint_eio_en_xilinx7.v
@@ -15,6 +15,8 @@ module lint_eio_en_xilinx7 (
     input  wire [3:0]  eio_probe_in,
     output wire [3:0]  eio_probe_out
 );
+    wire armed_out_unused;
+
     fcapz_ela_xilinx7 #(
         .SAMPLE_W   (8),
         .DEPTH      (1024),
@@ -27,6 +29,7 @@ module lint_eio_en_xilinx7 (
         .probe_in      (probe_in),
         .trigger_in    (1'b0),
         .trigger_out   (),
+        .armed_out     (armed_out_unused),
         .eio_probe_in  (eio_probe_in),
         .eio_probe_out (eio_probe_out)
     );

--- a/sim/run_sim.py
+++ b/sim/run_sim.py
@@ -139,6 +139,10 @@ LINT_TARGETS = [
     RTL / "jtag_tap" / "jtag_tap_polarfire.v",
     RTL / "fcapz_ela_polarfire.v",
     RTL / "fcapz_eio_polarfire.v",
+    # Gowin (GW_JTAG) -- requires gw_jtag_stub.
+    RTL / "jtag_tap" / "jtag_tap_gowin.v",
+    RTL / "fcapz_ela_gowin.v",
+    RTL / "fcapz_eio_gowin.v",
     # Harness that instantiates fcapz_ela_xilinx7 with EIO_EN=1 so the
     # g_shared generate branch is elaborated (default EIO_EN=0 lint
     # would dead-code-eliminate it).
@@ -149,6 +153,7 @@ LINT_STUBS = [
     SIM / "bscane2_stub.v",
     SIM / "xpm_fifo_async_stub.v",
     SIM / "ujtag_stub.v",
+    SIM / "gw_jtag_stub.v",
 ]
 
 

--- a/sim/run_verilator_lint.py
+++ b/sim/run_verilator_lint.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
 
-"""Run Verilator lint checks for RTL issues that iverilog can miss.
+"""Run the full-project Verilog RTL matrix through Verilator lint.
 
 The iverilog pass in sim/run_sim.py remains the broad elaboration and
 simulation gate. This script adds Verilator's stricter procedural-driver
-analysis, including MULTIDRIVEN warnings for one reg assigned by more than
-one always block.
+analysis across the project Verilog RTL surface, including MULTIDRIVEN
+warnings for one reg assigned by more than one always block.
 """
 
 from __future__ import annotations
@@ -24,6 +24,61 @@ ROOT = Path(__file__).resolve().parent.parent
 RTL = ROOT / "rtl"
 SIM = ROOT / "sim"
 
+STUBS = (
+    SIM / "bscane2_stub.v",
+    SIM / "xpm_fifo_async_stub.v",
+    SIM / "ujtag_stub.v",
+    SIM / "gw_jtag_stub.v",
+    SIM / "jtagg_stub.v",
+    SIM / "sld_virtual_jtag_stub.v",
+)
+
+ELA_CORE = (
+    RTL / "reset_sync.v",
+    RTL / "dpram.v",
+    RTL / "trig_compare.v",
+    RTL / "fcapz_ela.v",
+)
+
+EIO_CORE = (
+    RTL / "fcapz_eio.v",
+)
+
+EJTAG_AXI_CORE = (
+    RTL / "fcapz_async_fifo.v",
+    RTL / "fcapz_ejtagaxi.v",
+)
+
+EJTAG_UART_CORE = (
+    RTL / "fcapz_async_fifo.v",
+    RTL / "fcapz_ejtaguart.v",
+)
+
+JTAG_REG_SOURCES = (
+    RTL / "reset_sync.v",
+    RTL / "jtag_reg_iface.v",
+)
+
+ELA_WRAPPER_SOURCES = (
+    *ELA_CORE,
+    RTL / "jtag_reg_iface.v",
+    RTL / "jtag_burst_read.v",
+    RTL / "fcapz_eio.v",
+    RTL / "fcapz_regbus_mux.v",
+)
+
+EJTAG_AXI_WRAPPER_SOURCES = (
+    RTL / "reset_sync.v",
+    RTL / "jtag_pipe_iface.v",
+    *EJTAG_AXI_CORE,
+)
+
+EJTAG_UART_WRAPPER_SOURCES = (
+    RTL / "reset_sync.v",
+    RTL / "jtag_pipe_iface.v",
+    *EJTAG_UART_CORE,
+)
+
 
 @dataclass(frozen=True)
 class LintTarget:
@@ -34,13 +89,214 @@ class LintTarget:
 
 TARGETS = (
     LintTarget(
+        name="dpram",
+        top="dpram",
+        sources=(RTL / "dpram.v",),
+    ),
+    LintTarget(
+        name="reset_sync",
+        top="reset_sync",
+        sources=(RTL / "reset_sync.v",),
+    ),
+    LintTarget(
+        name="trig_compare",
+        top="trig_compare",
+        sources=(RTL / "trig_compare.v",),
+    ),
+    LintTarget(
+        name="jtag_reg_iface",
+        top="jtag_reg_iface",
+        sources=(RTL / "jtag_reg_iface.v",),
+    ),
+    LintTarget(
+        name="jtag_burst_read",
+        top="jtag_burst_read",
+        sources=(RTL / "jtag_burst_read.v",),
+    ),
+    LintTarget(
+        name="jtag_pipe_iface",
+        top="jtag_pipe_iface",
+        sources=(RTL / "jtag_pipe_iface.v",),
+    ),
+    LintTarget(
+        name="fcapz_async_fifo",
+        top="fcapz_async_fifo",
+        sources=(SIM / "xpm_fifo_async_stub.v", RTL / "fcapz_async_fifo.v"),
+    ),
+    LintTarget(
+        name="fcapz_regbus_mux",
+        top="fcapz_regbus_mux",
+        sources=(RTL / "fcapz_regbus_mux.v",),
+    ),
+    LintTarget(
         name="fcapz_ela",
         top="fcapz_ela",
+        sources=ELA_CORE,
+    ),
+    LintTarget(
+        name="fcapz_eio",
+        top="fcapz_eio",
+        sources=EIO_CORE,
+    ),
+    LintTarget(
+        name="fcapz_ejtagaxi",
+        top="fcapz_ejtagaxi",
+        sources=EJTAG_AXI_CORE,
+    ),
+    LintTarget(
+        name="fcapz_ejtaguart",
+        top="fcapz_ejtaguart",
+        sources=EJTAG_UART_CORE,
+    ),
+    LintTarget(
+        name="jtag_tap_xilinx7",
+        top="jtag_tap_xilinx7",
+        sources=(SIM / "bscane2_stub.v", RTL / "jtag_tap" / "jtag_tap_xilinx7.v"),
+    ),
+    LintTarget(
+        name="jtag_tap_xilinxus",
+        top="jtag_tap_xilinxus",
+        sources=(SIM / "bscane2_stub.v", RTL / "jtag_tap" / "jtag_tap_xilinxus.v"),
+    ),
+    LintTarget(
+        name="jtag_tap_polarfire",
+        top="jtag_tap_polarfire",
+        sources=(SIM / "ujtag_stub.v", RTL / "jtag_tap" / "jtag_tap_polarfire.v"),
+    ),
+    LintTarget(
+        name="jtag_tap_gowin",
+        top="jtag_tap_gowin",
+        sources=(SIM / "gw_jtag_stub.v", RTL / "jtag_tap" / "jtag_tap_gowin.v"),
+    ),
+    LintTarget(
+        name="jtag_tap_ecp5",
+        top="jtag_tap_ecp5",
+        sources=(SIM / "jtagg_stub.v", RTL / "jtag_tap" / "jtag_tap_ecp5.v"),
+    ),
+    LintTarget(
+        name="jtag_tap_intel",
+        top="jtag_tap_intel",
         sources=(
-            RTL / "reset_sync.v",
-            RTL / "dpram.v",
-            RTL / "trig_compare.v",
-            RTL / "fcapz_ela.v",
+            SIM / "sld_virtual_jtag_stub.v",
+            RTL / "jtag_tap" / "jtag_tap_intel.v",
+        ),
+    ),
+    LintTarget(
+        name="fcapz_ela_xilinx7",
+        top="fcapz_ela_xilinx7",
+        sources=(
+            SIM / "bscane2_stub.v",
+            *ELA_WRAPPER_SOURCES,
+            RTL / "jtag_tap" / "jtag_tap_xilinx7.v",
+            RTL / "fcapz_ela_xilinx7.v",
+        ),
+    ),
+    LintTarget(
+        name="lint_eio_en_xilinx7",
+        top="lint_eio_en_xilinx7",
+        sources=(
+            SIM / "bscane2_stub.v",
+            *ELA_WRAPPER_SOURCES,
+            RTL / "jtag_tap" / "jtag_tap_xilinx7.v",
+            RTL / "fcapz_ela_xilinx7.v",
+            SIM / "lint_eio_en_xilinx7.v",
+        ),
+    ),
+    LintTarget(
+        name="fcapz_eio_xilinx7",
+        top="fcapz_eio_xilinx7",
+        sources=(
+            SIM / "bscane2_stub.v",
+            *JTAG_REG_SOURCES,
+            *EIO_CORE,
+            RTL / "jtag_tap" / "jtag_tap_xilinx7.v",
+            RTL / "fcapz_eio_xilinx7.v",
+        ),
+    ),
+    LintTarget(
+        name="fcapz_ejtagaxi_xilinx7",
+        top="fcapz_ejtagaxi_xilinx7",
+        sources=(
+            SIM / "bscane2_stub.v",
+            SIM / "xpm_fifo_async_stub.v",
+            *EJTAG_AXI_WRAPPER_SOURCES,
+            RTL / "jtag_tap" / "jtag_tap_xilinx7.v",
+            RTL / "fcapz_ejtagaxi_xilinx7.v",
+        ),
+    ),
+    LintTarget(
+        name="fcapz_ejtaguart_xilinx7",
+        top="fcapz_ejtaguart_xilinx7",
+        sources=(
+            SIM / "bscane2_stub.v",
+            SIM / "xpm_fifo_async_stub.v",
+            *EJTAG_UART_WRAPPER_SOURCES,
+            RTL / "jtag_tap" / "jtag_tap_xilinx7.v",
+            RTL / "fcapz_ejtaguart_xilinx7.v",
+        ),
+    ),
+    LintTarget(
+        name="fcapz_ela_xilinxus",
+        top="fcapz_ela_xilinxus",
+        sources=(
+            SIM / "bscane2_stub.v",
+            *ELA_WRAPPER_SOURCES,
+            RTL / "jtag_tap" / "jtag_tap_xilinxus.v",
+            RTL / "fcapz_ela_xilinxus.v",
+        ),
+    ),
+    LintTarget(
+        name="fcapz_eio_xilinxus",
+        top="fcapz_eio_xilinxus",
+        sources=(
+            SIM / "bscane2_stub.v",
+            *JTAG_REG_SOURCES,
+            *EIO_CORE,
+            RTL / "jtag_tap" / "jtag_tap_xilinxus.v",
+            RTL / "fcapz_eio_xilinxus.v",
+        ),
+    ),
+    LintTarget(
+        name="fcapz_ejtagaxi_xilinxus",
+        top="fcapz_ejtagaxi_xilinxus",
+        sources=(
+            SIM / "bscane2_stub.v",
+            SIM / "xpm_fifo_async_stub.v",
+            *EJTAG_AXI_WRAPPER_SOURCES,
+            RTL / "jtag_tap" / "jtag_tap_xilinxus.v",
+            RTL / "fcapz_ejtagaxi_xilinxus.v",
+        ),
+    ),
+    LintTarget(
+        name="fcapz_ejtaguart_xilinxus",
+        top="fcapz_ejtaguart_xilinxus",
+        sources=(
+            SIM / "bscane2_stub.v",
+            SIM / "xpm_fifo_async_stub.v",
+            *EJTAG_UART_WRAPPER_SOURCES,
+            RTL / "jtag_tap" / "jtag_tap_xilinxus.v",
+            RTL / "fcapz_ejtaguart_xilinxus.v",
+        ),
+    ),
+    LintTarget(
+        name="fcapz_ela_polarfire",
+        top="fcapz_ela_polarfire",
+        sources=(
+            SIM / "ujtag_stub.v",
+            *ELA_WRAPPER_SOURCES,
+            RTL / "jtag_tap" / "jtag_tap_polarfire.v",
+            RTL / "fcapz_ela_polarfire.v",
+        ),
+    ),
+    LintTarget(
+        name="fcapz_eio_polarfire",
+        top="fcapz_eio_polarfire",
+        sources=(
+            SIM / "ujtag_stub.v",
+            *JTAG_REG_SOURCES,
+            *EIO_CORE,
+            RTL / "jtag_tap" / "jtag_tap_polarfire.v",
+            RTL / "fcapz_eio_polarfire.v",
         ),
     ),
     LintTarget(
@@ -72,6 +328,72 @@ TARGETS = (
             RTL / "fcapz_eio_gowin.v",
         ),
     ),
+    LintTarget(
+        name="fcapz_ela_ecp5",
+        top="fcapz_ela_ecp5",
+        sources=(
+            SIM / "jtagg_stub.v",
+            *ELA_WRAPPER_SOURCES,
+            RTL / "jtag_tap" / "jtag_tap_ecp5.v",
+            RTL / "fcapz_ela_ecp5.v",
+        ),
+    ),
+    LintTarget(
+        name="fcapz_eio_ecp5",
+        top="fcapz_eio_ecp5",
+        sources=(
+            SIM / "jtagg_stub.v",
+            *JTAG_REG_SOURCES,
+            *EIO_CORE,
+            RTL / "jtag_tap" / "jtag_tap_ecp5.v",
+            RTL / "fcapz_eio_ecp5.v",
+        ),
+    ),
+    LintTarget(
+        name="fcapz_ela_intel",
+        top="fcapz_ela_intel",
+        sources=(
+            SIM / "sld_virtual_jtag_stub.v",
+            *ELA_CORE,
+            RTL / "jtag_reg_iface.v",
+            RTL / "jtag_burst_read.v",
+            RTL / "jtag_tap" / "jtag_tap_intel.v",
+            RTL / "fcapz_ela_intel.v",
+        ),
+    ),
+    LintTarget(
+        name="fcapz_eio_intel",
+        top="fcapz_eio_intel",
+        sources=(
+            SIM / "sld_virtual_jtag_stub.v",
+            *JTAG_REG_SOURCES,
+            *EIO_CORE,
+            RTL / "jtag_tap" / "jtag_tap_intel.v",
+            RTL / "fcapz_eio_intel.v",
+        ),
+    ),
+    LintTarget(
+        name="fcapz_ejtagaxi_intel",
+        top="fcapz_ejtagaxi_intel",
+        sources=(
+            SIM / "sld_virtual_jtag_stub.v",
+            SIM / "xpm_fifo_async_stub.v",
+            *EJTAG_AXI_WRAPPER_SOURCES,
+            RTL / "jtag_tap" / "jtag_tap_intel.v",
+            RTL / "fcapz_ejtagaxi_intel.v",
+        ),
+    ),
+    LintTarget(
+        name="fcapz_ejtaguart_intel",
+        top="fcapz_ejtaguart_intel",
+        sources=(
+            SIM / "sld_virtual_jtag_stub.v",
+            SIM / "xpm_fifo_async_stub.v",
+            *EJTAG_UART_WRAPPER_SOURCES,
+            RTL / "jtag_tap" / "jtag_tap_intel.v",
+            RTL / "fcapz_ejtaguart_intel.v",
+        ),
+    ),
 )
 
 COMMON_FLAGS = (
@@ -85,6 +407,9 @@ COMMON_FLAGS = (
     "-Wno-WIDTHEXPAND",
     "-Wno-UNSIGNED",
     "-Wno-BLKSEQ",
+    "-Wno-PINCONNECTEMPTY",
+    "-Wno-UNUSEDPARAM",
+    "-Wno-SYNCASYNCNET",
 )
 
 

--- a/sim/run_verilator_lint.py
+++ b/sim/run_verilator_lint.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
+
+"""Run Verilator lint checks for RTL issues that iverilog can miss.
+
+The iverilog pass in sim/run_sim.py remains the broad elaboration and
+simulation gate. This script adds Verilator's stricter procedural-driver
+analysis, including MULTIDRIVEN warnings for one reg assigned by more than
+one always block.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+RTL = ROOT / "rtl"
+SIM = ROOT / "sim"
+
+
+@dataclass(frozen=True)
+class LintTarget:
+    name: str
+    top: str
+    sources: tuple[Path, ...]
+
+
+TARGETS = (
+    LintTarget(
+        name="fcapz_ela",
+        top="fcapz_ela",
+        sources=(
+            RTL / "reset_sync.v",
+            RTL / "dpram.v",
+            RTL / "trig_compare.v",
+            RTL / "fcapz_ela.v",
+        ),
+    ),
+    LintTarget(
+        name="fcapz_ela_gowin",
+        top="fcapz_ela_gowin",
+        sources=(
+            SIM / "gw_jtag_stub.v",
+            RTL / "reset_sync.v",
+            RTL / "dpram.v",
+            RTL / "trig_compare.v",
+            RTL / "fcapz_ela.v",
+            RTL / "jtag_reg_iface.v",
+            RTL / "jtag_burst_read.v",
+            RTL / "fcapz_eio.v",
+            RTL / "fcapz_regbus_mux.v",
+            RTL / "jtag_tap" / "jtag_tap_gowin.v",
+            RTL / "fcapz_ela_gowin.v",
+        ),
+    ),
+    LintTarget(
+        name="fcapz_eio_gowin",
+        top="fcapz_eio_gowin",
+        sources=(
+            SIM / "gw_jtag_stub.v",
+            RTL / "reset_sync.v",
+            RTL / "jtag_reg_iface.v",
+            RTL / "fcapz_eio.v",
+            RTL / "jtag_tap" / "jtag_tap_gowin.v",
+            RTL / "fcapz_eio_gowin.v",
+        ),
+    ),
+)
+
+COMMON_FLAGS = (
+    "--lint-only",
+    "-Wall",
+    "-Wno-DECLFILENAME",
+    "-Wno-GENUNNAMED",
+    "-Wno-UNUSEDSIGNAL",
+    "-Wno-UNDRIVEN",
+    "-Wno-WIDTHTRUNC",
+    "-Wno-WIDTHEXPAND",
+    "-Wno-UNSIGNED",
+    "-Wno-BLKSEQ",
+)
+
+
+def run_cmd(cmd: list[str], label: str, *, expect_ok: bool = True) -> bool:
+    print(f"[verilator] {label}: {' '.join(cmd)}", flush=True)
+    result = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True)
+    output = result.stdout + result.stderr
+    if output:
+        print(output, end="" if output.endswith("\n") else "\n")
+
+    ok = result.returncode == 0
+    if ok != expect_ok:
+        expectation = "succeed" if expect_ok else "fail"
+        print(f"[verilator] FAILED: expected {label} to {expectation}")
+        return False
+    return True
+
+
+def command_for(target: LintTarget) -> list[str]:
+    return [
+        "verilator",
+        *COMMON_FLAGS,
+        "-I" + str(RTL),
+        "-I" + str(RTL / "jtag_tap"),
+        "--top-module",
+        target.top,
+        *[str(src) for src in target.sources],
+    ]
+
+
+def run_lint() -> bool:
+    ok = True
+    for target in TARGETS:
+        if not run_cmd(command_for(target), f"lint {target.name}"):
+            ok = False
+    return ok
+
+
+def run_self_test() -> bool:
+    bad = LintTarget(
+        name="verilator_multidriven_bad",
+        top="verilator_multidriven_bad",
+        sources=(SIM / "verilator_multidriven_bad.v",),
+    )
+    cmd = command_for(bad)
+    print(f"[verilator] self-test: {' '.join(cmd)}", flush=True)
+    result = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True)
+    output = result.stdout + result.stderr
+    if output:
+        print(output, end="" if output.endswith("\n") else "\n")
+    if result.returncode == 0 or "MULTIDRIVEN" not in output:
+        print("[verilator] FAILED: self-test did not trip MULTIDRIVEN")
+        return False
+    return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="also prove Verilator fails an intentional MULTIDRIVEN fixture",
+    )
+    args = parser.parse_args()
+
+    if shutil.which("verilator") is None:
+        print("verilator not found on PATH", file=sys.stderr)
+        sys.exit(127)
+
+    ok = run_lint()
+    if args.self_test:
+        ok = run_self_test() and ok
+
+    if not ok:
+        sys.exit(1)
+    suffix = " and MULTIDRIVEN self-test" if args.self_test else ""
+    print(f"Verilator RTL lint passed for {len(TARGETS)} target(s){suffix}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/sim/run_verilator_lint.py
+++ b/sim/run_verilator_lint.py
@@ -13,6 +13,7 @@ one always block.
 from __future__ import annotations
 
 import argparse
+import re
 import shutil
 import subprocess
 import sys
@@ -87,6 +88,38 @@ COMMON_FLAGS = (
 )
 
 
+def verilator_version() -> tuple[int, int] | None:
+    result = subprocess.run(
+        ["verilator", "--version"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return None
+
+    match = re.search(r"Verilator\s+(\d+)\.(\d+)", result.stdout + result.stderr)
+    if not match:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+def check_verilator_version() -> bool:
+    version = verilator_version()
+    if version is None:
+        print("could not determine Verilator version", file=sys.stderr)
+        return False
+    if version < (5, 0):
+        major, minor = version
+        print(
+            "Verilator 5.0 or newer is required for this lint flag set "
+            f"(found {major}.{minor})",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
 def run_cmd(cmd: list[str], label: str, *, expect_ok: bool = True) -> bool:
     print(f"[verilator] {label}: {' '.join(cmd)}", flush=True)
     result = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True)
@@ -134,7 +167,11 @@ def run_self_test() -> bool:
     output = result.stdout + result.stderr
     if output:
         print(output, end="" if output.endswith("\n") else "\n")
-    if result.returncode == 0 or "MULTIDRIVEN" not in output:
+    saw_driver_warning = (
+        "MULTIDRIVEN" in output
+        or ("%Warning-" in output and "multiple driving" in output and "'q'" in output)
+    )
+    if result.returncode == 0 or not saw_driver_warning:
         print("[verilator] FAILED: self-test did not trip MULTIDRIVEN")
         return False
     return True
@@ -152,6 +189,8 @@ def main() -> None:
     if shutil.which("verilator") is None:
         print("verilator not found on PATH", file=sys.stderr)
         sys.exit(127)
+    if not check_verilator_version():
+        sys.exit(2)
 
     ok = run_lint()
     if args.self_test:

--- a/sim/sld_virtual_jtag_stub.v
+++ b/sim/sld_virtual_jtag_stub.v
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
+
+// Simulation stub for Intel/Altera sld_virtual_jtag.
+// Provides a quiet, inactive TAP for RTL elaboration/lint.
+`timescale 1ns/1ps
+
+module sld_virtual_jtag #(
+    parameter sld_auto_instance_index = "NO",
+    parameter integer sld_instance_index = 1,
+    parameter integer sld_ir_width = 1
+) (
+    output wire tck,
+    output wire tdi,
+    input  wire tdo,
+    output wire virtual_state_cdr,
+    output wire virtual_state_sdr,
+    output wire virtual_state_udr,
+    output wire [sld_ir_width-1:0] ir_in,
+    input  wire [sld_ir_width-1:0] ir_out
+);
+    assign tck = 1'b0;
+    assign tdi = 1'b0;
+    assign virtual_state_cdr = 1'b0;
+    assign virtual_state_sdr = 1'b0;
+    assign virtual_state_udr = 1'b0;
+    assign ir_in = {sld_ir_width{1'b0}};
+
+    wire unused = tdo | ^ir_out;
+endmodule

--- a/sim/verilator_multidriven_bad.v
+++ b/sim/verilator_multidriven_bad.v
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Deliberately bad RTL used by sim/run_verilator_lint.py --self-test.
+// The Verilator run must reject this with %Warning-MULTIDRIVEN; if it does not,
+// the lint gate is no longer proving the bug class that escaped iverilog.
+
+module verilator_multidriven_bad (
+    input  wire clk_a,
+    input  wire clk_b,
+    input  wire rst,
+    output reg  q
+);
+    always @(posedge clk_a or posedge rst) begin
+        if (rst)
+            q <= 1'b0;
+        else
+            q <= 1'b1;
+    end
+
+    always @(posedge clk_b or posedge rst) begin
+        if (rst)
+            q <= 1'b0;
+        else
+            q <= 1'b0;
+    end
+endmodule

--- a/tests/test_cli_rpc_events.py
+++ b/tests/test_cli_rpc_events.py
@@ -20,6 +20,7 @@ from fcapz.analyzer import (
 from fcapz.cli import (
     _build_config,
     _chain_shape_kwargs,
+    _make_transport,
     _non_negative_int,
     _parse_trigger_sequence,
     _positive_float,
@@ -28,7 +29,7 @@ from fcapz.cli import (
     _uint16,
     build_parser,
 )
-from fcapz.transport import XilinxHwServerTransport
+from fcapz.transport import OpenOcdTransport, XilinxHwServerTransport
 from fcapz.events import (
     ProbeDefinition,
     find_bursts,
@@ -651,6 +652,43 @@ class ChainShapeKwargsTests(unittest.TestCase):
         self.assertTrue(t.use_register_ir)
         # In register mode, dr_extra_bits is forced to 0 (xsdb handles bypass).
         self.assertEqual(t.dr_extra_bits, 0)
+
+
+class MakeTransportTests(unittest.TestCase):
+    """CLI transport construction convenience."""
+
+    def test_openocd_gowin_tap_uses_gowin_ir_table(self):
+        args = argparse.Namespace(
+            backend="openocd",
+            host="127.0.0.1",
+            port=6666,
+            tap="GW1NR-9C.tap",
+        )
+        t = _make_transport(args)
+        self.assertIsInstance(t, OpenOcdTransport)
+        self.assertEqual(t.ir_table, OpenOcdTransport.IR_TABLE_GOWIN)
+
+    def test_openocd_future_gowin_tap_uses_gowin_ir_table(self):
+        args = argparse.Namespace(
+            backend="openocd",
+            host="127.0.0.1",
+            port=6666,
+            tap="GW5A-25.tap",
+        )
+        t = _make_transport(args)
+        self.assertIsInstance(t, OpenOcdTransport)
+        self.assertEqual(t.ir_table, OpenOcdTransport.IR_TABLE_GOWIN)
+
+    def test_openocd_xilinx_tap_keeps_default_ir_table(self):
+        args = argparse.Namespace(
+            backend="openocd",
+            host="127.0.0.1",
+            port=6666,
+            tap="xc7a100t.tap",
+        )
+        t = _make_transport(args)
+        self.assertIsInstance(t, OpenOcdTransport)
+        self.assertEqual(t.ir_table, OpenOcdTransport.IR_TABLE_XILINX7)
 
 
 if __name__ == "__main__":

--- a/tests/test_ela_bug_probe_rtl.py
+++ b/tests/test_ela_bug_probe_rtl.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 import tempfile
@@ -15,6 +16,17 @@ ROOT = Path(__file__).resolve().parent.parent
 @unittest.skipUnless(shutil.which("iverilog"), "iverilog not on PATH")
 @unittest.skipUnless(shutil.which("vvp"), "vvp not on PATH")
 class ElaBugProbeRtlTests(unittest.TestCase):
+    def test_trig_holdoff_has_single_procedural_driver_region(self):
+        """Synthesis rejects trig_holdoff when it is assigned in two always blocks."""
+        rtl = (ROOT / "rtl" / "fcapz_ela.v").read_text()
+        blocks = re.split(r"\n\s*always\s*@", rtl)
+        driver_blocks = [
+            block
+            for block in blocks
+            if re.search(r"(?<![A-Za-z0-9_])trig_holdoff\s*<=", block)
+        ]
+        self.assertEqual(len(driver_blocks), 1)
+
     def test_focused_ela_regressions(self):
         with tempfile.TemporaryDirectory(prefix="ela-bug-probe-") as tmpdir:
             vvp = Path(tmpdir) / "fcapz_ela_bug_probe_tb.vvp"

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -274,6 +274,17 @@ class OpenOcdConnectFailureTests(unittest.TestCase):
         self.assertTrue(any("irscan" in c for c in cmds))
         self.assertFalse(any("runtest" in c for c in cmds))
 
+    def test_drscan_non_hex_response_raises_runtime_error(self):
+        """OpenOCD errors should not leak raw int(..., 16) ValueError text."""
+        t = OpenOcdTransport(tap="GW1NR-9C.tap")
+        t._cmd = MagicMock(return_value="Tap 'GW1NR-9C.tap' not found")  # type: ignore[method-assign]
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"OpenOCD drscan failed.*GW1NR-9C\.tap.*Tap 'GW1NR-9C\.tap' not found",
+        ):
+            t.raw_dr_scan(0, 49)
+
 
 # ---------------------------------------------------------------------------
 # XilinxHwServerTransport failure modes

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -228,6 +228,11 @@ class OpenOcdConnectFailureTests(unittest.TestCase):
         self.assertEqual(t.ir_table[3], 0x26)  # USER3
         self.assertEqual(t.ir_table[4], 0x27)  # USER4
 
+    def test_ir_table_gowin_preset(self):
+        """Gowin GW_JTAG ER1/ER2 have their own IR opcodes."""
+        t = OpenOcdTransport(ir_table=OpenOcdTransport.IR_TABLE_GOWIN)
+        self.assertEqual(t.ir_table, {1: 0x42, 2: 0x43})
+
     def test_ir_table_alias(self):
         """IR_TABLE_US is the same dict as IR_TABLE_XILINX_ULTRASCALE."""
         self.assertIs(


### PR DESCRIPTION
## Summary

Fixes Gowin JTAG TAP support, improves OpenOCD error reporting, fixes an RTL multi-driver bug, and adds full-project Verilog RTL driver linting with Verilator.

The Verilator job is now a full RTL matrix, not just a targeted Gowin/ELA check. It also includes a deliberate `MULTIDRIVEN` self-test so CI proves the escaped bug class is actually caught.

## Changes

- Replace the incorrect Gowin JTAG primitive wrapper with `GW_JTAG` wiring.
- Add Gowin simulation stub and include Gowin wrappers in RTL lint coverage.
- Add Gowin IR table support in the host transport and auto-select it for `GW*` taps.
- Clarify docs: Gowin has one `GW_JTAG` primitive per design; ELA+EIO should use `EIO_EN=1` unless the wrapper is refactored around a shared primitive.
- Guard invalid Gowin `CHAIN` values, including a synthesis/elaboration tripwire for non-Verilator tools.
- Fix OpenOCD non-hex `drscan` responses to produce useful transport errors.
- Fix `trig_holdoff` so the sample-domain register has a single procedural driver.
- Add `sim/run_verilator_lint.py` with a full-project Verilog RTL matrix.
- Add Verilator primitive stubs for:
  - Xilinx `BSCANE2`
  - Xilinx `xpm_fifo_async`
  - Microchip `UJTAG`
  - Gowin `GW_JTAG`
  - Lattice ECP5 `JTAGG`
  - Intel/Altera `sld_virtual_jtag`
- Include the `EIO_EN=1` Xilinx harness in Verilator lint so the shared ELA+EIO generate branch is checked.
- Add a deliberate `MULTIDRIVEN` self-test fixture so CI proves Verilator catches one reg driven by multiple always blocks.
- Add a `lint-rtl-verilator` CI job pinned to `ubuntu-24.04`.
- Add a Verilator >= 5.0 version check for local runs.
- Fix stale wrapper-port drift found by the expanded matrix:
  - ECP5/Intel/PolarFire ELA wrappers now wire `trigger_in`, `trigger_out`, and `armed_out`.
  - ECP5/PolarFire shared EIO mux paths now wire unused `b_rd_en`.
  - EJTAG UART FIFO instances now wire reset-busy outputs explicitly.

## Verification

- `python3 sim/run_verilator_lint.py --self-test`
  - Passes locally via WSL.
  - Covers 37 Verilator targets plus the intentional `MULTIDRIVEN` self-test.
- `python sim/run_sim.py --lint-only`
  - Passes 27 Icarus elaboration targets.
- `python -m pytest tests\test_transport.py tests\test_ela_bug_probe_rtl.py -q`
  - 68 passed.
- `python -m pytest tests\test_ela_bug_probe_rtl.py tests\test_ejtaguart_rtl.py tests\test_ejtaguart.py -q`
  - 26 passed.
- `python -m ruff check sim\run_verilator_lint.py tests\test_transport.py tests\test_ela_bug_probe_rtl.py`
  - Passes.
- Direct invalid Gowin `CHAIN=3` elaboration fails on the guard module as intended.
