### PR TITLE
Fix EJTAG UART plain Verilog lint compatibility

### DIFF
--- a/rtl/fcapz_ejtaguart.v
+++ b/rtl/fcapz_ejtaguart.v
@@ -65,6 +65,13 @@ module fcapz_ejtaguart #(
             BAUD_RATE_too_high_for_CLK_HZ _baud_check_FAILED();
     endgenerate
 
+    // Simulation-only baud error check scratch registers.  Keep these outside
+    // the unnamed initial block so strict Verilog parsers do not require
+    // SystemVerilog block declarations.
+    integer baud_check_div;
+    integer baud_check_actual;
+    integer baud_check_err;
+
     // Simulation-friendly versions of the same checks.
     initial begin
         if (TX_FIFO_DEPTH & (TX_FIFO_DEPTH - 1))
@@ -75,16 +82,14 @@ module fcapz_ejtaguart #(
             $error("BAUD_RATE too high for CLK_HZ: divider must be >= 4");
         // Check realized baud error: |actual_baud - BAUD_RATE| / BAUD_RATE
         // actual_baud = CLK_HZ / divider, divider = CLK_HZ / BAUD_RATE
-        begin
-            integer div, actual, err;
-            div    = CLK_HZ / BAUD_RATE;
-            actual = CLK_HZ / div;
-            err    = (actual > BAUD_RATE) ? actual - BAUD_RATE
-                                          : BAUD_RATE - actual;
-            if (err * 100 / BAUD_RATE > 3)
-                $warning("Baud rate error > 3%%: CLK_HZ=%0d BAUD_RATE=%0d divider=%0d actual=%0d",
-                         CLK_HZ, BAUD_RATE, div, actual);
-        end
+        baud_check_div    = CLK_HZ / BAUD_RATE;
+        baud_check_actual = CLK_HZ / baud_check_div;
+        baud_check_err    = (baud_check_actual > BAUD_RATE)
+                            ? baud_check_actual - BAUD_RATE
+                            : BAUD_RATE - baud_check_actual;
+        if (baud_check_err * 100 / BAUD_RATE > 3)
+            $warning("Baud rate error > 3%%: CLK_HZ=%0d BAUD_RATE=%0d divider=%0d actual=%0d",
+                     CLK_HZ, BAUD_RATE, baud_check_div, baud_check_actual);
     end
 
     // ---- Constants -----------------------------------------------------------

--- a/sim/run_sim.py
+++ b/sim/run_sim.py
@@ -206,7 +206,7 @@ def run_rtl_lint() -> bool:
     common = [
         "iverilog",
         "-Wall",
-        "-g2012",
+        "-g2001",
         "-I",
         str(RTL),
         "-y",


### PR DESCRIPTION
## Summary

- Move EJTAG UART baud-check scratch declarations out of an unnamed procedural block so the RTL parses as plain Verilog.
- Change the RTL lint pass from `iverilog -g2012` to `iverilog -g2001` so CI catches SystemVerilog-only constructs in `.v` files.

## Validation

- `python tools\sync_version.py --check`
- `ruff check .`
- `fcapz --help`
- `python sim\run_sim.py --lint-only`
- `python sim\run_sim.py`
- `python -m pytest tests\ -v --tb=short`
- `wsl -e bash -lc "cd /mnt/c/Projects/fpgacapZero && python3 sim/run_verilator_lint.py --self-test"`

Verilator lint passed for 37 RTL targets and confirmed the intentional `MULTIDRIVEN` self-test.
