### PR TITLE
Add cocotb regression and Verilator ELA coverage runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,9 +126,9 @@ jobs:
       - name: Run Verilator lint and MULTIDRIVEN self-test
         run: python sim/run_verilator_lint.py --self-test
 
-  # -- 6. RTL simulation (iverilog + vvp) ---------------------------
+  # -- 6. RTL simulation (cocotb + Icarus) --------------------------
   sim:
-    name: RTL simulation (iverilog + vvp)
+    name: RTL simulation (cocotb + Icarus)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -137,5 +137,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Run all RTL testbenches
-        run: python sim/run_sim.py
+      - name: Install cocotb dependencies
+        run: pip install -e ".[hdl]"
+      - name: Run cocotb RTL regression
+        run: python sim/run_cocotb.py --runner native --clean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,9 +127,15 @@ jobs:
         run: python sim/run_verilator_lint.py --self-test
 
   # -- 6. RTL simulation (cocotb + Icarus) --------------------------
+  # Sharded so the 16-target ELA suite runs in parallel with the protocol
+  # benches; cuts wall-clock at the cost of one extra job slot.
   sim:
-    name: RTL simulation (cocotb + Icarus)
+    name: RTL simulation (cocotb + Icarus) [${{ matrix.shard }}]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [protocol, ela]
     steps:
       - uses: actions/checkout@v4
       - name: Install iverilog
@@ -137,7 +143,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - name: Install cocotb dependencies
         run: pip install -e ".[hdl]"
-      - name: Run cocotb RTL regression
-        run: python sim/run_cocotb.py --runner native --clean
+      - name: Run cocotb RTL regression (protocol shard)
+        if: matrix.shard == 'protocol'
+        run: python sim/run_cocotb.py --runner native --clean --skip-ela
+      - name: Run cocotb RTL regression (ELA shard)
+        if: matrix.shard == 'ela'
+        run: python sim/run_cocotb.py --runner native --clean ela

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dfx_runtime.txt
 # Build artifacts
 dist/
 packages/
+build/verilator_ela_coverage/
 *.bit
 *.bin
 !host/fcapz/gui/assets/default_window_state_v6.bin

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ Thumbs.db
 tests/_tmp/
 .codex_pytest_tmp*/
 .claude/
+
+# Local-only working notes (per PROJECTS.md no_commit/ convention)
+no_commit/

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dfx_runtime.txt
 # Build artifacts
 dist/
 packages/
+build/cocotb_ela/
 build/verilator_ela_coverage/
 *.bit
 *.bin
@@ -24,6 +25,8 @@ build/verilator_ela_coverage/
 # Simulation artifacts
 sim/*.vvp
 sim/*.vcd
+sim/ghdl/
+work-obj*.cf
 
 # OS
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dfx_runtime.txt
 dist/
 packages/
 build/cocotb_ela/
+build/cocotb/
 build/verilator_ela_coverage/
 *.bit
 *.bin

--- a/README.md
+++ b/README.md
@@ -124,14 +124,14 @@ and readback behavior without switching cores.
 ### Developer quick start
 
 ```bash
-pip install -e ".[dev]"
+pip install -e ".[dev,hdl]"
 pytest tests/ -v
-python sim/run_sim.py
+python sim/run_cocotb.py --runner native --clean
 ```
 
-`python sim/run_sim.py` runs the shared RTL lint pass (`iverilog -Wall`)
-first, then the default simulation regression.  Use
-`python sim/run_sim.py --lint-only` when you only want the RTL lint check.
+`python sim/run_cocotb.py --runner native --clean` runs the default cocotb RTL
+simulation regression. Use `python sim/run_sim.py --lint-only` when you only
+want the shared RTL lint check (`iverilog -Wall`).
 Run `python sim/run_verilator_lint.py --self-test` when changing RTL; it runs
 the full Verilog RTL matrix through Verilator driver lint for issues such as
 one register assigned from two always blocks.
@@ -702,7 +702,7 @@ GitHub Actions runs on every push and pull request to `main` or `master`:
 | `test-host` | `pytest tests/ -v --tb=short` with the default `not hw` marker filter, plus an explicit JTAG readback pipeline regression for burst and timestamp stabilization paths |
 | `lint-rtl` | `python sim/run_sim.py --lint-only` — shared `iverilog -Wall` elaboration for the core RTL, vendor wrappers, and simulation stubs |
 | `lint-rtl-verilator` | `python sim/run_verilator_lint.py --self-test` -- full-project Verilog RTL driver lint plus an intentional `MULTIDRIVEN` fixture proving the gate catches one reg driven by multiple always blocks |
-| `sim` | `python sim/run_sim.py` — runs the same `iverilog -Wall` lint pass, then the default RTL regression: ELA behavior, ELA focused regressions, ELA configuration matrix, burst readout, single-chain pipe readout, EIO, core manager, and channel mux testbenches |
+| `sim` | `python sim/run_cocotb.py --runner native --clean` — runs the cocotb RTL regression, including the ELA suite and cocotb replacements for the former Verilog/SystemVerilog testbenches |
 
 Hardware integration tests run manually (require physical Arty A7-100T + hw_server).
 Optional **GUI + hardware** checks in `tests/test_gui_hw_capture.py` are

--- a/README.md
+++ b/README.md
@@ -702,7 +702,7 @@ GitHub Actions runs on every push and pull request to `main` or `master`:
 | `test-host` | `pytest tests/ -v --tb=short` with the default `not hw` marker filter, plus an explicit JTAG readback pipeline regression for burst and timestamp stabilization paths |
 | `lint-rtl` | `python sim/run_sim.py --lint-only` — shared `iverilog -Wall` elaboration for the core RTL, vendor wrappers, and simulation stubs |
 | `lint-rtl-verilator` | `python sim/run_verilator_lint.py --self-test` -- full-project Verilog RTL driver lint plus an intentional `MULTIDRIVEN` fixture proving the gate catches one reg driven by multiple always blocks |
-| `sim` | `python sim/run_cocotb.py --runner native --clean` — runs the cocotb RTL regression, including the ELA suite and cocotb replacements for the former Verilog/SystemVerilog testbenches |
+| `sim` (matrix: `protocol`, `ela`) | sharded cocotb RTL regression on Icarus, with `iverilog -Wall` enabled per bench and a `pyproject.toml`-keyed pip cache. The `protocol` shard runs `python sim/run_cocotb.py --runner native --clean --skip-ela` (trig compare, JTAG pipe/burst, EIO, core manager, channel mux, Xilinx7 single-chain wrapper, async-FIFO equivalence, EJTAG-AXI, EJTAG-AXI reset regression, EJTAG-UART). The `ela` shard runs `python sim/run_cocotb.py --runner native --clean ela` and exercises the 16-target cocotb ELA suite. |
 
 Hardware integration tests run manually (require physical Arty A7-100T + hw_server).
 Optional **GUI + hardware** checks in `tests/test_gui_hw_capture.py` are

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ first, then the default simulation regression.  Use
 Run `python sim/run_verilator_lint.py --self-test` when changing RTL; it runs
 the full Verilog RTL matrix through Verilator driver lint for issues such as
 one register assigned from two always blocks.
+Run `python sim/run_verilator_ela_coverage.py --runner wsl` when changing ELA
+behavior and you want Verilator simulation plus merged line/toggle and bound
+functional coverage for the Verilog ELA benches.
 
 Use the installed `fcapz` entry point for day-to-day ELA work. The legacy
 `python -m fcapz.cli` form still works, but the package install path is
@@ -727,6 +730,7 @@ Produces `examples/arty_a7/arty_a7_top.bit`.
 python sim/run_sim.py
 python sim/run_sim.py --lint-only
 python sim/run_verilator_lint.py --self-test
+python sim/run_verilator_ela_coverage.py --runner wsl
 ```
 
 The default command runs `iverilog -Wall` lint before compiling and running
@@ -738,6 +742,15 @@ list. The Verilator lint command complements that broad elaboration pass with
 a full-project Verilog RTL matrix and stricter procedural-driver checks; its
 self-test must fail a deliberately bad multi-driver fixture before the job is
 considered valid.
+
+The Verilator ELA coverage command builds and runs `fcapz_ela`,
+`fcapz_ela_bug_probe`, and `fcapz_ela_config_matrix` as Verilator simulations.
+It writes merged coverage to `build/verilator_ela_coverage/merged.dat` and
+annotated source under `build/verilator_ela_coverage/annotated/`. The runner
+also binds `tb/fcapz_ela_func_cov.sv` into each `fcapz_ela` instance so
+`--coverage-user` records functional events such as arm/reset, trigger commit,
+pre/post stores, overflow, segment completion, burst starts, and optional
+feature register activity.
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ one register assigned from two always blocks.
 Run `python sim/run_verilator_ela_coverage.py --runner wsl` when changing ELA
 behavior and you want Verilator simulation plus merged line/toggle and bound
 functional coverage for the Verilog ELA benches.
+Run `python sim/run_cocotb_ela.py --runner wsl --hdl verilog` to execute the
+shared cocotb ELA core stimulus. The same Python tests can target a VHDL ELA
+core with `--hdl vhdl --vhdl-source <file>` when a VHDL core implementation is
+available.
 
 Use the installed `fcapz` entry point for day-to-day ELA work. The legacy
 `python -m fcapz.cli` form still works, but the package install path is
@@ -731,6 +735,7 @@ python sim/run_sim.py
 python sim/run_sim.py --lint-only
 python sim/run_verilator_lint.py --self-test
 python sim/run_verilator_ela_coverage.py --runner wsl
+python sim/run_cocotb_ela.py --runner wsl --hdl verilog
 ```
 
 The default command runs `iverilog -Wall` lint before compiling and running
@@ -751,6 +756,14 @@ also binds `tb/fcapz_ela_func_cov.sv` into each `fcapz_ela` instance so
 `--coverage-user` records functional events such as arm/reset, trigger commit,
 pre/post stores, overflow, segment completion, burst starts, and optional
 feature register activity.
+
+The cocotb ELA command runs shared Python stimulus and scoreboarding directly
+against an HDL `fcapz_ela` top. It defaults to Icarus for Verilog and GHDL for
+VHDL, relaunching through WSL when requested. The Verilog target uses the same
+core sources as the SystemVerilog benches; the VHDL target expects a VHDL core
+source passed with `--vhdl-source` unless `rtl/vhdl/core/fcapz_ela.vhd` exists.
+It writes a small language-agnostic functional coverage JSON report under
+`build/cocotb_ela/`.
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -734,6 +734,7 @@ Produces `examples/arty_a7/arty_a7_top.bit`.
 python sim/run_sim.py
 python sim/run_sim.py --lint-only
 python sim/run_verilator_lint.py --self-test
+python sim/run_cocotb.py --runner wsl
 python sim/run_verilator_ela_coverage.py --runner wsl
 python sim/run_cocotb_ela.py --runner wsl --hdl verilog
 ```
@@ -764,6 +765,12 @@ core sources as the SystemVerilog benches; the VHDL target expects a VHDL core
 source passed with `--vhdl-source` unless `rtl/vhdl/core/fcapz_ela.vhd` exists.
 It writes a small language-agnostic functional coverage JSON report under
 `build/cocotb_ela/`.
+
+The general cocotb command runs the non-ELA cocotb replacements for the RTL
+simulation benches (`trig_compare`, JTAG pipe/burst, EIO, core manager,
+channel mux, Xilinx7 single-chain wrapper, async FIFO equivalence, EJTAG-AXI,
+EJTAG-AXI reset regression, and EJTAG-UART), and then runs the ELA cocotb suite
+unless `--skip-ela` is passed.
 
 ### Tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ include = ["fcapz*"]
 dev = ["pytest>=7.0", "pytest-qt>=4.2", "ruff>=0.4.0"]
 gui = ["PySide6>=6.6", "pyqtgraph>=0.13"]
 gui-preview = ["fpgacapzero[gui]"]
+hdl = ["cocotb>=1.9"]
 litex = ["litex"]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ include = ["fcapz*"]
 dev = ["pytest>=7.0", "pytest-qt>=4.2", "ruff>=0.4.0"]
 gui = ["PySide6>=6.6", "pyqtgraph>=0.13"]
 gui-preview = ["fpgacapzero[gui]"]
-hdl = ["cocotb>=1.9"]
+hdl = ["cocotb>=1.9,<2"]
 litex = ["litex"]
 
 [tool.pytest.ini_options]

--- a/rtl/fcapz_ela.v
+++ b/rtl/fcapz_ela.v
@@ -1474,7 +1474,7 @@ module fcapz_ela #(
                     end else if (WORDS_PER_SAMPLE == 1) begin
                         // Use sample_chunk_word so SAMPLE_W==32 does not
                         // emit the {0{1'b0}} zero-replication concat that
-                        // Verilator and several synthesis flows reject.
+                        // Some lint and synthesis flows reject.
                         jtag_rdata <= sample_chunk_word(rd_data_sync1, 0);
                     end else begin
                         jtag_rdata <= sample_chunk_word(

--- a/rtl/fcapz_ela.v
+++ b/rtl/fcapz_ela.v
@@ -1472,7 +1472,10 @@ module fcapz_ela #(
                             ((rd_addr_jtag - ADDR_TS_DATA_BASE[15:0]) >> 2) % TS_WORDS
                         ) * 32;
                     end else if (WORDS_PER_SAMPLE == 1) begin
-                        jtag_rdata <= {{(32-SAMPLE_W){1'b0}}, rd_data_sync1};
+                        // Use sample_chunk_word so SAMPLE_W==32 does not
+                        // emit the {0{1'b0}} zero-replication concat that
+                        // Verilator and several synthesis flows reject.
+                        jtag_rdata <= sample_chunk_word(rd_data_sync1, 0);
                     end else begin
                         jtag_rdata <= sample_chunk_word(
                             rd_data_sync1,

--- a/rtl/fcapz_ela.v
+++ b/rtl/fcapz_ela.v
@@ -1472,7 +1472,7 @@ module fcapz_ela #(
                             ((rd_addr_jtag - ADDR_TS_DATA_BASE[15:0]) >> 2) % TS_WORDS
                         ) * 32;
                     end else if (WORDS_PER_SAMPLE == 1) begin
-                        jtag_rdata <= {{(32-SAMPLE_W){1'b0}}, rd_data_sync1};
+                        jtag_rdata <= sample_chunk_word(rd_data_sync1, 0);
                     end else begin
                         jtag_rdata <= sample_chunk_word(
                             rd_data_sync1,

--- a/rtl/fcapz_ela.v
+++ b/rtl/fcapz_ela.v
@@ -1472,7 +1472,7 @@ module fcapz_ela #(
                             ((rd_addr_jtag - ADDR_TS_DATA_BASE[15:0]) >> 2) % TS_WORDS
                         ) * 32;
                     end else if (WORDS_PER_SAMPLE == 1) begin
-                        jtag_rdata <= sample_chunk_word(rd_data_sync1, 0);
+                        jtag_rdata <= {{(32-SAMPLE_W){1'b0}}, rd_data_sync1};
                     end else begin
                         jtag_rdata <= sample_chunk_word(
                             rd_data_sync1,

--- a/sim/_runner_utils.py
+++ b/sim/_runner_utils.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
+
+"""Shared helpers for the cocotb / Verilator simulation runners under sim/.
+
+Keeps WSL relaunch logic and JUnit XML parsing in one place so fixes do not
+have to be mirrored across run_cocotb.py, run_cocotb_ela.py and
+run_verilator_ela_coverage.py.
+"""
+
+from __future__ import annotations
+
+import platform
+import shlex
+import subprocess
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def windows_to_wsl_path(path: Path) -> str:
+    resolved = path.resolve()
+    drive = resolved.drive.rstrip(":").lower()
+    if not drive:
+        return resolved.as_posix()
+    rest = resolved.as_posix().split(":/", 1)[1]
+    return f"/mnt/{drive}/{rest}"
+
+
+def translate_wsl_arg(arg: str) -> str:
+    """Translate a Windows-style absolute path argument to its WSL equivalent.
+
+    Non-path args pass through untouched. Recognises both `C:\\foo` and `C:/foo`
+    spellings. Backslashes inside non-drive args are not rewritten because they
+    may be meaningful (regex, escapes); callers that want POSIX paths should
+    pass them through windows_to_wsl_path explicitly.
+    """
+    if len(arg) >= 3 and arg[0].isalpha() and arg[1:3] in (":\\", ":/"):
+        drive = arg[0].lower()
+        rest = arg[3:].replace("\\", "/")
+        return f"/mnt/{drive}/{rest}"
+    return arg
+
+
+def running_in_wsl() -> bool:
+    return "microsoft" in platform.release().lower()
+
+
+def relaunch_in_wsl(root: Path, argv: list[str]) -> int:
+    """Re-exec the current script inside WSL bash, translating known path args."""
+    script_args = [
+        windows_to_wsl_path(root / argv[0]),
+        *(translate_wsl_arg(a) for a in argv[1:]),
+    ]
+    script = "cd {} && python3 {}".format(
+        shlex.quote(windows_to_wsl_path(root)),
+        " ".join(shlex.quote(arg) for arg in script_args),
+    )
+    return subprocess.call(["wsl.exe", "-e", "bash", "-lc", script], cwd=root)
+
+
+def check_results(results_xml: Path) -> None:
+    """Raise SystemExit if the cocotb JUnit XML reports any failure/error."""
+    results = ET.parse(results_xml).getroot()
+    failures = len(list(results.iter("failure")))
+    errors = len(list(results.iter("error")))
+    if failures or errors:
+        raise SystemExit(
+            f"cocotb reported failures={failures} errors={errors}: {results_xml}"
+        )

--- a/sim/run_cocotb.py
+++ b/sim/run_cocotb.py
@@ -190,8 +190,6 @@ def check_results(results_xml: Path) -> None:
     results = ET.parse(results_xml).getroot()
     failures = len(list(results.iter("failure")))
     errors = len(list(results.iter("error")))
-    failures += sum(int(case.attrib.get("failures", "0")) for case in results.iter("testsuite"))
-    errors += sum(int(case.attrib.get("errors", "0")) for case in results.iter("testsuite"))
     if failures or errors:
         raise SystemExit(f"cocotb reported failures={failures} errors={errors}: {results_xml}")
 
@@ -230,6 +228,7 @@ def run_target(target: Target, args: argparse.Namespace) -> None:
         waves=args.waves,
         verbose=args.verbose,
         timescale=("1ns", "1ps"),
+        build_args=["-Wall"],
     )
     runner.test(
         test_module="core_test",

--- a/sim/run_cocotb.py
+++ b/sim/run_cocotb.py
@@ -34,9 +34,13 @@ class Target:
 
 ELA_TARGET = "ela"
 
+_TRIG_COMPARE_SRC = (RTL / "trig_compare.v",)
+
 TARGETS: tuple[Target, ...] = (
-    Target("trig_compare_light", "trig_compare", (RTL / "trig_compare.v",), "trig_compare_light", {"W": 8, "REL_COMPARE": 0}),
-    Target("trig_compare_full", "trig_compare", (RTL / "trig_compare.v",), "trig_compare_full", {"W": 8, "REL_COMPARE": 1}),
+    Target("trig_compare_light", "trig_compare", _TRIG_COMPARE_SRC,
+           "trig_compare_light", {"W": 8, "REL_COMPARE": 0}),
+    Target("trig_compare_full", "trig_compare", _TRIG_COMPARE_SRC,
+           "trig_compare_full", {"W": 8, "REL_COMPARE": 1}),
     Target(
         "jtag_burst_read",
         "jtag_burst_read",
@@ -58,7 +62,8 @@ TARGETS: tuple[Target, ...] = (
         "jtag_pipe_iface_segmented_alignment",
         {"SAMPLE_W": 8, "TIMESTAMP_W": 0, "DEPTH": 1024, "BURST_W": 256, "SEG_DEPTH": 256},
     ),
-    Target("fcapz_eio", "fcapz_eio", (RTL / "fcapz_eio.v",), "fcapz_eio_registers", {"IN_W": 16, "OUT_W": 12}),
+    Target("fcapz_eio", "fcapz_eio", (RTL / "fcapz_eio.v",),
+           "fcapz_eio_registers", {"IN_W": 16, "OUT_W": 12}),
     Target(
         "fcapz_core_manager",
         "fcapz_core_manager",
@@ -122,7 +127,9 @@ TARGETS: tuple[Target, ...] = (
     Target(
         "fcapz_async_fifo_equiv",
         "fcapz_async_fifo_equiv_wrap",
-        (TB_COCOTB / "fcapz_async_fifo_equiv_wrap.v", RTL / "fcapz_async_fifo.v", TB / "xpm_fifo_async_stub.v"),
+        (TB_COCOTB / "fcapz_async_fifo_equiv_wrap.v",
+         RTL / "fcapz_async_fifo.v",
+         TB / "xpm_fifo_async_stub.v"),
         "fcapz_async_fifo_equiv",
         {"DATA_W": 8, "DEPTH": 16},
     ),
@@ -148,14 +155,16 @@ TARGETS: tuple[Target, ...] = (
             TB / "axi4_test_slave.v",
         ),
         "fcapz_ejtagaxi_reset_regression",
-        {"DEBUG_EN": 0, "FIFO_DEPTH": 16, "CMD_FIFO_DEPTH": 32, "RESP_FIFO_DEPTH": 32, "USE_BEHAV_ASYNC_FIFO": 1},
+        {"DEBUG_EN": 0, "FIFO_DEPTH": 16, "CMD_FIFO_DEPTH": 32,
+         "RESP_FIFO_DEPTH": 32, "USE_BEHAV_ASYNC_FIFO": 1},
     ),
     Target(
         "fcapz_ejtaguart",
         "fcapz_ejtaguart",
         (RTL / "fcapz_async_fifo.v", RTL / "fcapz_ejtaguart.v"),
         "fcapz_ejtaguart_protocol",
-        {"CLK_HZ": 10_000_000, "BAUD_RATE": 100_000, "TX_FIFO_DEPTH": 16, "RX_FIFO_DEPTH": 16, "PARITY": 0},
+        {"CLK_HZ": 10_000_000, "BAUD_RATE": 100_000,
+         "TX_FIFO_DEPTH": 16, "RX_FIFO_DEPTH": 16, "PARITY": 0},
     ),
 )
 
@@ -224,7 +233,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--clean", action="store_true")
     parser.add_argument("--waves", action="store_true")
     parser.add_argument("--verbose", action="store_true")
-    parser.add_argument("--skip-ela", action="store_true", help="run only non-ELA cocotb replacements")
+    parser.add_argument("--skip-ela", action="store_true",
+                        help="run only non-ELA cocotb replacements")
     return parser.parse_args()
 
 
@@ -236,7 +246,8 @@ def main() -> None:
     requested = tuple(args.target) if args.target else DEFAULT_TARGETS
     unknown = [name for name in requested if name not in TARGET_BY_NAME and name != ELA_TARGET]
     if unknown:
-        raise SystemExit(f"Unknown target(s): {unknown}. Available: {[ELA_TARGET, *TARGET_BY_NAME]}")
+        available = [ELA_TARGET, *TARGET_BY_NAME]
+        raise SystemExit(f"Unknown target(s): {unknown}. Available: {available}")
 
     if (not args.target or ELA_TARGET in requested) and not args.skip_ela:
         run_ela(args)

--- a/sim/run_cocotb.py
+++ b/sim/run_cocotb.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
+
+"""Run cocotb replacements for the RTL simulation testbenches."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import shlex
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+RTL = ROOT / "rtl"
+SIM = ROOT / "sim"
+TB = ROOT / "tb"
+TB_COCOTB = ROOT / "tb" / "cocotb"
+BUILD_ROOT = ROOT / "build" / "cocotb"
+
+
+@dataclass(frozen=True)
+class Target:
+    name: str
+    top: str
+    sources: tuple[Path, ...]
+    testcase: str
+    parameters: dict[str, int] = field(default_factory=dict)
+
+
+ELA_TARGET = "ela"
+
+TARGETS: tuple[Target, ...] = (
+    Target("trig_compare_light", "trig_compare", (RTL / "trig_compare.v",), "trig_compare_light", {"W": 8, "REL_COMPARE": 0}),
+    Target("trig_compare_full", "trig_compare", (RTL / "trig_compare.v",), "trig_compare_full", {"W": 8, "REL_COMPARE": 1}),
+    Target(
+        "jtag_burst_read",
+        "jtag_burst_read",
+        (RTL / "jtag_burst_read.v",),
+        "jtag_burst_read_protocol",
+        {"SAMPLE_W": 8, "TIMESTAMP_W": 32, "DEPTH": 1024, "BURST_W": 256, "SEG_DEPTH": 256},
+    ),
+    Target(
+        "jtag_pipe_iface",
+        "jtag_pipe_iface",
+        (RTL / "jtag_pipe_iface.v",),
+        "jtag_pipe_iface_protocol",
+        {"SAMPLE_W": 8, "TIMESTAMP_W": 32, "DEPTH": 1024, "BURST_W": 256, "SEG_DEPTH": 1024},
+    ),
+    Target(
+        "jtag_pipe_iface_segmented",
+        "jtag_pipe_iface",
+        (RTL / "jtag_pipe_iface.v",),
+        "jtag_pipe_iface_segmented_alignment",
+        {"SAMPLE_W": 8, "TIMESTAMP_W": 0, "DEPTH": 1024, "BURST_W": 256, "SEG_DEPTH": 256},
+    ),
+    Target("fcapz_eio", "fcapz_eio", (RTL / "fcapz_eio.v",), "fcapz_eio_registers", {"IN_W": 16, "OUT_W": 12}),
+    Target(
+        "fcapz_core_manager",
+        "fcapz_core_manager",
+        (RTL / "fcapz_core_manager.v",),
+        "fcapz_core_manager_mux",
+        {
+            "NUM_SLOTS": 3,
+            "SAMPLE_W": 8,
+            "TIMESTAMP_W": 4,
+            "DEPTH": 16,
+            "SLOT_CORE_IDS": 0x494F_4C41_4C41,
+            "SLOT_HAS_BURST": 0b011,
+        },
+    ),
+    Target(
+        "chan_mux",
+        "fcapz_ela",
+        (RTL / "reset_sync.v", RTL / "fcapz_ela.v", RTL / "dpram.v", RTL / "trig_compare.v"),
+        "fcapz_ela_channel_mux",
+        {"SAMPLE_W": 8, "DEPTH": 16, "NUM_CHANNELS": 3},
+    ),
+    Target(
+        "fcapz_ela_xilinx7_single_chain",
+        "fcapz_ela_xilinx7",
+        (
+            SIM / "bscane2_stub.v",
+            RTL / "reset_sync.v",
+            RTL / "dpram.v",
+            RTL / "trig_compare.v",
+            RTL / "fcapz_ela.v",
+            RTL / "jtag_pipe_iface.v",
+            RTL / "jtag_reg_iface.v",
+            RTL / "jtag_burst_read.v",
+            RTL / "jtag_tap" / "jtag_tap_xilinx7.v",
+            RTL / "fcapz_eio.v",
+            RTL / "fcapz_regbus_mux.v",
+            RTL / "fcapz_ela_xilinx7.v",
+        ),
+        "fcapz_ela_xilinx7_single_chain",
+        {
+            "SAMPLE_W": 8,
+            "DEPTH": 64,
+            "TRIG_STAGES": 1,
+            "STOR_QUAL": 0,
+            "INPUT_PIPE": 0,
+            "NUM_CHANNELS": 1,
+            "DECIM_EN": 0,
+            "EXT_TRIG_EN": 0,
+            "TIMESTAMP_W": 0,
+            "NUM_SEGMENTS": 1,
+            "STARTUP_ARM": 0,
+            "BURST_EN": 1,
+            "SINGLE_CHAIN_BURST": 1,
+            "CTRL_CHAIN": 1,
+            "DATA_CHAIN": 2,
+            "REL_COMPARE": 0,
+            "DUAL_COMPARE": 0,
+            "USER1_DATA_EN": 1,
+        },
+    ),
+    Target(
+        "fcapz_async_fifo_equiv",
+        "fcapz_async_fifo_equiv_wrap",
+        (TB_COCOTB / "fcapz_async_fifo_equiv_wrap.v", RTL / "fcapz_async_fifo.v", TB / "xpm_fifo_async_stub.v"),
+        "fcapz_async_fifo_equiv",
+        {"DATA_W": 8, "DEPTH": 16},
+    ),
+    Target(
+        "fcapz_ejtagaxi",
+        "fcapz_ejtagaxi_tb_wrap",
+        (
+            TB_COCOTB / "fcapz_ejtagaxi_tb_wrap.v",
+            RTL / "fcapz_async_fifo.v",
+            RTL / "fcapz_ejtagaxi.v",
+            TB / "axi4_test_slave.v",
+        ),
+        "fcapz_ejtagaxi_protocol",
+        {"FIFO_DEPTH": 16},
+    ),
+    Target(
+        "fcapz_ejtagaxi_reset_regression",
+        "fcapz_ejtagaxi_tb_wrap",
+        (
+            TB_COCOTB / "fcapz_ejtagaxi_tb_wrap.v",
+            RTL / "fcapz_async_fifo.v",
+            RTL / "fcapz_ejtagaxi.v",
+            TB / "axi4_test_slave.v",
+        ),
+        "fcapz_ejtagaxi_reset_regression",
+        {"DEBUG_EN": 0, "FIFO_DEPTH": 16, "CMD_FIFO_DEPTH": 32, "RESP_FIFO_DEPTH": 32, "USE_BEHAV_ASYNC_FIFO": 1},
+    ),
+    Target(
+        "fcapz_ejtaguart",
+        "fcapz_ejtaguart",
+        (RTL / "fcapz_async_fifo.v", RTL / "fcapz_ejtaguart.v"),
+        "fcapz_ejtaguart_protocol",
+        {"CLK_HZ": 10_000_000, "BAUD_RATE": 100_000, "TX_FIFO_DEPTH": 16, "RX_FIFO_DEPTH": 16, "PARITY": 0},
+    ),
+)
+
+TARGET_BY_NAME = {target.name: target for target in TARGETS}
+DEFAULT_TARGETS = tuple(target.name for target in TARGETS)
+
+
+def windows_to_wsl_path(path: Path) -> str:
+    resolved = path.resolve()
+    drive = resolved.drive.rstrip(":").lower()
+    if not drive:
+        return resolved.as_posix()
+    rest = resolved.as_posix().split(":/", 1)[1]
+    return f"/mnt/{drive}/{rest}"
+
+
+def running_in_wsl() -> bool:
+    return "microsoft" in platform.release().lower()
+
+
+def relaunch_in_wsl(argv: list[str]) -> int:
+    script_args = [windows_to_wsl_path(ROOT / argv[0]), *argv[1:]]
+    script = "cd {} && python3 {}".format(
+        shlex.quote(windows_to_wsl_path(ROOT)),
+        " ".join(shlex.quote(arg) for arg in script_args),
+    )
+    return subprocess.call(["wsl.exe", "-e", "bash", "-lc", script], cwd=ROOT)
+
+
+def check_results(results_xml: Path) -> None:
+    results = ET.parse(results_xml).getroot()
+    failures = len(list(results.iter("failure")))
+    errors = len(list(results.iter("error")))
+    failures += sum(int(case.attrib.get("failures", "0")) for case in results.iter("testsuite"))
+    errors += sum(int(case.attrib.get("errors", "0")) for case in results.iter("testsuite"))
+    if failures or errors:
+        raise SystemExit(f"cocotb reported failures={failures} errors={errors}: {results_xml}")
+
+
+def run_ela(args: argparse.Namespace) -> None:
+    cmd = [
+        sys.executable,
+        str(ROOT / "sim" / "run_cocotb_ela.py"),
+        "--runner",
+        "native",
+        "--hdl",
+        "verilog",
+        "--suite",
+        "all",
+    ]
+    if args.clean:
+        cmd.append("--clean")
+    subprocess.check_call(cmd, cwd=ROOT)
+
+
+def run_target(target: Target, args: argparse.Namespace) -> None:
+    from cocotb.runner import get_runner
+
+    runner = get_runner(args.sim)
+    build_dir = BUILD_ROOT / "verilog_icarus" / target.name
+    results_xml = build_dir / "results.xml"
+
+    runner.build(
+        verilog_sources=list(target.sources),
+        includes=[RTL],
+        parameters=target.parameters,
+        hdl_toplevel=target.top,
+        build_dir=build_dir,
+        clean=args.clean,
+        always=True,
+        waves=args.waves,
+        verbose=args.verbose,
+        timescale=("1ns", "1ps"),
+    )
+    runner.test(
+        test_module="core_test",
+        hdl_toplevel=target.top,
+        testcase=(target.testcase,),
+        build_dir=build_dir,
+        test_dir=TB_COCOTB,
+        results_xml=results_xml,
+        waves=args.waves,
+        verbose=args.verbose,
+        extra_env={"COCOTB_RESOLVE_X": "ZEROS", "FCAPZ_COCOTB_TARGET": target.name},
+    )
+    check_results(results_xml)
+    print(f"cocotb target passed: {target.name}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("target", nargs="*", help=f"target name(s), or {ELA_TARGET}")
+    parser.add_argument("--runner", choices=("auto", "native", "wsl"), default="auto")
+    parser.add_argument("--sim", default="icarus")
+    parser.add_argument("--clean", action="store_true")
+    parser.add_argument("--waves", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--skip-ela", action="store_true", help="run only non-ELA cocotb replacements")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if os.name == "nt" and not running_in_wsl() and args.runner in ("auto", "wsl"):
+        raise SystemExit(relaunch_in_wsl(sys.argv))
+
+    requested = tuple(args.target) if args.target else DEFAULT_TARGETS
+    unknown = [name for name in requested if name not in TARGET_BY_NAME and name != ELA_TARGET]
+    if unknown:
+        raise SystemExit(f"Unknown target(s): {unknown}. Available: {[ELA_TARGET, *TARGET_BY_NAME]}")
+
+    if (not args.target or ELA_TARGET in requested) and not args.skip_ela:
+        run_ela(args)
+
+    for name in requested:
+        if name == ELA_TARGET:
+            continue
+        run_target(TARGET_BY_NAME[name], args)
+
+    print("cocotb regression complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/sim/run_cocotb.py
+++ b/sim/run_cocotb.py
@@ -8,13 +8,12 @@ from __future__ import annotations
 
 import argparse
 import os
-import platform
-import shlex
 import subprocess
 import sys
-import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
 from pathlib import Path
+
+from _runner_utils import check_results, relaunch_in_wsl, running_in_wsl
 
 ROOT = Path(__file__).resolve().parent.parent
 RTL = ROOT / "rtl"
@@ -164,36 +163,6 @@ TARGET_BY_NAME = {target.name: target for target in TARGETS}
 DEFAULT_TARGETS = tuple(target.name for target in TARGETS)
 
 
-def windows_to_wsl_path(path: Path) -> str:
-    resolved = path.resolve()
-    drive = resolved.drive.rstrip(":").lower()
-    if not drive:
-        return resolved.as_posix()
-    rest = resolved.as_posix().split(":/", 1)[1]
-    return f"/mnt/{drive}/{rest}"
-
-
-def running_in_wsl() -> bool:
-    return "microsoft" in platform.release().lower()
-
-
-def relaunch_in_wsl(argv: list[str]) -> int:
-    script_args = [windows_to_wsl_path(ROOT / argv[0]), *argv[1:]]
-    script = "cd {} && python3 {}".format(
-        shlex.quote(windows_to_wsl_path(ROOT)),
-        " ".join(shlex.quote(arg) for arg in script_args),
-    )
-    return subprocess.call(["wsl.exe", "-e", "bash", "-lc", script], cwd=ROOT)
-
-
-def check_results(results_xml: Path) -> None:
-    results = ET.parse(results_xml).getroot()
-    failures = len(list(results.iter("failure")))
-    errors = len(list(results.iter("error")))
-    if failures or errors:
-        raise SystemExit(f"cocotb reported failures={failures} errors={errors}: {results_xml}")
-
-
 def run_ela(args: argparse.Namespace) -> None:
     cmd = [
         sys.executable,
@@ -249,7 +218,9 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("target", nargs="*", help=f"target name(s), or {ELA_TARGET}")
     parser.add_argument("--runner", choices=("auto", "native", "wsl"), default="auto")
-    parser.add_argument("--sim", default="icarus")
+    parser.add_argument("--sim", choices=("icarus",), default="icarus",
+                        help="cocotb simulator backend; only Icarus is supported "
+                             "(some wrappers use hierarchical refs to internal regs)")
     parser.add_argument("--clean", action="store_true")
     parser.add_argument("--waves", action="store_true")
     parser.add_argument("--verbose", action="store_true")
@@ -260,7 +231,7 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
     if os.name == "nt" and not running_in_wsl() and args.runner in ("auto", "wsl"):
-        raise SystemExit(relaunch_in_wsl(sys.argv))
+        raise SystemExit(relaunch_in_wsl(ROOT, sys.argv))
 
     requested = tuple(args.target) if args.target else DEFAULT_TARGETS
     unknown = [name for name in requested if name not in TARGET_BY_NAME and name != ELA_TARGET]

--- a/sim/run_cocotb_ela.py
+++ b/sim/run_cocotb_ela.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
+
+"""Run shared cocotb ELA core tests against Verilog or VHDL implementations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import shlex
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+RTL = ROOT / "rtl"
+TB_COCOTB = ROOT / "tb" / "cocotb"
+BUILD_ROOT = ROOT / "build" / "cocotb_ela"
+
+VERILOG_SOURCES = [
+    RTL / "reset_sync.v",
+    RTL / "fcapz_ela.v",
+    RTL / "dpram.v",
+    RTL / "trig_compare.v",
+]
+
+BASE_PARAMETERS = {
+    "SAMPLE_W": 8,
+    "DEPTH": 16,
+    "TRIG_STAGES": 1,
+    "STOR_QUAL": 0,
+    "NUM_CHANNELS": 1,
+    "INPUT_PIPE": 0,
+    "DECIM_EN": 0,
+    "EXT_TRIG_EN": 0,
+    "TIMESTAMP_W": 0,
+    "NUM_SEGMENTS": 1,
+    "PROBE_MUX_W": 0,
+    "STARTUP_ARM": 0,
+    "DEFAULT_TRIG_EXT": 0,
+    "REL_COMPARE": 0,
+    "DUAL_COMPARE": 1,
+    "USER1_DATA_EN": 1,
+}
+
+
+@dataclass(frozen=True)
+class CocotbTarget:
+    name: str
+    parameters: dict[str, int] = field(default_factory=dict)
+    testcases: tuple[str, ...] = ()
+
+    @property
+    def merged_parameters(self) -> dict[str, int]:
+        return {**BASE_PARAMETERS, **self.parameters}
+
+
+TARGETS: tuple[CocotbTarget, ...] = (
+    CocotbTarget(
+        "base",
+        {"DECIM_EN": 1, "EXT_TRIG_EN": 1},
+        (
+            "identity_registers",
+            "features_registers",
+            "register_roundtrip",
+            "value_capture",
+            "edge_capture",
+            "overflow_and_reset",
+            "decimation_and_external_trigger",
+            "decimation_zero_and_every4",
+            "external_trigger_disabled",
+            "trigger_out_pulse",
+            "trigger_delay_startup_and_holdoff",
+            "burst_start_register",
+        ),
+    ),
+    CocotbTarget("timestamp32", {"DECIM_EN": 1, "TIMESTAMP_W": 32}, ("timestamp_capture", "timestamp_decimation_gap")),
+    CocotbTarget("timestamp48", {"TIMESTAMP_W": 48}, ("timestamp_48_upper_word",)),
+    CocotbTarget("segments4", {"NUM_SEGMENTS": 4}, ("segmented_capture",)),
+    CocotbTarget("probe_mux", {"PROBE_MUX_W": 32}, ("probe_mux_slice_selection",)),
+    CocotbTarget(
+        "input_pipe",
+        {"DEPTH": 1024, "DECIM_EN": 1, "EXT_TRIG_EN": 1, "TIMESTAMP_W": 32, "NUM_SEGMENTS": 4, "INPUT_PIPE": 1},
+        ("input_pipe_captures", "input_pipe_holdoff_late_ext_pulse"),
+    ),
+    CocotbTarget("full_depth", {"DEPTH": 8}, ("full_depth_capture",)),
+    CocotbTarget("decim_anchor", {"DECIM_EN": 1}, ("decimated_trigger_anchor", "early_pretrigger_waits_for_fill")),
+    CocotbTarget("sequencer", {"TRIG_STAGES": 2}, ("sequencer_count_target_one",)),
+    CocotbTarget("wide48", {"SAMPLE_W": 48, "DEPTH": 8}, ("wide_sample_readback",)),
+    CocotbTarget(
+        "segmented_ext_rearm",
+        {"DEPTH": 1024, "EXT_TRIG_EN": 1, "TIMESTAMP_W": 32, "NUM_SEGMENTS": 4, "INPUT_PIPE": 1},
+        ("segmented_single_pulse_stalls", "segmented_rearm_pulses_complete"),
+    ),
+    CocotbTarget(
+        "rolling_prehistory",
+        {"EXT_TRIG_EN": 1, "INPUT_PIPE": 1},
+        ("rolling_prehistory_and_rearm",),
+    ),
+    CocotbTarget(
+        "config_min",
+        {"TRIG_STAGES": 1, "STOR_QUAL": 0, "DECIM_EN": 0, "EXT_TRIG_EN": 0, "DUAL_COMPARE": 0},
+        ("config_minimal",),
+    ),
+    CocotbTarget("config_nouser1", {"USER1_DATA_EN": 0}, ("config_user1_disabled",)),
+    CocotbTarget(
+        "config_rel",
+        {"TRIG_STAGES": 2, "INPUT_PIPE": 1, "REL_COMPARE": 1, "DUAL_COMPARE": 0},
+        ("config_rel_compare",),
+    ),
+    CocotbTarget(
+        "config_combo",
+        {"TRIG_STAGES": 2, "STOR_QUAL": 1, "INPUT_PIPE": 1, "NUM_SEGMENTS": 4, "REL_COMPARE": 1, "DUAL_COMPARE": 1},
+        ("config_combo_sq_segments",),
+    ),
+)
+
+SMOKE_TARGETS = (TARGETS[0],)
+
+
+def windows_to_wsl_path(path: Path) -> str:
+    resolved = path.resolve()
+    drive = resolved.drive.rstrip(":").lower()
+    if not drive:
+        return resolved.as_posix()
+    rest = resolved.as_posix().split(":/", 1)[1]
+    return f"/mnt/{drive}/{rest}"
+
+
+def running_in_wsl() -> bool:
+    return "microsoft" in platform.release().lower()
+
+
+def relaunch_in_wsl(argv: list[str]) -> int:
+    script_args = [windows_to_wsl_path(ROOT / argv[0]), *argv[1:]]
+    script = "cd {} && python3 {}".format(
+        shlex.quote(windows_to_wsl_path(ROOT)),
+        " ".join(shlex.quote(arg) for arg in script_args),
+    )
+    return subprocess.call(["wsl.exe", "-e", "bash", "-lc", script], cwd=ROOT)
+
+
+def parse_parameter(text: str) -> tuple[str, int]:
+    if "=" not in text:
+        raise argparse.ArgumentTypeError("parameter must be NAME=VALUE")
+    name, value = text.split("=", 1)
+    try:
+        return name, int(value, 0)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid integer parameter value: {text}") from exc
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hdl", choices=("verilog", "vhdl"), default="verilog")
+    parser.add_argument("--suite", choices=("all", "smoke", "manual"), default="all")
+    parser.add_argument("--sim", default=None)
+    parser.add_argument("--runner", choices=("auto", "native", "wsl"), default="auto")
+    parser.add_argument("--top", default="fcapz_ela")
+    parser.add_argument("--test-module", default="ela_core_test")
+    parser.add_argument("--testcase", action="append", default=[])
+    parser.add_argument("--vhdl-source", action="append", type=Path, default=[])
+    parser.add_argument("--parameter", action="append", type=parse_parameter, default=[])
+    parser.add_argument("--waves", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--clean", action="store_true")
+    return parser.parse_args()
+
+
+def resolve_sources(args: argparse.Namespace) -> tuple[list[Path], list[Path]]:
+    if args.hdl == "verilog":
+        return VERILOG_SOURCES, []
+
+    vhdl_sources = args.vhdl_source
+    if not vhdl_sources:
+        default_core = RTL / "vhdl" / "core" / "fcapz_ela.vhd"
+        if default_core.exists():
+            vhdl_sources = [default_core]
+        else:
+            raise SystemExit(
+                "No VHDL core source was found. Pass --vhdl-source for the VHDL "
+                "implementation to run the same cocotb tests against VHDL."
+            )
+    return [], vhdl_sources
+
+
+def selected_targets(args: argparse.Namespace) -> tuple[CocotbTarget, ...]:
+    overrides = dict(args.parameter)
+    if args.suite == "manual":
+        return (
+            CocotbTarget(
+                "manual",
+                overrides,
+                tuple(args.testcase) if args.testcase else ("identity_registers", "value_capture"),
+            ),
+        )
+    if args.parameter or args.testcase:
+        raise SystemExit("--parameter and --testcase are only supported with --suite manual")
+    return TARGETS if args.suite == "all" else SMOKE_TARGETS
+
+
+def check_results(results_xml: Path) -> None:
+    results = ET.parse(results_xml).getroot()
+    failures = len(list(results.iter("failure")))
+    errors = len(list(results.iter("error")))
+    failures += sum(int(case.attrib.get("failures", "0")) for case in results.iter("testsuite"))
+    errors += sum(int(case.attrib.get("errors", "0")) for case in results.iter("testsuite"))
+    if failures or errors:
+        raise SystemExit(f"cocotb reported failures={failures} errors={errors}: {results_xml}")
+
+
+def merge_coverage(build_dir: Path, targets: tuple[CocotbTarget, ...]) -> Path:
+    merged: dict[str, int] = {}
+    total_bins = 0
+    for target in targets:
+        coverage_path = build_dir / target.name / "functional_coverage.json"
+        if not coverage_path.exists():
+            continue
+        payload = json.loads(coverage_path.read_text())
+        for name, count in payload["bins"].items():
+            merged[name] = merged.get(name, 0) + int(count)
+        total_bins = max(total_bins, int(payload["total_bins"]))
+
+    covered = sum(1 for count in merged.values() if count)
+    out = build_dir / "functional_coverage_merged.json"
+    out.write_text(
+        json.dumps(
+            {
+                "covered_bins": covered,
+                "total_bins": total_bins,
+                "percent": round((covered / total_bins) * 100.0, 2) if total_bins else 0.0,
+                "bins": merged,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    return out
+
+
+def main() -> None:
+    args = parse_args()
+    if os.name == "nt" and not running_in_wsl() and args.runner in ("auto", "wsl"):
+        raise SystemExit(relaunch_in_wsl(sys.argv))
+
+    try:
+        from cocotb.runner import get_runner
+    except ModuleNotFoundError as exc:
+        raise SystemExit("cocotb is not installed in this Python environment") from exc
+
+    sim = args.sim or ("icarus" if args.hdl == "verilog" else "ghdl")
+    verilog_sources, vhdl_sources = resolve_sources(args)
+    targets = selected_targets(args)
+    build_dir = BUILD_ROOT / f"{args.hdl}_{sim}_{args.suite}"
+    runner = get_runner(sim)
+
+    for target in targets:
+        target_dir = build_dir / target.name
+        results_xml = target_dir / "results.xml"
+        coverage_json = target_dir / "functional_coverage.json"
+        parameters = target.merged_parameters
+
+        runner.build(
+            verilog_sources=verilog_sources,
+            vhdl_sources=vhdl_sources,
+            includes=[RTL],
+            parameters=parameters,
+            hdl_toplevel=args.top,
+            build_dir=target_dir,
+            clean=args.clean,
+            always=True,
+            waves=args.waves,
+            verbose=args.verbose,
+            timescale=("1ns", "1ps"),
+        )
+        runner.test(
+            test_module=args.test_module,
+            hdl_toplevel=args.top,
+            hdl_toplevel_lang=args.hdl,
+            testcase=target.testcases,
+            build_dir=target_dir,
+            test_dir=TB_COCOTB,
+            results_xml=results_xml,
+            waves=args.waves,
+            verbose=args.verbose,
+            extra_env={
+                "COCOTB_RESOLVE_X": "ZEROS",
+                "ELA_COCOTB_COVERAGE_JSON": str(coverage_json),
+                "ELA_COCOTB_RUN": target.name,
+                **{f"ELA_PARAM_{name}": str(value) for name, value in parameters.items()},
+            },
+        )
+        check_results(results_xml)
+
+    merged = merge_coverage(build_dir, targets)
+    print(f"cocotb ELA {args.hdl} suite complete: {build_dir.relative_to(ROOT)}")
+    print(f"Merged functional coverage: {merged.relative_to(ROOT)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sim/run_cocotb_ela.py
+++ b/sim/run_cocotb_ela.py
@@ -208,8 +208,6 @@ def check_results(results_xml: Path) -> None:
     results = ET.parse(results_xml).getroot()
     failures = len(list(results.iter("failure")))
     errors = len(list(results.iter("error")))
-    failures += sum(int(case.attrib.get("failures", "0")) for case in results.iter("testsuite"))
-    errors += sum(int(case.attrib.get("errors", "0")) for case in results.iter("testsuite"))
     if failures or errors:
         raise SystemExit(f"cocotb reported failures={failures} errors={errors}: {results_xml}")
 
@@ -277,6 +275,7 @@ def main() -> None:
             waves=args.waves,
             verbose=args.verbose,
             timescale=("1ns", "1ps"),
+            build_args=["-Wall"] if args.hdl == "verilog" else [],
         )
         runner.test(
             test_module=args.test_module,

--- a/sim/run_cocotb_ela.py
+++ b/sim/run_cocotb_ela.py
@@ -9,13 +9,11 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import platform
-import shlex
-import subprocess
 import sys
-import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
 from pathlib import Path
+
+from _runner_utils import check_results, relaunch_in_wsl, running_in_wsl
 
 ROOT = Path(__file__).resolve().parent.parent
 RTL = ROOT / "rtl"
@@ -123,28 +121,6 @@ TARGETS: tuple[CocotbTarget, ...] = (
 SMOKE_TARGETS = (TARGETS[0],)
 
 
-def windows_to_wsl_path(path: Path) -> str:
-    resolved = path.resolve()
-    drive = resolved.drive.rstrip(":").lower()
-    if not drive:
-        return resolved.as_posix()
-    rest = resolved.as_posix().split(":/", 1)[1]
-    return f"/mnt/{drive}/{rest}"
-
-
-def running_in_wsl() -> bool:
-    return "microsoft" in platform.release().lower()
-
-
-def relaunch_in_wsl(argv: list[str]) -> int:
-    script_args = [windows_to_wsl_path(ROOT / argv[0]), *argv[1:]]
-    script = "cd {} && python3 {}".format(
-        shlex.quote(windows_to_wsl_path(ROOT)),
-        " ".join(shlex.quote(arg) for arg in script_args),
-    )
-    return subprocess.call(["wsl.exe", "-e", "bash", "-lc", script], cwd=ROOT)
-
-
 def parse_parameter(text: str) -> tuple[str, int]:
     if "=" not in text:
         raise argparse.ArgumentTypeError("parameter must be NAME=VALUE")
@@ -204,14 +180,6 @@ def selected_targets(args: argparse.Namespace) -> tuple[CocotbTarget, ...]:
     return TARGETS if args.suite == "all" else SMOKE_TARGETS
 
 
-def check_results(results_xml: Path) -> None:
-    results = ET.parse(results_xml).getroot()
-    failures = len(list(results.iter("failure")))
-    errors = len(list(results.iter("error")))
-    if failures or errors:
-        raise SystemExit(f"cocotb reported failures={failures} errors={errors}: {results_xml}")
-
-
 def merge_coverage(build_dir: Path, targets: tuple[CocotbTarget, ...]) -> Path:
     merged: dict[str, int] = {}
     total_bins = 0
@@ -244,7 +212,7 @@ def merge_coverage(build_dir: Path, targets: tuple[CocotbTarget, ...]) -> Path:
 def main() -> None:
     args = parse_args()
     if os.name == "nt" and not running_in_wsl() and args.runner in ("auto", "wsl"):
-        raise SystemExit(relaunch_in_wsl(sys.argv))
+        raise SystemExit(relaunch_in_wsl(ROOT, sys.argv))
 
     try:
         from cocotb.runner import get_runner

--- a/sim/run_cocotb_ela.py
+++ b/sim/run_cocotb_ela.py
@@ -77,17 +77,20 @@ TARGETS: tuple[CocotbTarget, ...] = (
             "burst_start_register",
         ),
     ),
-    CocotbTarget("timestamp32", {"DECIM_EN": 1, "TIMESTAMP_W": 32}, ("timestamp_capture", "timestamp_decimation_gap")),
+    CocotbTarget("timestamp32", {"DECIM_EN": 1, "TIMESTAMP_W": 32},
+                 ("timestamp_capture", "timestamp_decimation_gap")),
     CocotbTarget("timestamp48", {"TIMESTAMP_W": 48}, ("timestamp_48_upper_word",)),
     CocotbTarget("segments4", {"NUM_SEGMENTS": 4}, ("segmented_capture",)),
     CocotbTarget("probe_mux", {"PROBE_MUX_W": 32}, ("probe_mux_slice_selection",)),
     CocotbTarget(
         "input_pipe",
-        {"DEPTH": 1024, "DECIM_EN": 1, "EXT_TRIG_EN": 1, "TIMESTAMP_W": 32, "NUM_SEGMENTS": 4, "INPUT_PIPE": 1},
+        {"DEPTH": 1024, "DECIM_EN": 1, "EXT_TRIG_EN": 1,
+         "TIMESTAMP_W": 32, "NUM_SEGMENTS": 4, "INPUT_PIPE": 1},
         ("input_pipe_captures", "input_pipe_holdoff_late_ext_pulse"),
     ),
     CocotbTarget("full_depth", {"DEPTH": 8}, ("full_depth_capture",)),
-    CocotbTarget("decim_anchor", {"DECIM_EN": 1}, ("decimated_trigger_anchor", "early_pretrigger_waits_for_fill")),
+    CocotbTarget("decim_anchor", {"DECIM_EN": 1},
+                 ("decimated_trigger_anchor", "early_pretrigger_waits_for_fill")),
     CocotbTarget("sequencer", {"TRIG_STAGES": 2}, ("sequencer_count_target_one",)),
     CocotbTarget("wide48", {"SAMPLE_W": 48, "DEPTH": 8}, ("wide_sample_readback",)),
     CocotbTarget(
@@ -113,7 +116,8 @@ TARGETS: tuple[CocotbTarget, ...] = (
     ),
     CocotbTarget(
         "config_combo",
-        {"TRIG_STAGES": 2, "STOR_QUAL": 1, "INPUT_PIPE": 1, "NUM_SEGMENTS": 4, "REL_COMPARE": 1, "DUAL_COMPARE": 1},
+        {"TRIG_STAGES": 2, "STOR_QUAL": 1, "INPUT_PIPE": 1,
+         "NUM_SEGMENTS": 4, "REL_COMPARE": 1, "DUAL_COMPARE": 1},
         ("config_combo_sq_segments",),
     ),
 )

--- a/sim/run_verilator_ela_coverage.py
+++ b/sim/run_verilator_ela_coverage.py
@@ -21,6 +21,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from _runner_utils import windows_to_wsl_path
+
 ROOT = Path(__file__).resolve().parent.parent
 RTL = ROOT / "rtl"
 TB = ROOT / "tb"
@@ -85,15 +87,6 @@ BENCH_BY_NAME = {bench.name: bench for bench in BENCHES}
 
 def rel(path: Path) -> str:
     return path.relative_to(ROOT).as_posix()
-
-
-def windows_to_wsl_path(path: Path) -> str:
-    resolved = path.resolve()
-    drive = resolved.drive.rstrip(":").lower()
-    if not drive:
-        return resolved.as_posix()
-    rest = resolved.as_posix().split(":/", 1)[1]
-    return f"/mnt/{drive}/{rest}"
 
 
 def quote_cmd(args: list[str]) -> str:

--- a/sim/run_verilator_ela_coverage.py
+++ b/sim/run_verilator_ela_coverage.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
+
+"""Run the Verilog ELA testbenches under Verilator with coverage enabled.
+
+The Icarus runner remains the fast compatibility simulation gate. This script
+uses Verilator as a simulation engine for the ELA benches and emits merged code
+and functional coverage data for the original Verilog core.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+RTL = ROOT / "rtl"
+TB = ROOT / "tb"
+
+DEFAULT_BUILD = ROOT / "build" / "verilator_ela_coverage"
+
+ELA_RTL = (
+    RTL / "reset_sync.v",
+    RTL / "fcapz_ela.v",
+    RTL / "dpram.v",
+    RTL / "trig_compare.v",
+)
+
+COVERAGE_FLAGS = (
+    "--coverage-line",
+    "--coverage-toggle",
+    "--coverage-user",
+)
+
+WARNING_FLAGS = (
+    "-Wno-DECLFILENAME",
+    "-Wno-GENUNNAMED",
+    "-Wno-UNUSEDSIGNAL",
+    "-Wno-UNDRIVEN",
+    "-Wno-WIDTHTRUNC",
+    "-Wno-WIDTHEXPAND",
+    "-Wno-UNSIGNED",
+    "-Wno-BLKSEQ",
+    "-Wno-PINCONNECTEMPTY",
+    "-Wno-PINMISSING",
+    "-Wno-UNUSEDPARAM",
+    "-Wno-SYNCASYNCNET",
+    "-Wno-TIMESCALEMOD",
+    "-Wno-INITIALDLY",
+)
+
+
+@dataclass(frozen=True)
+class ElaBench:
+    name: str
+    top: str
+    testbench: Path
+    sources: tuple[Path, ...] = ELA_RTL
+
+
+BENCHES = (
+    ElaBench("fcapz_ela", "fcapz_ela_tb", TB / "fcapz_ela_tb.sv"),
+    ElaBench(
+        "fcapz_ela_bug_probe",
+        "fcapz_ela_bug_probe_tb",
+        TB / "fcapz_ela_bug_probe_tb.sv",
+    ),
+    ElaBench(
+        "fcapz_ela_config_matrix",
+        "fcapz_ela_config_matrix_tb",
+        TB / "fcapz_ela_config_matrix_tb.sv",
+    ),
+)
+
+BENCH_BY_NAME = {bench.name: bench for bench in BENCHES}
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def windows_to_wsl_path(path: Path) -> str:
+    resolved = path.resolve()
+    drive = resolved.drive.rstrip(":").lower()
+    if not drive:
+        return resolved.as_posix()
+    rest = resolved.as_posix().split(":/", 1)[1]
+    return f"/mnt/{drive}/{rest}"
+
+
+def quote_cmd(args: list[str]) -> str:
+    return " ".join(shlex.quote(arg) for arg in args)
+
+
+class Runner:
+    def __init__(self, mode: str, *, dry_run: bool = False) -> None:
+        self.mode = self._resolve_mode(mode)
+        self.dry_run = dry_run
+        self.root_wsl = windows_to_wsl_path(ROOT)
+
+    @staticmethod
+    def _resolve_mode(mode: str) -> str:
+        if mode != "auto":
+            return mode
+        if shutil.which("verilator") and shutil.which("verilator_coverage"):
+            return "native"
+        if os.name == "nt" and shutil.which("wsl.exe"):
+            return "wsl"
+        return "native"
+
+    def _display(self, args: list[str]) -> str:
+        if self.mode == "wsl":
+            return f"wsl.exe -e bash -lc {shlex.quote('cd ' + shlex.quote(self.root_wsl) + ' && ' + quote_cmd(args))}"
+        return quote_cmd(args)
+
+    def run(
+        self,
+        args: list[str],
+        label: str,
+        *,
+        capture: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        print(f"[verilator-cov] {label}: {self._display(args)}", flush=True)
+        if self.dry_run:
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        if self.mode == "wsl":
+            script = f"cd {shlex.quote(self.root_wsl)} && {quote_cmd(args)}"
+            cmd = ["wsl.exe", "-e", "bash", "-lc", script]
+            cwd = ROOT
+        else:
+            cmd = args
+            cwd = ROOT
+
+        return subprocess.run(
+            cmd,
+            cwd=cwd,
+            text=True,
+            capture_output=capture,
+        )
+
+
+def check_tools(runner: Runner) -> bool:
+    result = runner.run(["verilator", "--version"], "check verilator", capture=True)
+    if result.returncode != 0:
+        sys.stderr.write(result.stdout + result.stderr)
+        print("verilator is not reachable; use --runner wsl if it is installed in WSL", file=sys.stderr)
+        return False
+
+    match = re.search(r"Verilator\s+(\d+)\.(\d+)", result.stdout + result.stderr)
+    if not match:
+        print("could not parse Verilator version", file=sys.stderr)
+        return False
+    version = int(match.group(1)), int(match.group(2))
+    if version < (5, 0):
+        print(f"Verilator 5.0 or newer is required (found {version[0]}.{version[1]})", file=sys.stderr)
+        return False
+
+    cov = runner.run(["verilator_coverage", "--help"], "check verilator_coverage", capture=True)
+    if cov.returncode != 0:
+        sys.stderr.write(cov.stdout + cov.stderr)
+        print("verilator_coverage is not reachable", file=sys.stderr)
+        return False
+    return True
+
+
+def build_cmd(bench: ElaBench, build_dir: Path, *, functional: bool, runner: Runner) -> list[str]:
+    bench_dir = build_dir / bench.name
+    obj_dir = bench_dir / "obj_dir"
+    main_cpp = bench_dir / "coverage_main.cpp"
+    main_cpp_arg = windows_to_wsl_path(main_cpp) if runner.mode == "wsl" else str(main_cpp)
+    sources = [bench.testbench, *bench.sources]
+    if functional:
+        sources.append(TB / "fcapz_ela_func_cov.sv")
+
+    return [
+        "verilator",
+        "-sv",
+        "--cc",
+        "--exe",
+        "--build",
+        "--timing",
+        "--assert",
+        *COVERAGE_FLAGS,
+        *WARNING_FLAGS,
+        "-Irtl",
+        "--top-module",
+        bench.top,
+        "-Mdir",
+        rel(obj_dir),
+        *[rel(src) for src in sources],
+        main_cpp_arg,
+    ]
+
+
+def run_cmd(bench: ElaBench, build_dir: Path, *, windows_exe: bool) -> list[str]:
+    exe = build_dir / bench.name / "obj_dir" / f"V{bench.top}"
+    if windows_exe:
+        exe = exe.with_suffix(".exe")
+    return [rel(exe)]
+
+
+def write_harness(bench: ElaBench, build_dir: Path) -> None:
+    bench_dir = build_dir / bench.name
+    coverage_file = rel(bench_dir / "coverage.dat")
+    text = f"""// Generated by sim/run_verilator_ela_coverage.py
+#include "V{bench.top}.h"
+#include "verilated.h"
+#include "verilated_cov.h"
+
+int main(int argc, char** argv) {{
+    VerilatedContext context;
+    context.commandArgs(argc, argv);
+
+    V{bench.top} top(&context);
+    while (!context.gotFinish()) {{
+        top.eval();
+        if (!top.eventsPending()) break;
+        context.time(top.nextTimeSlot());
+    }}
+
+    top.final();
+    VerilatedCov::write("{coverage_file}");
+    return 0;
+}}
+"""
+    (bench_dir / "coverage_main.cpp").write_text(text)
+
+
+def merge_cmd(build_dir: Path, benches: list[ElaBench]) -> list[str]:
+    return [
+        "verilator_coverage",
+        "--write",
+        rel(build_dir / "merged.dat"),
+        *[rel(build_dir / bench.name / "coverage.dat") for bench in benches],
+    ]
+
+
+def annotate_cmd(build_dir: Path) -> list[str]:
+    return [
+        "verilator_coverage",
+        "--annotate",
+        rel(build_dir / "annotated"),
+        "--annotate-all",
+        "--annotate-points",
+        "--annotate-min",
+        "1",
+        rel(build_dir / "merged.dat"),
+    ]
+
+
+def write_info_cmd(build_dir: Path) -> list[str]:
+    return [
+        "verilator_coverage",
+        "--write-info",
+        rel(build_dir / "merged.info"),
+        rel(build_dir / "merged.dat"),
+    ]
+
+
+def selected_benches(names: list[str]) -> list[ElaBench]:
+    if not names:
+        return list(BENCHES)
+    unknown = [name for name in names if name not in BENCH_BY_NAME]
+    if unknown:
+        print(f"Unknown ELA coverage bench(es): {unknown}", file=sys.stderr)
+        print(f"Available: {', '.join(BENCH_BY_NAME)}", file=sys.stderr)
+        sys.exit(2)
+    return [BENCH_BY_NAME[name] for name in names]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("testbench", nargs="*", help="ELA bench name(s) to run")
+    parser.add_argument(
+        "--runner",
+        choices=("auto", "native", "wsl"),
+        default="auto",
+        help="where to run Verilator; auto prefers native, then WSL on Windows",
+    )
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        default=DEFAULT_BUILD,
+        help="coverage output directory",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="print commands without running them")
+    parser.add_argument("--keep-going", action="store_true", help="continue after a bench fails")
+    parser.add_argument(
+        "--no-functional",
+        action="store_true",
+        help="skip the bound functional coverage module",
+    )
+    parser.add_argument("--no-merge", action="store_true", help="skip coverage merge")
+    parser.add_argument("--no-annotate", action="store_true", help="skip annotated coverage output")
+    parser.add_argument("--write-info", action="store_true", help="also emit lcov-compatible merged.info")
+    args = parser.parse_args()
+
+    benches = selected_benches(args.testbench)
+    build_dir = args.build_dir if args.build_dir.is_absolute() else ROOT / args.build_dir
+    runner = Runner(args.runner, dry_run=args.dry_run)
+
+    if not args.dry_run and not check_tools(runner):
+        sys.exit(127)
+
+    failures: list[str] = []
+    build_dir.mkdir(parents=True, exist_ok=True)
+
+    for bench in benches:
+        (build_dir / bench.name).mkdir(parents=True, exist_ok=True)
+        if not args.dry_run:
+            write_harness(bench, build_dir)
+        for label, cmd in (
+            (
+                f"build {bench.name}",
+                build_cmd(bench, build_dir, functional=not args.no_functional, runner=runner),
+            ),
+            (
+                f"simulate {bench.name}",
+                run_cmd(bench, build_dir, windows_exe=(runner.mode == "native" and os.name == "nt")),
+            ),
+        ):
+            result = runner.run(cmd, label)
+            if result.returncode != 0:
+                failures.append(label)
+                if not args.keep_going:
+                    print(f"[verilator-cov] FAILED: {label}", file=sys.stderr)
+                    sys.exit(result.returncode)
+                break
+
+    if failures and not args.keep_going:
+        sys.exit(1)
+
+    if not failures and not args.no_merge:
+        result = runner.run(merge_cmd(build_dir, benches), "merge coverage")
+        if result.returncode != 0:
+            sys.exit(result.returncode)
+
+        if not args.no_annotate:
+            result = runner.run(annotate_cmd(build_dir), "annotate coverage")
+            if result.returncode != 0:
+                sys.exit(result.returncode)
+
+        if args.write_info:
+            result = runner.run(write_info_cmd(build_dir), "write lcov info")
+            if result.returncode != 0:
+                sys.exit(result.returncode)
+
+    if failures:
+        print(f"[verilator-cov] FAILED: {failures}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Verilator ELA coverage complete for {len(benches)} bench(es).")
+    if not args.no_merge:
+        print(f"Coverage data: {rel(build_dir / 'merged.dat')}")
+        if not args.no_annotate:
+            print(f"Annotated RTL: {rel(build_dir / 'annotated')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sim/run_verilator_ela_coverage.py
+++ b/sim/run_verilator_ela_coverage.py
@@ -111,7 +111,8 @@ class Runner:
 
     def _display(self, args: list[str]) -> str:
         if self.mode == "wsl":
-            return f"wsl.exe -e bash -lc {shlex.quote('cd ' + shlex.quote(self.root_wsl) + ' && ' + quote_cmd(args))}"
+            inner = f"cd {shlex.quote(self.root_wsl)} && {quote_cmd(args)}"
+            return f"wsl.exe -e bash -lc {shlex.quote(inner)}"
         return quote_cmd(args)
 
     def run(
@@ -145,7 +146,8 @@ def check_tools(runner: Runner) -> bool:
     result = runner.run(["verilator", "--version"], "check verilator", capture=True)
     if result.returncode != 0:
         sys.stderr.write(result.stdout + result.stderr)
-        print("verilator is not reachable; use --runner wsl if it is installed in WSL", file=sys.stderr)
+        print("verilator is not reachable; use --runner wsl if it is installed in WSL",
+              file=sys.stderr)
         return False
 
     match = re.search(r"Verilator\s+(\d+)\.(\d+)", result.stdout + result.stderr)
@@ -154,7 +156,8 @@ def check_tools(runner: Runner) -> bool:
         return False
     version = int(match.group(1)), int(match.group(2))
     if version < (5, 0):
-        print(f"Verilator 5.0 or newer is required (found {version[0]}.{version[1]})", file=sys.stderr)
+        print(f"Verilator 5.0 or newer is required (found {version[0]}.{version[1]})",
+              file=sys.stderr)
         return False
 
     cov = runner.run(["verilator_coverage", "--help"], "check verilator_coverage", capture=True)
@@ -285,16 +288,20 @@ def main() -> None:
         default=DEFAULT_BUILD,
         help="coverage output directory",
     )
-    parser.add_argument("--dry-run", action="store_true", help="print commands without running them")
-    parser.add_argument("--keep-going", action="store_true", help="continue after a bench fails")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="print commands without running them")
+    parser.add_argument("--keep-going", action="store_true",
+                        help="continue after a bench fails")
     parser.add_argument(
         "--no-functional",
         action="store_true",
         help="skip the bound functional coverage module",
     )
     parser.add_argument("--no-merge", action="store_true", help="skip coverage merge")
-    parser.add_argument("--no-annotate", action="store_true", help="skip annotated coverage output")
-    parser.add_argument("--write-info", action="store_true", help="also emit lcov-compatible merged.info")
+    parser.add_argument("--no-annotate", action="store_true",
+                        help="skip annotated coverage output")
+    parser.add_argument("--write-info", action="store_true",
+                        help="also emit lcov-compatible merged.info")
     args = parser.parse_args()
 
     benches = selected_benches(args.testbench)
@@ -318,7 +325,8 @@ def main() -> None:
             ),
             (
                 f"simulate {bench.name}",
-                run_cmd(bench, build_dir, windows_exe=(runner.mode == "native" and os.name == "nt")),
+                run_cmd(bench, build_dir,
+                        windows_exe=(runner.mode == "native" and os.name == "nt")),
             ),
         ):
             result = runner.run(cmd, label)

--- a/tb/cocotb/core_test.py
+++ b/tb/cocotb/core_test.py
@@ -1,0 +1,1206 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
+
+from __future__ import annotations
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import Edge, RisingEdge, FallingEdge, Timer
+
+
+async def tick(signal) -> None:
+    await RisingEdge(signal)
+    await Timer(1, units="ns")
+
+
+async def idle_tap(dut, n: int, *, shift_name: str = "shift_en") -> None:
+    dut.sel.value = 0
+    dut.capture.value = 0
+    getattr(dut, shift_name).value = 0
+    dut.update.value = 0
+    dut.tdi.value = 0
+    for _ in range(n):
+        await tick(dut.tck)
+
+
+def make_frame(addr: int, data: int, write: bool) -> int:
+    return ((1 if write else 0) << 48) | ((addr & 0xFFFF) << 32) | (data & 0xFFFF_FFFF)
+
+
+async def scan_reg(dut, frame: int, *, shift_name: str = "shift_en", tdo=None) -> int:
+    if tdo is None:
+        tdo = dut.tdo
+    captured = 0
+    dut.sel.value = 1
+    dut.capture.value = 1
+    await tick(dut.tck)
+    dut.capture.value = 0
+    getattr(dut, shift_name).value = 1
+    for i in range(49):
+        dut.tdi.value = (frame >> i) & 1
+        if i < 32 and int(tdo.value):
+            captured |= 1 << i
+        await tick(dut.tck)
+    getattr(dut, shift_name).value = 0
+    dut.tdi.value = 0
+    dut.update.value = 1
+    await tick(dut.tck)
+    dut.update.value = 0
+    dut.sel.value = 0
+    return captured
+
+
+async def scan_burst(dut, *, shift_name: str = "shift_en", tdo=None, bits: int = 256) -> int:
+    if tdo is None:
+        tdo = dut.tdo
+    captured = 0
+    dut.sel.value = 1
+    dut.capture.value = 1
+    await tick(dut.tck)
+    dut.capture.value = 0
+    getattr(dut, shift_name).value = 1
+    for i in range(bits):
+        dut.tdi.value = 0
+        if int(tdo.value):
+            captured |= 1 << i
+        await tick(dut.tck)
+    getattr(dut, shift_name).value = 0
+    dut.update.value = 1
+    await tick(dut.tck)
+    dut.update.value = 0
+    dut.sel.value = 0
+    return captured
+
+
+def sample_at(bits: int, index: int, width: int = 8) -> int:
+    return (bits >> (index * width)) & ((1 << width) - 1)
+
+
+async def jtag_write(dut, addr: int, data: int) -> None:
+    await RisingEdge(dut.jtag_clk)
+    dut.jtag_addr.value = addr
+    dut.jtag_wdata.value = data
+    dut.jtag_wr_en.value = 1
+    await RisingEdge(dut.jtag_clk)
+    dut.jtag_wr_en.value = 0
+
+
+async def jtag_read(dut, addr: int, settle: int = 8) -> int:
+    await RisingEdge(dut.jtag_clk)
+    dut.jtag_addr.value = addr
+    if hasattr(dut, "jtag_rd_en"):
+        dut.jtag_rd_en.value = 1
+        await RisingEdge(dut.jtag_clk)
+        dut.jtag_rd_en.value = 0
+        for _ in range(settle):
+            await RisingEdge(dut.jtag_clk)
+    else:
+        await RisingEdge(dut.jtag_clk)
+    return int(dut.jtag_rdata.value)
+
+
+async def arm_ela(dut) -> None:
+    await jtag_write(dut, 0x0004, 1)
+    for _ in range(80):
+        await RisingEdge(dut.sample_clk)
+        if int(dut.armed_out.value):
+            return
+    raise AssertionError("ELA did not arm")
+
+
+@cocotb.test()
+async def trig_compare_light(dut):
+    cases = (
+        (0x12, 0x10, 0x12, 0xFF, 0, 1),
+        (0x12, 0x10, 0x10, 0xFF, 1, 1),
+        (0x01, 0x00, 0x00, 0xFF, 6, 1),
+        (0x00, 0x01, 0x00, 0xFF, 7, 1),
+        (0x5D, 0x55, 0x00, 0xFF, 8, 1),
+        (0x05, 0x10, 0x10, 0xFF, 2, 0),
+        (0x20, 0x10, 0x10, 0xFF, 3, 0),
+        (0x10, 0x10, 0x10, 0xFF, 4, 0),
+        (0x10, 0x10, 0x10, 0xFF, 5, 0),
+    )
+    for probe, prev, value, mask, mode, expected in cases:
+        dut.probe.value = probe
+        dut.probe_prev.value = prev
+        dut.value.value = value
+        dut.mask.value = mask
+        dut.mode.value = mode
+        await Timer(1, units="ns")
+        assert int(dut.hit.value) == expected
+
+
+@cocotb.test()
+async def trig_compare_full(dut):
+    cases = (
+        (0x12, 0x10, 0x12, 0xFF, 0, 1),
+        (0x12, 0x10, 0x10, 0xFF, 1, 1),
+        (0x01, 0x00, 0x00, 0xFF, 6, 1),
+        (0x00, 0x01, 0x00, 0xFF, 7, 1),
+        (0x5D, 0x55, 0x00, 0xFF, 8, 1),
+        (0x05, 0x10, 0x10, 0xFF, 2, 1),
+        (0x20, 0x10, 0x10, 0xFF, 3, 1),
+        (0x10, 0x10, 0x10, 0xFF, 4, 1),
+        (0x10, 0x10, 0x10, 0xFF, 5, 1),
+    )
+    for probe, prev, value, mask, mode, expected in cases:
+        dut.probe.value = probe
+        dut.probe_prev.value = prev
+        dut.value.value = value
+        dut.mask.value = mask
+        dut.mode.value = mode
+        await Timer(1, units="ns")
+        assert int(dut.hit.value) == expected
+
+
+async def burst_mem_driver(dut) -> None:
+    while True:
+        await RisingEdge(dut.tck)
+        dut.sample_data.value = int(dut.mem_addr.value) & 0xFF
+        if len(dut.timestamp_data) > 1:
+            dut.timestamp_data.value = 0xA500_0000 | int(dut.mem_addr.value)
+
+
+async def start_burst(dut, ptr: int, timestamp: bool) -> None:
+    dut.sel.value = 0
+    dut.burst_ptr_in.value = ptr
+    dut.burst_timestamp.value = int(timestamp)
+    dut.burst_start.value = 0 if int(dut.burst_start.value) else 1
+    await tick(dut.tck)
+
+
+def assert_sample_sequence(bits: int, start: int, count: int = 32) -> None:
+    for i in range(count):
+        assert sample_at(bits, i) == ((start + i) & 0xFF)
+
+
+def assert_timestamp_sequence(bits: int, start: int, count: int = 8) -> None:
+    for i in range(count):
+        got = sample_at(bits, i, 32)
+        exp = 0xA500_0000 | ((start + i) & 0xFF)
+        assert got == exp
+
+
+@cocotb.test()
+async def jtag_burst_read_protocol(dut):
+    cocotb.start_soon(Clock(dut.tck, 10, units="ns").start())
+    cocotb.start_soon(burst_mem_driver(dut))
+    dut.arst.value = 1
+    dut.tdi.value = 0
+    dut.capture.value = 0
+    dut.shift_en.value = 0
+    dut.update.value = 0
+    dut.sel.value = 0
+    dut.sample_data.value = 0
+    dut.timestamp_data.value = 0
+    dut.burst_start.value = 0
+    dut.burst_timestamp.value = 0
+    dut.burst_ptr_in.value = 0
+    await idle_tap(dut, 4)
+    dut.arst.value = 0
+    await idle_tap(dut, 4)
+
+    await start_burst(dut, 42, False)
+    await idle_tap(dut, 80)
+    await scan_burst(dut)
+    scan = await scan_burst(dut)
+    assert_sample_sequence(scan, 42)
+    scan = await scan_burst(dut)
+    assert_sample_sequence(scan, 74)
+
+    await start_burst(dut, 250, False)
+    await idle_tap(dut, 80)
+    await scan_burst(dut)
+    scan = await scan_burst(dut)
+    assert_sample_sequence(scan, 250)
+
+    await start_burst(dut, 64, True)
+    await idle_tap(dut, 80)
+    await scan_burst(dut)
+    scan = await scan_burst(dut)
+    assert_timestamp_sequence(scan, 64)
+
+
+async def pipe_bus_monitor(dut) -> None:
+    while True:
+        await RisingEdge(dut.tck)
+        dut.sample_data.value = int(dut.mem_addr.value) & 0xFF
+        dut.timestamp_data.value = 0xA500_0000 | int(dut.mem_addr.value)
+        if int(dut.reg_wr_en.value) and int(dut.reg_addr.value) == 0x002C:
+            dut.burst_ptr_in.value = 42
+            dut.burst_timestamp.value = (int(dut.reg_wdata.value) >> 31) & 1
+            dut.burst_start.value = 0 if int(dut.burst_start.value) else 1
+
+
+@cocotb.test()
+async def jtag_pipe_iface_protocol(dut):
+    cocotb.start_soon(Clock(dut.tck, 10, units="ns").start())
+    cocotb.start_soon(pipe_bus_monitor(dut))
+    dut.arst.value = 1
+    dut.tdi.value = 0
+    dut.capture.value = 0
+    dut.shift_en.value = 0
+    dut.update.value = 0
+    dut.sel.value = 0
+    dut.reg_rdata.value = 0x1234_5678
+    dut.sample_data.value = 0
+    dut.timestamp_data.value = 0
+    dut.burst_start.value = 0
+    dut.burst_timestamp.value = 0
+    dut.burst_ptr_in.value = 0
+    await idle_tap(dut, 4)
+    dut.arst.value = 0
+    await idle_tap(dut, 4)
+
+    await scan_reg(dut, make_frame(0x0024, 0xCAFE_BABE, True))
+    assert int(dut.reg_addr.value) == 0x0024
+    assert int(dut.reg_wdata.value) == 0xCAFE_BABE
+
+    await scan_reg(dut, make_frame(0, 0, False))
+    await idle_tap(dut, 4)
+    captured = await scan_reg(dut, make_frame(0, 0, False))
+    assert captured == 0x1234_5678
+
+    await scan_reg(dut, make_frame(0x002C, 0, True))
+    await idle_tap(dut, 80)
+    await scan_burst(dut)
+    first = await scan_burst(dut)
+    second = await scan_burst(dut)
+    assert_sample_sequence(first, 42)
+    assert_sample_sequence(second, 74)
+
+
+@cocotb.test()
+async def jtag_pipe_iface_segmented_alignment(dut):
+    cocotb.start_soon(Clock(dut.tck, 10, units="ns").start())
+    dut.arst.value = 1
+    dut.tdi.value = 0
+    dut.capture.value = 0
+    dut.shift_en.value = 0
+    dut.update.value = 0
+    dut.sel.value = 0
+    dut.reg_rdata.value = 0
+    dut.sample_data.value = 0
+    dut.timestamp_data.value = 0
+    dut.burst_start.value = 0
+    dut.burst_timestamp.value = 0
+    dut.burst_ptr_in.value = 256
+    await idle_tap(dut, 4)
+    dut.arst.value = 0
+    await idle_tap(dut, 4)
+    dut.sel.value = 1
+    dut.capture.value = 1
+    dut.burst_start.value = 1
+    await tick(dut.tck)
+    dut.capture.value = 0
+    dut.sel.value = 0
+    await idle_tap(dut, 4)
+    assert (int(dut.mem_addr.value) >> 8) == 1
+
+
+@cocotb.test()
+async def fcapz_eio_registers(dut):
+    cocotb.start_soon(Clock(dut.jtag_clk, 14, units="ns").start())
+    dut.jtag_rst.value = 1
+    dut.probe_in.value = 0
+    dut.jtag_wr_en.value = 0
+    dut.jtag_addr.value = 0
+    dut.jtag_wdata.value = 0
+    for _ in range(3):
+        await RisingEdge(dut.jtag_clk)
+    dut.jtag_rst.value = 0
+    for _ in range(2):
+        await RisingEdge(dut.jtag_clk)
+
+    version = await jtag_read(dut, 0x0000, settle=0)
+    assert version & 0xFFFF == 0x494F
+    assert await jtag_read(dut, 0x0004, settle=0) == 16
+    assert await jtag_read(dut, 0x0008, settle=0) == 12
+    await jtag_write(dut, 0x0100, 0xABC)
+    assert await jtag_read(dut, 0x0100, settle=0) == 0xABC
+    assert int(dut.probe_out.value) == 0xABC
+    await jtag_write(dut, 0x0100, 0)
+    assert await jtag_read(dut, 0x0100, settle=0) == 0
+    assert int(dut.probe_out.value) == 0
+    await jtag_write(dut, 0x0100, 0xFFF)
+    assert await jtag_read(dut, 0x0100, settle=0) == 0xFFF
+    assert int(dut.probe_out.value) == 0xFFF
+
+    dut.jtag_rst.value = 1
+    for _ in range(2):
+        await RisingEdge(dut.jtag_clk)
+    dut.jtag_rst.value = 0
+    for _ in range(2):
+        await RisingEdge(dut.jtag_clk)
+    assert await jtag_read(dut, 0x0100, settle=0) == 0
+    assert int(dut.probe_out.value) == 0
+
+    dut.probe_in.value = 0xCAFE
+    for _ in range(4):
+        await RisingEdge(dut.jtag_clk)
+    assert await jtag_read(dut, 0x0010, settle=0) == 0xCAFE
+    dut.probe_in.value = 0x1234
+    for _ in range(4):
+        await RisingEdge(dut.jtag_clk)
+    assert await jtag_read(dut, 0x0010, settle=0) == 0x1234
+    assert await jtag_read(dut, 0x0200, settle=0) == 0
+
+    await jtag_write(dut, 0x0100, 0)
+    data = await jtag_read(dut, 0x0100, settle=0)
+    await jtag_write(dut, 0x0100, data | 0x8)
+    data = await jtag_read(dut, 0x0100, settle=0)
+    assert data & 0x8
+    assert data & 0xFFFF_FFF7 == 0
+    await jtag_write(dut, 0x0100, data & ~0x8)
+    assert not (await jtag_read(dut, 0x0100, settle=0) & 0x8)
+
+
+async def manager_write(dut, addr: int, data: int) -> None:
+    await FallingEdge(dut.jtag_clk)
+    dut.jtag_addr.value = addr
+    dut.jtag_wdata.value = data
+    dut.jtag_wr_en.value = 1
+    dut.jtag_rd_en.value = 0
+    await FallingEdge(dut.jtag_clk)
+    dut.jtag_wr_en.value = 0
+
+
+async def manager_read(dut, addr: int) -> int:
+    await FallingEdge(dut.jtag_clk)
+    dut.jtag_addr.value = addr
+    dut.jtag_rd_en.value = 1
+    dut.jtag_wr_en.value = 0
+    await Timer(1, units="ns")
+    data = int(dut.jtag_rdata.value)
+    await FallingEdge(dut.jtag_clk)
+    dut.jtag_rd_en.value = 0
+    return data
+
+
+@cocotb.test()
+async def fcapz_core_manager_mux(dut):
+    cocotb.start_soon(Clock(dut.jtag_clk, 10, units="ns").start())
+    dut.jtag_rst.value = 1
+    dut.jtag_wr_en.value = 0
+    dut.jtag_rd_en.value = 0
+    dut.jtag_addr.value = 0
+    dut.jtag_wdata.value = 0
+    dut.slot_rdata.value = (0x2222_0000 << 64) | (0x1111_0000 << 32)
+    dut.slot_burst_rd_data.value = (0xC2 << 16) | (0xB1 << 8) | 0xA0
+    dut.slot_burst_rd_ts_data.value = (0x2 << 8) | (0x1 << 4)
+    dut.slot_burst_start.value = 0b111
+    dut.slot_burst_timestamp.value = 0b101
+    dut.slot_burst_start_ptr.value = (0xC << 8) | (0xB << 4) | 0xA
+    for _ in range(3):
+        await FallingEdge(dut.jtag_clk)
+    dut.jtag_rst.value = 0
+    await FallingEdge(dut.jtag_clk)
+
+    assert await manager_read(dut, 0xF000) == 0x0004_434D
+    assert await manager_read(dut, 0xF004) == 3
+    assert await manager_read(dut, 0xF008) == 0
+    assert await manager_read(dut, 0xEFFF) == 0
+    assert int(dut.slot_rd_en.value) & 1
+    assert await manager_read(dut, 0xF000) == 0x0004_434D
+    assert int(dut.slot_rd_en.value) == 0
+
+    await manager_write(dut, 0xF014, 2)
+    assert await manager_read(dut, 0xF018) == 0x494F
+    assert await manager_read(dut, 0xF01C) == 0
+    await manager_write(dut, 0xF008, 1)
+    assert await manager_read(dut, 0xF008) == 1
+    assert await manager_read(dut, 0x0020) == 0x1111_0000
+    assert int(dut.slot_rd_en.value) & 0b010
+    await manager_write(dut, 0xF008, 2)
+    assert await manager_read(dut, 0x0020) == 0x2222_0000
+    assert int(dut.burst_rd_data.value) == 0
+    assert int(dut.burst_rd_ts_data.value) == 0
+    assert int(dut.burst_start.value) == 0
+    assert int(dut.burst_timestamp.value) == 0
+    assert int(dut.burst_start_ptr.value) == 0
+    await manager_write(dut, 0xF008, 1)
+    await Timer(1, units="ns")
+    assert int(dut.burst_rd_data.value) == 0xB1
+    assert int(dut.burst_rd_ts_data.value) == 1
+    assert int(dut.burst_start.value) == 1
+    assert int(dut.burst_timestamp.value) == 0
+    assert int(dut.burst_start_ptr.value) == 0xB
+    await manager_write(dut, 0xF008, 7)
+    assert await manager_read(dut, 0xF008) == 1
+
+
+@cocotb.test()
+async def fcapz_ela_channel_mux(dut):
+    cocotb.start_soon(Clock(dut.sample_clk, 10, units="ns").start())
+    cocotb.start_soon(Clock(dut.jtag_clk, 14, units="ns").start())
+    dut.sample_rst.value = 1
+    dut.jtag_rst.value = 1
+    dut.probe_in.value = (0xCC << 16) | (0xBB << 8) | 0xAA
+    dut.trigger_in.value = 0
+    dut.jtag_wr_en.value = 0
+    dut.jtag_rd_en.value = 0
+    dut.jtag_addr.value = 0
+    dut.jtag_wdata.value = 0
+    dut.burst_rd_addr.value = 0
+    for _ in range(4):
+        await RisingEdge(dut.sample_clk)
+    dut.sample_rst.value = 0
+    for _ in range(2):
+        await RisingEdge(dut.jtag_clk)
+    dut.jtag_rst.value = 0
+    for _ in range(4):
+        await RisingEdge(dut.jtag_clk)
+
+    assert await jtag_read(dut, 0x00A4) == 3
+    assert await jtag_read(dut, 0x00A0) == 0
+
+    async def capture_channel(index: int) -> int:
+        await jtag_write(dut, 0x00A0, index)
+        await jtag_write(dut, 0x0004, 2)
+        for _ in range(10):
+            await RisingEdge(dut.sample_clk)
+        await jtag_write(dut, 0x0020, 1)
+        await jtag_write(dut, 0x0024, 0)
+        await jtag_write(dut, 0x0028, 0)
+        await jtag_write(dut, 0x0014, 0)
+        await jtag_write(dut, 0x0018, 2)
+        await arm_ela(dut)
+        for _ in range(100):
+            await RisingEdge(dut.sample_clk)
+        return await jtag_read(dut, 0x0100)
+
+    assert capture_channel
+    assert (await capture_channel(0)) & 0xFF == 0xAA
+    assert (await capture_channel(1)) & 0xFF == 0xBB
+    assert (await capture_channel(2)) & 0xFF == 0xCC
+    await jtag_write(dut, 0x00A0, 1)
+    assert await jtag_read(dut, 0x00A0) == 1
+    await jtag_write(dut, 0x00A0, 0)
+    assert await jtag_read(dut, 0x00A0) == 0
+    assert (await capture_channel(7)) & 0xFF == 0xAA
+
+
+@cocotb.test()
+async def fcapz_ela_xilinx7_single_chain(dut):
+    cocotb.start_soon(Clock(dut.sample_clk, 6, units="ns").start())
+    tap = dut.u_tap_ctrl.u_bscan
+    dut.sample_rst.value = 1
+    dut.probe_in.value = 0
+    dut.trigger_in.value = 0
+    dut.eio_probe_in.value = 0
+    tap.TCK.value = 0
+    tap.TDI.value = 0
+    tap.CAPTURE.value = 0
+    tap.SHIFT.value = 0
+    tap.UPDATE.value = 0
+    tap.SEL.value = 0
+
+    async def tck_tick() -> None:
+        tap.TCK.value = 0
+        await Timer(5, units="ns")
+        tap.TCK.value = 1
+        await Timer(1, units="ns")
+        tap.TCK.value = 0
+        await Timer(4, units="ns")
+
+    async def wrapper_idle(n: int) -> None:
+        tap.SEL.value = 0
+        tap.CAPTURE.value = 0
+        tap.SHIFT.value = 0
+        tap.UPDATE.value = 0
+        tap.TDI.value = 0
+        for _ in range(n):
+            await tck_tick()
+
+    async def wrapper_scan_reg(frame: int) -> int:
+        captured = 0
+        tap.SEL.value = 1
+        tap.CAPTURE.value = 1
+        await tck_tick()
+        tap.CAPTURE.value = 0
+        tap.SHIFT.value = 1
+        for i in range(49):
+            tap.TDI.value = (frame >> i) & 1
+            if i < 32 and int(dut.tap1_tdo.value):
+                captured |= 1 << i
+            await tck_tick()
+        tap.SHIFT.value = 0
+        tap.TDI.value = 0
+        tap.UPDATE.value = 1
+        await tck_tick()
+        tap.UPDATE.value = 0
+        tap.SEL.value = 0
+        return captured
+
+    async def wrapper_read(addr: int) -> int:
+        await wrapper_scan_reg(make_frame(addr, 0, False))
+        await wrapper_idle(2)
+        data = await wrapper_scan_reg(make_frame(addr, 0, False))
+        await wrapper_idle(2)
+        return data
+
+    async def wrapper_write(addr: int, data: int) -> None:
+        await wrapper_scan_reg(make_frame(addr, data, True))
+        await wrapper_idle(8)
+
+    async def wrapper_scan_burst() -> int:
+        bits = 0
+        tap.SEL.value = 1
+        tap.CAPTURE.value = 1
+        await tck_tick()
+        tap.CAPTURE.value = 0
+        tap.SHIFT.value = 1
+        for i in range(256):
+            tap.TDI.value = 0
+            if int(dut.tap1_tdo.value):
+                bits |= 1 << i
+            await tck_tick()
+        tap.SHIFT.value = 0
+        tap.UPDATE.value = 1
+        await tck_tick()
+        tap.UPDATE.value = 0
+        tap.SEL.value = 0
+        return bits
+
+    async def counter_driver() -> None:
+        value = 0
+        while True:
+            await RisingEdge(dut.sample_clk)
+            if int(dut.sample_rst.value):
+                value = 0
+            else:
+                value = (value + 1) & 0xFF
+            dut.probe_in.value = value
+
+    cocotb.start_soon(counter_driver())
+    await wrapper_idle(8)
+    for _ in range(8):
+        await RisingEdge(dut.sample_clk)
+    dut.sample_rst.value = 0
+    await wrapper_idle(12)
+
+    assert await wrapper_read(0x000C) == 8
+    await wrapper_write(0x0014, 4)
+    await wrapper_write(0x0018, 8)
+    await wrapper_write(0x0020, 1)
+    await wrapper_write(0x0024, 0x20)
+    await wrapper_write(0x0028, 0xFF)
+    await wrapper_write(0x0004, 1)
+
+    status = 0
+    for _ in range(200):
+        await wrapper_idle(8)
+        status = await wrapper_read(0x0008)
+        if status & 0x4:
+            break
+    assert status & 0x4
+    assert await wrapper_read(0x001C) == 13
+
+    await wrapper_write(0x002C, 0)
+    await wrapper_idle(80)
+    await wrapper_scan_burst()
+    burst = await wrapper_scan_burst()
+    prev = sample_at(burst, 0)
+    for i in range(1, 13):
+        cur = sample_at(burst, i)
+        assert cur == ((prev + 1) & 0xFF)
+        prev = cur
+
+
+@cocotb.test()
+async def fcapz_async_fifo_equiv(dut):
+    cocotb.start_soon(Clock(dut.wr_clk, 10, units="ns").start())
+    cocotb.start_soon(Clock(dut.rd_clk, 14, units="ns").start())
+    dut.rst.value = 1
+    dut.wr_en.value = 0
+    dut.rd_en.value = 0
+    dut.wr_data.value = 0
+
+    async def check_stable() -> None:
+        await FallingEdge(dut.rd_clk)
+        if int(dut.rd_empty_a.value) != int(dut.rd_empty_b.value):
+            raise AssertionError("rd_empty mismatch")
+        if int(dut.wr_full_a.value) != int(dut.wr_full_b.value):
+            raise AssertionError("wr_full mismatch")
+        if not int(dut.rd_empty_a.value) and not int(dut.rd_empty_b.value):
+            assert int(dut.rd_data_a.value) == int(dut.rd_data_b.value)
+
+    for _ in range(3):
+        await RisingEdge(dut.wr_clk)
+    dut.rst.value = 0
+    await RisingEdge(dut.wr_clk)
+
+    for i in range(16):
+        await RisingEdge(dut.wr_clk)
+        dut.wr_data.value = i
+        dut.wr_en.value = 1
+        await check_stable()
+    await RisingEdge(dut.wr_clk)
+    dut.wr_en.value = 0
+    for _ in range(4):
+        await check_stable()
+
+    for _ in range(16):
+        await RisingEdge(dut.rd_clk)
+        dut.rd_en.value = 1
+        await check_stable()
+    await RisingEdge(dut.rd_clk)
+    dut.rd_en.value = 0
+
+    for _ in range(4):
+        await RisingEdge(dut.wr_clk)
+    for i in range(8):
+        await RisingEdge(dut.wr_clk)
+        dut.wr_data.value = (0xA0 + i) & 0xFF
+        dut.wr_en.value = 1
+        await RisingEdge(dut.rd_clk)
+        dut.rd_en.value = 1
+        await check_stable()
+    await RisingEdge(dut.wr_clk)
+    dut.wr_en.value = 0
+    await RisingEdge(dut.rd_clk)
+    dut.rd_en.value = 0
+    for _ in range(8):
+        await check_stable()
+
+
+CMD_NOP = 0x0
+CMD_WRITE = 0x1
+CMD_READ = 0x2
+CMD_WRITE_INC = 0x3
+CMD_READ_INC = 0x4
+CMD_SET_ADDR = 0x5
+CMD_BURST_SETUP = 0x6
+CMD_BURST_WDATA = 0x7
+CMD_BURST_RDATA = 0x8
+CMD_BURST_RSTART = 0x9
+CMD_CONFIG = 0xE
+CMD_RESET = 0xF
+
+
+def axi_cmd(cmd: int, addr: int, payload: int, wstrb: int) -> int:
+    return ((cmd & 0xF) << 68) | ((wstrb & 0xF) << 64) | ((payload & 0xFFFF_FFFF) << 32) | (addr & 0xFFFF_FFFF)
+
+
+def axi_status(dout: int) -> int:
+    return (dout >> 68) & 0xF
+
+
+def axi_rdata(dout: int) -> int:
+    return dout & 0xFFFF_FFFF
+
+
+def axi_resp(dout: int) -> int:
+    return (dout >> 64) & 0x3
+
+
+async def axi_cdc_wait(dut, cycles: int = 10) -> None:
+    for _ in range(cycles):
+        await RisingEdge(dut.tck)
+
+
+async def dr_scan_72(dut, din: int) -> int:
+    dout = 0
+    await RisingEdge(dut.tck)
+    dut.sel.value = 1
+    dut.capture.value = 1
+    await RisingEdge(dut.tck)
+    dut.capture.value = 0
+    dut.shift_en.value = 1
+    for i in range(72):
+        dut.tdi.value = (din >> i) & 1
+        await FallingEdge(dut.tck)
+        if int(dut.tdo.value):
+            dout |= 1 << i
+        await RisingEdge(dut.tck)
+    dut.shift_en.value = 0
+    await RisingEdge(dut.tck)
+    dut.update.value = 1
+    await RisingEdge(dut.tck)
+    dut.update.value = 0
+    dut.sel.value = 0
+    return dout
+
+
+async def init_ejtagaxi(dut) -> None:
+    cocotb.start_soon(Clock(dut.tck, 100, units="ns").start())
+    cocotb.start_soon(Clock(dut.axi_clk, 30, units="ns").start())
+    dut.tdi.value = 0
+    dut.capture.value = 0
+    dut.shift_en.value = 0
+    dut.update.value = 0
+    dut.sel.value = 0
+    dut.axi_rst.value = 1
+    for _ in range(4):
+        await RisingEdge(dut.axi_clk)
+    dut.axi_rst.value = 0
+    await axi_cdc_wait(dut, 10)
+
+
+async def issue_and_wait_valid(dut, command: int, label: str) -> int:
+    await dr_scan_72(dut, command)
+    await axi_cdc_wait(dut)
+    last = 0
+    for _ in range(32):
+        last = await dr_scan_72(dut, axi_cmd(CMD_NOP, 0, 0, 0))
+        status = axi_status(last)
+        if status & 0x1:
+            return last
+        assert status & 0x2, f"{label}: became idle before prev_valid"
+        assert not (status & 0x4), f"{label}: error_sticky set"
+        await axi_cdc_wait(dut)
+    raise AssertionError(f"{label}: timed out waiting for prev_valid; last status=0x{axi_status(last):x}")
+
+
+async def drain_until_idle(dut) -> int:
+    last = 0
+    for _ in range(32):
+        last = await dr_scan_72(dut, axi_cmd(CMD_NOP, 0, 0, 0))
+        if not (axi_status(last) & 0x2):
+            return last
+        await axi_cdc_wait(dut)
+    raise AssertionError(f"reset drain timed out; last status=0x{axi_status(last):x}")
+
+
+@cocotb.test()
+async def fcapz_ejtagaxi_protocol(dut):
+    await init_ejtagaxi(dut)
+
+    out = await issue_and_wait_valid(dut, axi_cmd(CMD_WRITE, 0x0000_0000, 0xDEAD_BEEF, 0xF), "S1 write")
+    assert axi_resp(out) == 0
+    assert int(dut.mem0.value) == 0xDEAD_BEEF
+    await axi_cdc_wait(dut)
+
+    out = await issue_and_wait_valid(dut, axi_cmd(CMD_READ, 0x0000_0000, 0, 0), "S2 read")
+    assert axi_rdata(out) == 0xDEAD_BEEF
+    await axi_cdc_wait(dut)
+
+    await issue_and_wait_valid(dut, axi_cmd(CMD_WRITE, 0x0000_0004, 0x1234_5678, 0xF), "S3 write")
+    out = await issue_and_wait_valid(dut, axi_cmd(CMD_READ, 0x0000_0004, 0, 0), "S3 read")
+    assert axi_rdata(out) == 0x1234_5678
+    await axi_cdc_wait(dut)
+
+    await issue_and_wait_valid(dut, axi_cmd(CMD_WRITE, 0x0000_0008, 0xFFFF_FFFF, 0xF), "S4 full write")
+    await issue_and_wait_valid(dut, axi_cmd(CMD_WRITE, 0x0000_0008, 0xAABB_CCDD, 0x3), "S4 partial write")
+    out = await issue_and_wait_valid(dut, axi_cmd(CMD_READ, 0x0000_0008, 0, 0), "S4 read")
+    assert axi_rdata(out) == 0xFFFF_CCDD
+    await axi_cdc_wait(dut)
+
+    await dr_scan_72(dut, axi_cmd(CMD_SET_ADDR, 0x0000_0010, 0, 0))
+    await axi_cdc_wait(dut)
+    for i in range(4):
+        await issue_and_wait_valid(dut, axi_cmd(CMD_WRITE_INC, 0, 0xA000_0000 + i, 0xF), f"S5 write_inc {i}")
+    assert int(dut.mem4.value) == 0xA000_0000
+    assert int(dut.mem5.value) == 0xA000_0001
+    assert int(dut.mem6.value) == 0xA000_0002
+    assert int(dut.mem7.value) == 0xA000_0003
+
+    await dr_scan_72(dut, axi_cmd(CMD_SET_ADDR, 0x0000_0010, 0, 0))
+    await axi_cdc_wait(dut)
+    for i in range(4):
+        out = await issue_and_wait_valid(dut, axi_cmd(CMD_READ_INC, 0, 0, 0), f"S6 read_inc {i}")
+        assert axi_rdata(out) == 0xA000_0000 + i
+        await axi_cdc_wait(dut)
+
+    burst_setup = (0b01 << 12) | (0b010 << 8) | 3
+    await dr_scan_72(dut, axi_cmd(CMD_BURST_SETUP, 0x0000_0020, burst_setup, 0))
+    await axi_cdc_wait(dut)
+    for i in range(4):
+        await dr_scan_72(dut, axi_cmd(CMD_BURST_WDATA, 0, 0xB000_0000 + i, 0xF))
+        await axi_cdc_wait(dut)
+        await dr_scan_72(dut, axi_cmd(CMD_NOP, 0, 0, 0))
+        await axi_cdc_wait(dut)
+    assert int(dut.mem8.value) == 0xB000_0000
+    assert int(dut.mem9.value) == 0xB000_0001
+    assert int(dut.mem10.value) == 0xB000_0002
+    assert int(dut.mem11.value) == 0xB000_0003
+
+    await dr_scan_72(dut, axi_cmd(CMD_BURST_SETUP, 0x0000_0020, burst_setup, 0))
+    await axi_cdc_wait(dut)
+    await dr_scan_72(dut, axi_cmd(CMD_BURST_RSTART, 0, 0, 0))
+    await axi_cdc_wait(dut)
+    await axi_cdc_wait(dut, 20)
+    await dr_scan_72(dut, axi_cmd(CMD_BURST_RDATA, 0, 0, 0))
+    await axi_cdc_wait(dut)
+    for i in range(4):
+        out = await dr_scan_72(dut, axi_cmd(CMD_BURST_RDATA, 0, 0, 0))
+        assert axi_rdata(out) == 0xB000_0000 + i
+        await axi_cdc_wait(dut)
+
+    out = await issue_and_wait_valid(dut, axi_cmd(CMD_CONFIG, 0x0000_0000, 0, 0), "S9 version")
+    assert axi_rdata(out) == 0x0004_4A58
+    await axi_cdc_wait(dut)
+
+    out = await issue_and_wait_valid(dut, axi_cmd(CMD_CONFIG, 0x0000_0004, 0, 0), "S9 version alias")
+    assert axi_rdata(out) == 0x0004_4A58
+    await axi_cdc_wait(dut)
+
+    out = await issue_and_wait_valid(dut, axi_cmd(CMD_CONFIG, 0x0000_002C, 0, 0), "S9 features")
+    assert axi_rdata(out) == 0x000F_2020
+    await axi_cdc_wait(dut)
+
+    await dr_scan_72(dut, axi_cmd(CMD_RESET, 0, 0, 0))
+    await axi_cdc_wait(dut)
+    out = await drain_until_idle(dut)
+    assert not (axi_status(out) & 0x4)
+    assert not (axi_status(out) & 0x2)
+
+
+@cocotb.test()
+async def fcapz_ejtagaxi_reset_regression(dut):
+    await init_ejtagaxi(dut)
+
+    out = await issue_and_wait_valid(dut, axi_cmd(CMD_WRITE, 0x0000_0000, 0x1234_5678, 0xF), "write addr 0")
+    assert axi_resp(out) == 0
+    out = await issue_and_wait_valid(dut, axi_cmd(CMD_WRITE, 0x0000_0004, 0x89AB_CDEF, 0xF), "write addr 4")
+    assert axi_resp(out) == 0
+    assert int(dut.mem0.value) == 0x1234_5678
+    assert int(dut.mem1.value) == 0x89AB_CDEF
+
+    await dr_scan_72(dut, axi_cmd(CMD_RESET, 0, 0, 0))
+    await axi_cdc_wait(dut)
+    out = await drain_until_idle(dut)
+    status = axi_status(out)
+    assert not (status & 0x2)
+    assert int(dut.pending_count_probe.value) == 0
+    assert int(dut.last_cmd_probe.value) == CMD_NOP
+
+    out = await dr_scan_72(dut, axi_cmd(CMD_NOP, 0, 0, 0))
+    status = axi_status(out)
+    assert not (status & 0x1)
+    assert not (status & 0x4)
+    await axi_cdc_wait(dut)
+
+    out = await issue_and_wait_valid(dut, axi_cmd(CMD_READ, 0x0000_0000, 0, 0), "first post-reset read")
+    assert axi_resp(out) == 0
+    assert axi_rdata(out) == 0x1234_5678
+
+    await dr_scan_72(dut, axi_cmd(CMD_SET_ADDR, 0x0000_0004, 0, 0))
+    await axi_cdc_wait(dut)
+    out = await issue_and_wait_valid(dut, axi_cmd(CMD_READ_INC, 0, 0, 0), "first post-reset read_inc")
+    assert axi_resp(out) == 0
+    assert axi_rdata(out) == 0x89AB_CDEF
+    assert int(dut.debug_tck.value) == 0
+    assert int(dut.debug_tck_edge.value) == 0
+    assert int(dut.debug_axi.value) == 0
+    assert int(dut.debug_axi_edge.value) == 0
+
+
+UART_CMD_NOP = 0x0
+UART_CMD_TX_PUSH = 0x1
+UART_CMD_RX_POP = 0x2
+UART_CMD_TXRX = 0x3
+UART_CMD_CONFIG = 0xE
+UART_CMD_RESET = 0xF
+UART_BIT_PERIOD_NS = 10_000
+UART_TX_FIFO_DEPTH = 16
+UART_RX_FIFO_DEPTH = 16
+UART_BAUD_DIV = 100
+
+
+def uart_cmd(cmd: int, tx_byte: int) -> int:
+    return ((cmd & 0xF) << 28) | (tx_byte & 0xFF)
+
+
+def uart_rx_byte(dout: int) -> int:
+    return dout & 0xFF
+
+
+def uart_tx_free(dout: int) -> int:
+    return (dout >> 8) & 0xFF
+
+
+def uart_rx_ready(dout: int) -> int:
+    return (dout >> 24) & 1
+
+
+def uart_rx_valid(dout: int) -> int:
+    return (dout >> 28) & 1
+
+
+def uart_tx_full(dout: int) -> int:
+    return (dout >> 29) & 1
+
+
+def uart_rx_overflow(dout: int) -> int:
+    return (dout >> 30) & 1
+
+
+def uart_frame_err(dout: int) -> int:
+    return (dout >> 31) & 1
+
+
+async def uart_cdc_wait(dut, cycles: int = 10) -> None:
+    for _ in range(cycles):
+        await RisingEdge(dut.tck)
+
+
+async def dr_scan_32(dut, din: int) -> int:
+    dout = 0
+    await RisingEdge(dut.tck)
+    dut.sel.value = 1
+    dut.capture.value = 1
+    await RisingEdge(dut.tck)
+    dut.capture.value = 0
+    dut.shift.value = 1
+    for i in range(32):
+        dut.tdi.value = (din >> i) & 1
+        await FallingEdge(dut.tck)
+        if int(dut.tdo.value):
+            dout |= 1 << i
+        await RisingEdge(dut.tck)
+    dut.shift.value = 0
+    await RisingEdge(dut.tck)
+    dut.update.value = 1
+    await RisingEdge(dut.tck)
+    dut.update.value = 0
+    dut.sel.value = 0
+    return dout
+
+
+async def uart_send_byte(dut, data: int, stop_high: bool = True) -> None:
+    dut.uart_rxd.value = 0
+    await Timer(UART_BIT_PERIOD_NS, units="ns")
+    for i in range(8):
+        dut.uart_rxd.value = (data >> i) & 1
+        await Timer(UART_BIT_PERIOD_NS, units="ns")
+    dut.uart_rxd.value = 1 if stop_high else 0
+    await Timer(UART_BIT_PERIOD_NS, units="ns")
+    dut.uart_rxd.value = 1
+
+
+async def uart_recv_byte_timeout(dut, timeout_ns: int) -> tuple[bool, int]:
+    waited = 0
+    while int(dut.uart_txd.value) == 1 and waited < timeout_ns:
+        await Timer(100, units="ns")
+        waited += 100
+    if int(dut.uart_txd.value) != 0:
+        return False, 0
+    await Timer(UART_BIT_PERIOD_NS // 2, units="ns")
+    data = 0
+    for i in range(8):
+        await Timer(UART_BIT_PERIOD_NS, units="ns")
+        data |= int(dut.uart_txd.value) << i
+    await Timer(UART_BIT_PERIOD_NS, units="ns")
+    return True, data
+
+
+async def uart_recv_byte(dut) -> int:
+    while int(dut.uart_txd.value) == 1:
+        await Edge(dut.uart_txd)
+    await Timer(UART_BIT_PERIOD_NS // 2, units="ns")
+    data = 0
+    for i in range(8):
+        await Timer(UART_BIT_PERIOD_NS, units="ns")
+        data |= int(dut.uart_txd.value) << i
+    await Timer(UART_BIT_PERIOD_NS, units="ns")
+    return data
+
+
+async def init_ejtaguart(dut) -> None:
+    cocotb.start_soon(Clock(dut.tck, 100, units="ns").start())
+    cocotb.start_soon(Clock(dut.uart_clk, 100, units="ns").start())
+    dut.tdi.value = 0
+    dut.capture.value = 0
+    dut.shift.value = 0
+    dut.update.value = 0
+    dut.sel.value = 0
+    dut.uart_rxd.value = 1
+    dut.uart_rst.value = 1
+    for _ in range(4):
+        await RisingEdge(dut.uart_clk)
+    dut.uart_rst.value = 0
+    await uart_cdc_wait(dut, 20)
+
+
+@cocotb.test()
+async def fcapz_ejtaguart_protocol(dut):
+    await init_ejtaguart(dut)
+
+    await dr_scan_32(dut, uart_cmd(UART_CMD_CONFIG, 0x00))
+    await uart_cdc_wait(dut)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_CONFIG, 0x01))
+    assert uart_rx_byte(out) == 0x55
+    await uart_cdc_wait(dut)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_CONFIG, 0x02))
+    assert uart_rx_byte(out) == 0x4A
+    await uart_cdc_wait(dut)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_CONFIG, 0x03))
+    assert uart_rx_byte(out) == 0x04
+    await uart_cdc_wait(dut)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0x00))
+    assert uart_rx_byte(out) == 0x00
+    await uart_cdc_wait(dut)
+    await dr_scan_32(dut, uart_cmd(UART_CMD_CONFIG, 0x04))
+    await uart_cdc_wait(dut)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0x00))
+    assert uart_rx_byte(out) == 0x55
+    await uart_cdc_wait(dut)
+
+    await dr_scan_32(dut, uart_cmd(UART_CMD_TX_PUSH, 0xA5))
+    await uart_cdc_wait(dut)
+    valid, tx_byte = await uart_recv_byte_timeout(dut, UART_BIT_PERIOD_NS * 12)
+    assert valid
+    assert tx_byte == 0xA5
+    for _ in range(20):
+        await RisingEdge(dut.uart_clk)
+
+    await uart_send_byte(dut, 0x3C)
+    await uart_cdc_wait(dut, 40)
+    await dr_scan_32(dut, uart_cmd(UART_CMD_RX_POP, 0))
+    await uart_cdc_wait(dut)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
+    assert uart_rx_byte(out) == 0x3C
+    assert uart_rx_valid(out)
+    await uart_cdc_wait(dut)
+
+    await uart_send_byte(dut, 0xBE)
+    await uart_cdc_wait(dut, 40)
+    await dr_scan_32(dut, uart_cmd(UART_CMD_TXRX, 0x55))
+    valid, tx_byte = await uart_recv_byte_timeout(dut, UART_BIT_PERIOD_NS * 14)
+    assert valid
+    assert tx_byte == 0x55
+    await uart_cdc_wait(dut)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
+    assert uart_rx_byte(out) == 0xBE
+    assert uart_rx_valid(out)
+    for _ in range(UART_BAUD_DIV * 12):
+        await RisingEdge(dut.uart_clk)
+
+    await uart_send_byte(dut, 0xAA)
+    await uart_cdc_wait(dut, 40)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
+    assert uart_rx_ready(out)
+    await uart_cdc_wait(dut)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
+    assert uart_rx_ready(out)
+    assert not uart_rx_valid(out)
+    await uart_cdc_wait(dut)
+    await dr_scan_32(dut, uart_cmd(UART_CMD_RX_POP, 0))
+    await uart_cdc_wait(dut)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
+    assert uart_rx_byte(out) == 0xAA
+    await uart_cdc_wait(dut)
+
+    for i in range(UART_TX_FIFO_DEPTH + 8):
+        await dr_scan_32(dut, uart_cmd(UART_CMD_TX_PUSH, i))
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
+    assert uart_tx_full(out)
+    for _ in range(UART_TX_FIFO_DEPTH * UART_BAUD_DIV * 12):
+        await RisingEdge(dut.uart_clk)
+    await uart_cdc_wait(dut)
+
+    await dr_scan_32(dut, uart_cmd(UART_CMD_RESET, 0))
+    await uart_cdc_wait(dut, 30)
+    for i in range(UART_RX_FIFO_DEPTH + 2):
+        await uart_send_byte(dut, i)
+    await uart_cdc_wait(dut, 50)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
+    await uart_cdc_wait(dut, 10)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
+    assert uart_rx_overflow(out)
+    await uart_cdc_wait(dut)
+
+    await dr_scan_32(dut, uart_cmd(UART_CMD_RESET, 0))
+    await uart_cdc_wait(dut, 30)
+    await uart_send_byte(dut, 0, stop_high=False)
+    await uart_cdc_wait(dut, 50)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
+    assert uart_frame_err(out)
+    await uart_cdc_wait(dut)
+
+    await dr_scan_32(dut, uart_cmd(UART_CMD_RESET, 0))
+    await uart_cdc_wait(dut, 30)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
+    assert not uart_rx_overflow(out)
+    assert not uart_frame_err(out)
+    assert not uart_tx_full(out)
+    assert not uart_rx_ready(out)
+    await uart_cdc_wait(dut)
+
+    for expected in (0x11, 0x22, 0x33, 0x44):
+        await dr_scan_32(dut, uart_cmd(UART_CMD_TX_PUSH, expected))
+        got = await uart_recv_byte(dut)
+        await uart_send_byte(dut, got)
+        await uart_cdc_wait(dut, 40)
+        await dr_scan_32(dut, uart_cmd(UART_CMD_RX_POP, 0))
+        await uart_cdc_wait(dut)
+        out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
+        assert uart_rx_byte(out) == expected
+    await uart_cdc_wait(dut)
+
+    await dr_scan_32(dut, uart_cmd(UART_CMD_TX_PUSH, 0xFF))
+    while int(dut.uart_txd.value) == 1:
+        await Edge(dut.uart_txd)
+    await Timer(UART_BIT_PERIOD_NS * 10, units="ns")
+    for _ in range(20):
+        await RisingEdge(dut.uart_clk)
+    await uart_cdc_wait(dut)
+
+    await dr_scan_32(dut, uart_cmd(UART_CMD_RESET, 0))
+    await uart_cdc_wait(dut, 20)
+    for _ in range(UART_BAUD_DIV * 12 * 4):
+        await RisingEdge(dut.uart_clk)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
+    assert uart_tx_free(out) == UART_TX_FIFO_DEPTH
+    for i in range(3):
+        await dr_scan_32(dut, uart_cmd(UART_CMD_TX_PUSH, i))
+    await uart_cdc_wait(dut)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
+    assert uart_tx_free(out) < UART_TX_FIFO_DEPTH
+    for _ in range(100):
+        await RisingEdge(dut.uart_clk)
+    await uart_cdc_wait(dut)
+
+    await dr_scan_32(dut, uart_cmd(UART_CMD_RESET, 0))
+    await uart_cdc_wait(dut, 30)
+    for data in (0xD1, 0xD2, 0xD3):
+        await uart_send_byte(dut, data)
+    await uart_cdc_wait(dut, 40)
+    await dr_scan_32(dut, uart_cmd(UART_CMD_RX_POP, 0))
+    await uart_cdc_wait(dut)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_RX_POP, 0))
+    assert uart_rx_byte(out) == 0xD1
+    assert uart_rx_valid(out)
+    await uart_cdc_wait(dut)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_RX_POP, 0))
+    assert uart_rx_byte(out) == 0xD2
+    await uart_cdc_wait(dut)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
+    assert uart_rx_byte(out) == 0xD3
+    await uart_cdc_wait(dut)
+
+    await dr_scan_32(dut, uart_cmd(UART_CMD_RESET, 0))
+    await uart_cdc_wait(dut, 20)
+    for _ in range(UART_BAUD_DIV * 12 * 4):
+        await RisingEdge(dut.uart_clk)
+
+    bridge_on = True
+
+    async def bridge_txd_to_rxd() -> None:
+        dut.uart_rxd.value = int(dut.uart_txd.value)
+        while bridge_on:
+            await Edge(dut.uart_txd)
+            dut.uart_rxd.value = int(dut.uart_txd.value)
+
+    bridge_task = cocotb.start_soon(bridge_txd_to_rxd())
+    stress = (0x10, 0x21, 0x32, 0x43, 0x54, 0x65, 0x76, 0x87)
+    for data in stress:
+        await dr_scan_32(dut, uart_cmd(UART_CMD_TX_PUSH, data))
+    for _ in range(UART_BAUD_DIV * 12 * len(stress)):
+        await RisingEdge(dut.uart_clk)
+    await uart_cdc_wait(dut)
+    await dr_scan_32(dut, uart_cmd(UART_CMD_RX_POP, 0))
+    await uart_cdc_wait(dut)
+    for expected in stress[:-1]:
+        out = await dr_scan_32(dut, uart_cmd(UART_CMD_RX_POP, 0))
+        assert uart_rx_byte(out) == expected
+        assert uart_rx_valid(out)
+        await uart_cdc_wait(dut)
+    out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
+    assert uart_rx_byte(out) == stress[-1]
+    assert uart_rx_valid(out)
+    bridge_on = False
+    bridge_task.kill()
+    dut.uart_rxd.value = 1

--- a/tb/cocotb/core_test.py
+++ b/tb/cocotb/core_test.py
@@ -13,14 +13,67 @@ async def tick(signal) -> None:
     await Timer(1, units="ns")
 
 
-async def idle_tap(dut, n: int, *, shift_name: str = "shift_en") -> None:
-    dut.sel.value = 0
-    dut.capture.value = 0
-    getattr(dut, shift_name).value = 0
-    dut.update.value = 0
-    dut.tdi.value = 0
+async def _tap_idle(tap, tick_fn, n: int, *,
+                    sel: str, capture: str, shift: str, update: str, tdi: str) -> None:
+    getattr(tap, sel).value = 0
+    getattr(tap, capture).value = 0
+    getattr(tap, shift).value = 0
+    getattr(tap, update).value = 0
+    getattr(tap, tdi).value = 0
     for _ in range(n):
-        await tick(dut.tck)
+        await tick_fn()
+
+
+async def _tap_shift_frame(tap, tdo, tick_fn, frame: int, *,
+                           sel: str, capture: str, shift: str, update: str, tdi: str,
+                           bits: int = 49, capture_bits: int = 32) -> int:
+    captured = 0
+    getattr(tap, sel).value = 1
+    getattr(tap, capture).value = 1
+    await tick_fn()
+    getattr(tap, capture).value = 0
+    getattr(tap, shift).value = 1
+    for i in range(bits):
+        getattr(tap, tdi).value = (frame >> i) & 1
+        if i < capture_bits and int(tdo.value):
+            captured |= 1 << i
+        await tick_fn()
+    getattr(tap, shift).value = 0
+    getattr(tap, tdi).value = 0
+    getattr(tap, update).value = 1
+    await tick_fn()
+    getattr(tap, update).value = 0
+    getattr(tap, sel).value = 0
+    return captured
+
+
+async def _tap_shift_burst(tap, tdo, tick_fn, *,
+                           sel: str, capture: str, shift: str, update: str, tdi: str,
+                           bits: int = 256) -> int:
+    captured = 0
+    getattr(tap, sel).value = 1
+    getattr(tap, capture).value = 1
+    await tick_fn()
+    getattr(tap, capture).value = 0
+    getattr(tap, shift).value = 1
+    for i in range(bits):
+        getattr(tap, tdi).value = 0
+        if int(tdo.value):
+            captured |= 1 << i
+        await tick_fn()
+    getattr(tap, shift).value = 0
+    getattr(tap, update).value = 1
+    await tick_fn()
+    getattr(tap, update).value = 0
+    getattr(tap, sel).value = 0
+    return captured
+
+
+_DEFAULT_TAP_NAMES = dict(sel="sel", capture="capture", update="update", tdi="tdi")
+
+
+async def idle_tap(dut, n: int, *, shift_name: str = "shift_en") -> None:
+    await _tap_idle(dut, lambda: tick(dut.tck), n, shift=shift_name, **_DEFAULT_TAP_NAMES)
 
 
 def make_frame(addr: int, data: int, write: bool) -> int:
@@ -28,48 +81,17 @@ def make_frame(addr: int, data: int, write: bool) -> int:
 
 
 async def scan_reg(dut, frame: int, *, shift_name: str = "shift_en", tdo=None) -> int:
-    if tdo is None:
-        tdo = dut.tdo
-    captured = 0
-    dut.sel.value = 1
-    dut.capture.value = 1
-    await tick(dut.tck)
-    dut.capture.value = 0
-    getattr(dut, shift_name).value = 1
-    for i in range(49):
-        dut.tdi.value = (frame >> i) & 1
-        if i < 32 and int(tdo.value):
-            captured |= 1 << i
-        await tick(dut.tck)
-    getattr(dut, shift_name).value = 0
-    dut.tdi.value = 0
-    dut.update.value = 1
-    await tick(dut.tck)
-    dut.update.value = 0
-    dut.sel.value = 0
-    return captured
+    return await _tap_shift_frame(
+        dut, tdo if tdo is not None else dut.tdo, lambda: tick(dut.tck), frame,
+        shift=shift_name, **_DEFAULT_TAP_NAMES,
+    )
 
 
 async def scan_burst(dut, *, shift_name: str = "shift_en", tdo=None, bits: int = 256) -> int:
-    if tdo is None:
-        tdo = dut.tdo
-    captured = 0
-    dut.sel.value = 1
-    dut.capture.value = 1
-    await tick(dut.tck)
-    dut.capture.value = 0
-    getattr(dut, shift_name).value = 1
-    for i in range(bits):
-        dut.tdi.value = 0
-        if int(tdo.value):
-            captured |= 1 << i
-        await tick(dut.tck)
-    getattr(dut, shift_name).value = 0
-    dut.update.value = 1
-    await tick(dut.tck)
-    dut.update.value = 0
-    dut.sel.value = 0
-    return captured
+    return await _tap_shift_burst(
+        dut, tdo if tdo is not None else dut.tdo, lambda: tick(dut.tck),
+        shift=shift_name, bits=bits, **_DEFAULT_TAP_NAMES,
+    )
 
 
 def sample_at(bits: int, index: int, width: int = 8) -> int:
@@ -503,34 +525,13 @@ async def fcapz_ela_xilinx7_single_chain(dut):
         tap.TCK.value = 0
         await Timer(4, units="ns")
 
+    bscane_names = dict(sel="SEL", capture="CAPTURE", shift="SHIFT", update="UPDATE", tdi="TDI")
+
     async def wrapper_idle(n: int) -> None:
-        tap.SEL.value = 0
-        tap.CAPTURE.value = 0
-        tap.SHIFT.value = 0
-        tap.UPDATE.value = 0
-        tap.TDI.value = 0
-        for _ in range(n):
-            await tck_tick()
+        await _tap_idle(tap, tck_tick, n, **bscane_names)
 
     async def wrapper_scan_reg(frame: int) -> int:
-        captured = 0
-        tap.SEL.value = 1
-        tap.CAPTURE.value = 1
-        await tck_tick()
-        tap.CAPTURE.value = 0
-        tap.SHIFT.value = 1
-        for i in range(49):
-            tap.TDI.value = (frame >> i) & 1
-            if i < 32 and int(dut.tap1_tdo.value):
-                captured |= 1 << i
-            await tck_tick()
-        tap.SHIFT.value = 0
-        tap.TDI.value = 0
-        tap.UPDATE.value = 1
-        await tck_tick()
-        tap.UPDATE.value = 0
-        tap.SEL.value = 0
-        return captured
+        return await _tap_shift_frame(tap, dut.tap1_tdo, tck_tick, frame, **bscane_names)
 
     async def wrapper_read(addr: int) -> int:
         await wrapper_scan_reg(make_frame(addr, 0, False))
@@ -544,23 +545,7 @@ async def fcapz_ela_xilinx7_single_chain(dut):
         await wrapper_idle(8)
 
     async def wrapper_scan_burst() -> int:
-        bits = 0
-        tap.SEL.value = 1
-        tap.CAPTURE.value = 1
-        await tck_tick()
-        tap.CAPTURE.value = 0
-        tap.SHIFT.value = 1
-        for i in range(256):
-            tap.TDI.value = 0
-            if int(dut.tap1_tdo.value):
-                bits |= 1 << i
-            await tck_tick()
-        tap.SHIFT.value = 0
-        tap.UPDATE.value = 1
-        await tck_tick()
-        tap.UPDATE.value = 0
-        tap.SEL.value = 0
-        return bits
+        return await _tap_shift_burst(tap, dut.tap1_tdo, tck_tick, **bscane_names)
 
     async def counter_driver() -> None:
         value = 0

--- a/tb/cocotb/core_test.py
+++ b/tb/cocotb/core_test.py
@@ -470,7 +470,6 @@ async def fcapz_ela_channel_mux(dut):
             await RisingEdge(dut.sample_clk)
         return await jtag_read(dut, 0x0100)
 
-    assert capture_channel
     assert (await capture_channel(0)) & 0xFF == 0xAA
     assert (await capture_channel(1)) & 0xFF == 0xBB
     assert (await capture_channel(2)) & 0xFF == 0xCC

--- a/tb/cocotb/core_test.py
+++ b/tb/cocotb/core_test.py
@@ -664,7 +664,10 @@ CMD_RESET = 0xF
 
 
 def axi_cmd(cmd: int, addr: int, payload: int, wstrb: int) -> int:
-    return ((cmd & 0xF) << 68) | ((wstrb & 0xF) << 64) | ((payload & 0xFFFF_FFFF) << 32) | (addr & 0xFFFF_FFFF)
+    return (((cmd & 0xF) << 68)
+            | ((wstrb & 0xF) << 64)
+            | ((payload & 0xFFFF_FFFF) << 32)
+            | (addr & 0xFFFF_FFFF))
 
 
 def axi_status(dout: int) -> int:
@@ -734,7 +737,8 @@ async def issue_and_wait_valid(dut, command: int, label: str) -> int:
         assert status & 0x2, f"{label}: became idle before prev_valid"
         assert not (status & 0x4), f"{label}: error_sticky set"
         await axi_cdc_wait(dut)
-    raise AssertionError(f"{label}: timed out waiting for prev_valid; last status=0x{axi_status(last):x}")
+    raise AssertionError(
+        f"{label}: timed out waiting for prev_valid; last status=0x{axi_status(last):x}")
 
 
 async def drain_until_idle(dut) -> int:
@@ -751,7 +755,8 @@ async def drain_until_idle(dut) -> int:
 async def fcapz_ejtagaxi_protocol(dut):
     await init_ejtagaxi(dut)
 
-    out = await issue_and_wait_valid(dut, axi_cmd(CMD_WRITE, 0x0000_0000, 0xDEAD_BEEF, 0xF), "S1 write")
+    out = await issue_and_wait_valid(
+        dut, axi_cmd(CMD_WRITE, 0x0000_0000, 0xDEAD_BEEF, 0xF), "S1 write")
     assert axi_resp(out) == 0
     assert int(dut.mem0.value) == 0xDEAD_BEEF
     await axi_cdc_wait(dut)
@@ -765,8 +770,10 @@ async def fcapz_ejtagaxi_protocol(dut):
     assert axi_rdata(out) == 0x1234_5678
     await axi_cdc_wait(dut)
 
-    await issue_and_wait_valid(dut, axi_cmd(CMD_WRITE, 0x0000_0008, 0xFFFF_FFFF, 0xF), "S4 full write")
-    await issue_and_wait_valid(dut, axi_cmd(CMD_WRITE, 0x0000_0008, 0xAABB_CCDD, 0x3), "S4 partial write")
+    await issue_and_wait_valid(
+        dut, axi_cmd(CMD_WRITE, 0x0000_0008, 0xFFFF_FFFF, 0xF), "S4 full write")
+    await issue_and_wait_valid(
+        dut, axi_cmd(CMD_WRITE, 0x0000_0008, 0xAABB_CCDD, 0x3), "S4 partial write")
     out = await issue_and_wait_valid(dut, axi_cmd(CMD_READ, 0x0000_0008, 0, 0), "S4 read")
     assert axi_rdata(out) == 0xFFFF_CCDD
     await axi_cdc_wait(dut)
@@ -774,7 +781,9 @@ async def fcapz_ejtagaxi_protocol(dut):
     await dr_scan_72(dut, axi_cmd(CMD_SET_ADDR, 0x0000_0010, 0, 0))
     await axi_cdc_wait(dut)
     for i in range(4):
-        await issue_and_wait_valid(dut, axi_cmd(CMD_WRITE_INC, 0, 0xA000_0000 + i, 0xF), f"S5 write_inc {i}")
+        await issue_and_wait_valid(
+            dut, axi_cmd(CMD_WRITE_INC, 0, 0xA000_0000 + i, 0xF),
+            f"S5 write_inc {i}")
     assert int(dut.mem4.value) == 0xA000_0000
     assert int(dut.mem5.value) == 0xA000_0001
     assert int(dut.mem6.value) == 0xA000_0002
@@ -816,7 +825,8 @@ async def fcapz_ejtagaxi_protocol(dut):
     assert axi_rdata(out) == 0x0004_4A58
     await axi_cdc_wait(dut)
 
-    out = await issue_and_wait_valid(dut, axi_cmd(CMD_CONFIG, 0x0000_0004, 0, 0), "S9 version alias")
+    out = await issue_and_wait_valid(
+        dut, axi_cmd(CMD_CONFIG, 0x0000_0004, 0, 0), "S9 version alias")
     assert axi_rdata(out) == 0x0004_4A58
     await axi_cdc_wait(dut)
 
@@ -835,9 +845,11 @@ async def fcapz_ejtagaxi_protocol(dut):
 async def fcapz_ejtagaxi_reset_regression(dut):
     await init_ejtagaxi(dut)
 
-    out = await issue_and_wait_valid(dut, axi_cmd(CMD_WRITE, 0x0000_0000, 0x1234_5678, 0xF), "write addr 0")
+    out = await issue_and_wait_valid(
+        dut, axi_cmd(CMD_WRITE, 0x0000_0000, 0x1234_5678, 0xF), "write addr 0")
     assert axi_resp(out) == 0
-    out = await issue_and_wait_valid(dut, axi_cmd(CMD_WRITE, 0x0000_0004, 0x89AB_CDEF, 0xF), "write addr 4")
+    out = await issue_and_wait_valid(
+        dut, axi_cmd(CMD_WRITE, 0x0000_0004, 0x89AB_CDEF, 0xF), "write addr 4")
     assert axi_resp(out) == 0
     assert int(dut.mem0.value) == 0x1234_5678
     assert int(dut.mem1.value) == 0x89AB_CDEF
@@ -856,13 +868,15 @@ async def fcapz_ejtagaxi_reset_regression(dut):
     assert not (status & 0x4)
     await axi_cdc_wait(dut)
 
-    out = await issue_and_wait_valid(dut, axi_cmd(CMD_READ, 0x0000_0000, 0, 0), "first post-reset read")
+    out = await issue_and_wait_valid(
+        dut, axi_cmd(CMD_READ, 0x0000_0000, 0, 0), "first post-reset read")
     assert axi_resp(out) == 0
     assert axi_rdata(out) == 0x1234_5678
 
     await dr_scan_72(dut, axi_cmd(CMD_SET_ADDR, 0x0000_0004, 0, 0))
     await axi_cdc_wait(dut)
-    out = await issue_and_wait_valid(dut, axi_cmd(CMD_READ_INC, 0, 0, 0), "first post-reset read_inc")
+    out = await issue_and_wait_valid(
+        dut, axi_cmd(CMD_READ_INC, 0, 0, 0), "first post-reset read_inc")
     assert axi_resp(out) == 0
     assert axi_rdata(out) == 0x89AB_CDEF
     assert int(dut.debug_tck.value) == 0

--- a/tb/cocotb/ela_core_test.py
+++ b/tb/cocotb/ela_core_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import atexit
 import json
 import os
 from pathlib import Path
@@ -104,7 +105,6 @@ class ElaFunctionalCoverage:
 
     def hit(self, name: str) -> None:
         self.bins[name] += 1
-        self.write()
 
     def write(self) -> None:
         path = os.environ.get("ELA_COCOTB_COVERAGE_JSON")
@@ -123,6 +123,7 @@ class ElaFunctionalCoverage:
 
 
 FUNCTIONAL_COVERAGE = ElaFunctionalCoverage()
+atexit.register(FUNCTIONAL_COVERAGE.write)
 
 
 class ElaDriver:

--- a/tb/cocotb/ela_core_test.py
+++ b/tb/cocotb/ela_core_test.py
@@ -578,7 +578,8 @@ async def input_pipe_holdoff_late_ext_pulse(dut):
     ela.dut.trigger_in.value = 0
     for cycle in range(320):
         ela.dut.probe_in.value = cycle & 0xFF
-        ela.dut.trigger_in.value = 1 if any(start <= cycle <= start + 15 for start in (20, 90, 160, 230)) else 0
+        in_pulse = any(start <= cycle <= start + 15 for start in (20, 90, 160, 230))
+        ela.dut.trigger_in.value = 1 if in_pulse else 0
         await RisingEdge(ela.dut.sample_clk)
     ela.dut.trigger_in.value = 0
     assert await ela.wait_done() & 0x4
@@ -664,7 +665,12 @@ async def config_minimal(dut):
     ela = await setup(dut)
     assert await ela.read(ADDR_FEATURES) == 0x0001_0101
     assert await ela.read(ADDR_COMPARE_CAPS) == 0x0002_01C3
-    for addr in (ADDR_SQ_MODE, ADDR_SQ_VALUE, ADDR_SQ_MASK, ADDR_CHAN_SEL, ADDR_DECIM, ADDR_TRIG_EXT, ADDR_SEG_SEL, ADDR_PROBE_SEL):
+    disabled_regs = (
+        ADDR_SQ_MODE, ADDR_SQ_VALUE, ADDR_SQ_MASK,
+        ADDR_CHAN_SEL, ADDR_DECIM, ADDR_TRIG_EXT,
+        ADDR_SEG_SEL, ADDR_PROBE_SEL,
+    )
+    for addr in disabled_regs:
         await ela.write(addr, 0xFFFF)
         assert await ela.read(addr) == 0
     assert await ela.read(ADDR_SEG_STATUS) == 0x8000_0000
@@ -783,7 +789,8 @@ async def segmented_rearm_pulses_complete(dut):
     ela.dut.trigger_in.value = 0
     for cycle in range(320):
         ela.dut.probe_in.value = cycle & 0xFF
-        ela.dut.trigger_in.value = 1 if any(start <= cycle <= start + 3 for start in (8, 80, 152, 224)) else 0
+        in_pulse = any(start <= cycle <= start + 3 for start in (8, 80, 152, 224))
+        ela.dut.trigger_in.value = 1 if in_pulse else 0
         await RisingEdge(ela.dut.sample_clk)
     ela.dut.trigger_in.value = 0
     assert await ela.wait_done() & 0x4

--- a/tb/cocotb/ela_core_test.py
+++ b/tb/cocotb/ela_core_test.py
@@ -1,0 +1,833 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge
+
+
+ADDR_CTRL = 0x0004
+ADDR_STATUS = 0x0008
+ADDR_SAMPLE_W = 0x000C
+ADDR_DEPTH = 0x0010
+ADDR_PRETRIG = 0x0014
+ADDR_POSTTRIG = 0x0018
+ADDR_CAPTURE_LEN = 0x001C
+ADDR_TRIG_MODE = 0x0020
+ADDR_TRIG_VALUE = 0x0024
+ADDR_TRIG_MASK = 0x0028
+ADDR_BURST_PTR = 0x002C
+ADDR_SQ_MODE = 0x0030
+ADDR_SQ_VALUE = 0x0034
+ADDR_SQ_MASK = 0x0038
+ADDR_FEATURES = 0x003C
+ADDR_SEQ_BASE = 0x0040
+ADDR_CHAN_SEL = 0x00A0
+ADDR_NUM_CHAN = 0x00A4
+ADDR_PROBE_SEL = 0x00AC
+ADDR_DECIM = 0x00B0
+ADDR_TRIG_EXT = 0x00B4
+ADDR_NUM_SEGMENTS = 0x00B8
+ADDR_SEG_STATUS = 0x00BC
+ADDR_SEG_SEL = 0x00C0
+ADDR_TIMESTAMP_W = 0x00C4
+ADDR_PROBE_MUX_W = 0x00D0
+ADDR_TRIG_DELAY = 0x00D4
+ADDR_STARTUP_ARM = 0x00D8
+ADDR_TRIG_HOLDOFF = 0x00DC
+ADDR_COMPARE_CAPS = 0x00E0
+ADDR_DATA_BASE = 0x0100
+
+
+def env_int(name: str, default: int) -> int:
+    return int(os.environ.get(name, str(default)), 0)
+
+
+SAMPLE_W = env_int("ELA_PARAM_SAMPLE_W", 8)
+DEPTH = env_int("ELA_PARAM_DEPTH", 16)
+TIMESTAMP_W = env_int("ELA_PARAM_TIMESTAMP_W", 0)
+WORDS_PER_SAMPLE = (SAMPLE_W + 31) // 32
+TS_WORDS = (TIMESTAMP_W + 31) // 32 if TIMESTAMP_W > 0 else 0
+ADDR_TS_DATA_BASE = ADDR_DATA_BASE + DEPTH * WORDS_PER_SAMPLE * 4
+
+
+class ElaFunctionalCoverage:
+    def __init__(self) -> None:
+        self.bins = {
+            "version": 0,
+            "identity": 0,
+            "features": 0,
+            "register_roundtrip": 0,
+            "reset": 0,
+            "arm": 0,
+            "value_trigger": 0,
+            "edge_trigger": 0,
+            "overflow": 0,
+            "decim_zero": 0,
+            "decim_every4": 0,
+            "decimation": 0,
+            "external_trigger_disabled": 0,
+            "external_trigger_or": 0,
+            "external_trigger_and": 0,
+            "trigger_out": 0,
+            "timestamp": 0,
+            "timestamp_decim": 0,
+            "timestamp_48": 0,
+            "segments": 0,
+            "segmented_single_pulse_stall": 0,
+            "segmented_rearm_pulses": 0,
+            "probe_mux": 0,
+            "probe_mux_slice0": 0,
+            "trigger_delay": 0,
+            "trigger_delay_zero": 0,
+            "startup_arm": 0,
+            "trigger_holdoff": 0,
+            "input_pipe": 0,
+            "input_pipe_holdoff_ext": 0,
+            "full_depth": 0,
+            "early_pretrigger": 0,
+            "wide_sample": 0,
+            "sequencer": 0,
+            "user1_disabled": 0,
+            "rel_compare": 0,
+            "storage_qualifier": 0,
+            "burst_start": 0,
+            "rolling_prehistory": 0,
+            "rolling_rearm_history": 0,
+        }
+
+    def hit(self, name: str) -> None:
+        self.bins[name] += 1
+        self.write()
+
+    def write(self) -> None:
+        path = os.environ.get("ELA_COCOTB_COVERAGE_JSON")
+        if not path:
+            return
+        covered = sum(1 for count in self.bins.values() if count)
+        payload = {
+            "run": os.environ.get("ELA_COCOTB_RUN", "manual"),
+            "covered_bins": covered,
+            "total_bins": len(self.bins),
+            "percent": round((covered / len(self.bins)) * 100.0, 2),
+            "bins": self.bins,
+        }
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        Path(path).write_text(json.dumps(payload, indent=2) + "\n")
+
+
+FUNCTIONAL_COVERAGE = ElaFunctionalCoverage()
+
+
+class ElaDriver:
+    def __init__(self, dut) -> None:
+        self.dut = dut
+
+    async def start(self) -> None:
+        cocotb.start_soon(Clock(self.dut.sample_clk, 10, units="ns").start())
+        cocotb.start_soon(Clock(self.dut.jtag_clk, 14, units="ns").start())
+        self.dut.sample_rst.value = 1
+        self.dut.jtag_rst.value = 1
+        self.dut.probe_in.value = 0
+        self.dut.trigger_in.value = 0
+        self.dut.jtag_wr_en.value = 0
+        self.dut.jtag_rd_en.value = 0
+        self.dut.jtag_addr.value = 0
+        self.dut.jtag_wdata.value = 0
+        self.dut.burst_rd_addr.value = 0
+        await self.wait_sample(4)
+        self.dut.sample_rst.value = 0
+        await self.wait_jtag(2)
+        self.dut.jtag_rst.value = 0
+        await self.wait_jtag(4)
+
+    async def wait_sample(self, cycles: int) -> None:
+        for _ in range(cycles):
+            await RisingEdge(self.dut.sample_clk)
+
+    async def wait_jtag(self, cycles: int) -> None:
+        for _ in range(cycles):
+            await RisingEdge(self.dut.jtag_clk)
+
+    async def write(self, addr: int, data: int) -> None:
+        await RisingEdge(self.dut.jtag_clk)
+        self.dut.jtag_addr.value = addr
+        self.dut.jtag_wdata.value = data
+        self.dut.jtag_wr_en.value = 1
+        await RisingEdge(self.dut.jtag_clk)
+        self.dut.jtag_wr_en.value = 0
+
+    async def read(self, addr: int) -> int:
+        await RisingEdge(self.dut.jtag_clk)
+        self.dut.jtag_addr.value = addr
+        self.dut.jtag_rd_en.value = 1
+        await RisingEdge(self.dut.jtag_clk)
+        self.dut.jtag_rd_en.value = 0
+        await self.wait_jtag(8)
+        return int(self.dut.jtag_rdata.value)
+
+    async def reset_core(self) -> None:
+        await self.write(ADDR_CTRL, 0x2)
+        await self.wait_sample(10)
+
+    async def arm(self) -> None:
+        await self.write(ADDR_CTRL, 0x1)
+        await self.wait_armed()
+        FUNCTIONAL_COVERAGE.hit("arm")
+
+    async def wait_armed(self, timeout_cycles: int = 80) -> None:
+        for _ in range(timeout_cycles):
+            await self.wait_sample(1)
+            if int(self.dut.armed_out.value):
+                return
+        status = await self.read(ADDR_STATUS)
+        raise AssertionError(f"arm did not reach sample domain, status=0x{status:08x}")
+
+    async def wait_done(self, timeout_cycles: int = 200) -> int:
+        status = 0
+        for _ in range(timeout_cycles):
+            await self.wait_sample(1)
+            status = await self.read(ADDR_STATUS)
+            if status & 0x4:
+                return status
+        raise AssertionError(f"capture did not complete, last status=0x{status:08x}")
+
+    async def drive_counter(self, cycles: int, *, start: int = 0, mask: int | None = None) -> None:
+        if mask is None:
+            mask = (1 << min(SAMPLE_W, 32)) - 1
+        value = start & mask
+        self.dut.probe_in.value = value
+        for _ in range(cycles):
+            await RisingEdge(self.dut.sample_clk)
+            value = (value + 1) & mask
+            self.dut.probe_in.value = value
+
+    async def configure_value_capture(
+        self,
+        *,
+        pre: int,
+        post: int,
+        value: int,
+        mask: int = 0xFF,
+    ) -> None:
+        await self.write(ADDR_PRETRIG, pre)
+        await self.write(ADDR_POSTTRIG, post)
+        await self.write(ADDR_TRIG_MODE, 1)
+        await self.write(ADDR_TRIG_VALUE, value)
+        await self.write(ADDR_TRIG_MASK, mask)
+
+    async def read_samples(self, count: int, *, base: int = ADDR_DATA_BASE) -> list[int]:
+        return [await self.read(base + i * 4) for i in range(count)]
+
+
+async def setup(dut) -> ElaDriver:
+    ela = ElaDriver(dut)
+    await ela.start()
+    return ela
+
+
+@cocotb.test()
+async def identity_registers(dut):
+    ela = await setup(dut)
+    version = await ela.read(0x0000)
+    assert version & 0xFFFF == 0x4C41
+    FUNCTIONAL_COVERAGE.hit("version")
+    assert await ela.read(ADDR_SAMPLE_W) == SAMPLE_W
+    assert await ela.read(ADDR_DEPTH) == DEPTH
+    FUNCTIONAL_COVERAGE.hit("identity")
+
+
+@cocotb.test()
+async def features_registers(dut):
+    ela = await setup(dut)
+    features = await ela.read(ADDR_FEATURES)
+    assert ((features >> 16) & 0xFF) == env_int("ELA_PARAM_NUM_SEGMENTS", 1)
+    assert bool(features & 0x20) == bool(env_int("ELA_PARAM_DECIM_EN", 0))
+    assert bool(features & 0x40) == bool(env_int("ELA_PARAM_EXT_TRIG_EN", 0))
+    assert bool(features & 0x80) == bool(TIMESTAMP_W)
+    FUNCTIONAL_COVERAGE.hit("features")
+
+
+@cocotb.test()
+async def register_roundtrip(dut):
+    ela = await setup(dut)
+    await ela.write(ADDR_TRIG_VALUE, 0xDEAD_BEEF)
+    assert await ela.read(ADDR_TRIG_VALUE) == 0xDEAD_BEEF
+    await ela.write(ADDR_TRIG_MASK, 0x5A5A_5A5A)
+    assert await ela.read(ADDR_TRIG_MASK) == 0x5A5A_5A5A
+    FUNCTIONAL_COVERAGE.hit("register_roundtrip")
+
+
+@cocotb.test()
+async def value_capture(dut):
+    ela = await setup(dut)
+    await ela.configure_value_capture(pre=2, post=3, value=8)
+    await ela.arm()
+    await ela.drive_counter(13)
+    status = await ela.wait_done()
+    assert status & 0x2 and status & 0x4 and not (status & 0x9)
+    assert await ela.read(ADDR_CAPTURE_LEN) == 6
+    assert (await ela.read(ADDR_DATA_BASE + 2 * 4)) & 0xFF == 8
+    FUNCTIONAL_COVERAGE.hit("value_trigger")
+
+
+@cocotb.test()
+async def edge_capture(dut):
+    ela = await setup(dut)
+    await ela.reset_core()
+    await ela.write(ADDR_PRETRIG, 1)
+    await ela.write(ADDR_POSTTRIG, 2)
+    await ela.write(ADDR_TRIG_MODE, 2)
+    await ela.write(ADDR_TRIG_VALUE, 0)
+    await ela.write(ADDR_TRIG_MASK, 0x01)
+    await ela.arm()
+    ela.dut.probe_in.value = 0
+    await ela.wait_sample(3)
+    ela.dut.probe_in.value = 1
+    await ela.wait_sample(1)
+    ela.dut.probe_in.value = 3
+    await ela.wait_sample(1)
+    assert await ela.wait_done() & 0x6 == 0x6
+    FUNCTIONAL_COVERAGE.hit("edge_trigger")
+
+
+@cocotb.test()
+async def overflow_and_reset(dut):
+    ela = await setup(dut)
+    await ela.configure_value_capture(pre=8, post=8, value=5)
+    await ela.arm()
+    await ela.drive_counter(20)
+    status = 0
+    for _ in range(120):
+        await ela.wait_sample(1)
+        status = await ela.read(ADDR_STATUS)
+        if status & 0x8:
+            break
+    assert status & 0x8, f"overflow bit did not set: 0x{status:08x}"
+    FUNCTIONAL_COVERAGE.hit("overflow")
+    await ela.reset_core()
+    status = await ela.read(ADDR_STATUS)
+    assert status == 0
+    FUNCTIONAL_COVERAGE.hit("reset")
+
+
+@cocotb.test()
+async def decimation_and_external_trigger(dut):
+    ela = await setup(dut)
+    await ela.write(ADDR_DECIM, 3)
+    assert await ela.read(ADDR_DECIM) == 3
+    await ela.configure_value_capture(pre=0, post=3, value=8)
+    await ela.arm()
+    await ela.drive_counter(32)
+    assert await ela.wait_done(250) & 0x4
+    assert await ela.read(ADDR_CAPTURE_LEN) == 4
+    FUNCTIONAL_COVERAGE.hit("decimation")
+
+    await ela.reset_core()
+    await ela.write(ADDR_TRIG_EXT, 1)
+    await ela.configure_value_capture(pre=0, post=2, value=0xEE)
+    await ela.arm()
+    await ela.wait_sample(5)
+    ela.dut.trigger_in.value = 1
+    await ela.wait_sample(1)
+    ela.dut.trigger_in.value = 0
+    assert await ela.wait_done() & 0x4
+    FUNCTIONAL_COVERAGE.hit("external_trigger_or")
+
+    await ela.reset_core()
+    await ela.write(ADDR_TRIG_EXT, 2)
+    await ela.configure_value_capture(pre=0, post=2, value=3)
+    await ela.arm()
+    await ela.drive_counter(8)
+    assert not (await ela.read(ADDR_STATUS) & 0x2)
+    ela.dut.probe_in.value = 3
+    ela.dut.trigger_in.value = 1
+    await ela.wait_sample(1)
+    ela.dut.trigger_in.value = 0
+    assert await ela.wait_done() & 0x4
+    FUNCTIONAL_COVERAGE.hit("external_trigger_and")
+
+
+@cocotb.test()
+async def decimation_zero_and_every4(dut):
+    ela = await setup(dut)
+    await ela.write(ADDR_DECIM, 0)
+    await ela.configure_value_capture(pre=0, post=3, value=3)
+    await ela.arm()
+    await ela.drive_counter(16)
+    assert await ela.wait_done() & 0x4
+    assert await ela.read(ADDR_CAPTURE_LEN) == 4
+    assert await ela.read(ADDR_DATA_BASE) & 0xFF == 3
+    FUNCTIONAL_COVERAGE.hit("decim_zero")
+
+    await ela.reset_core()
+    await ela.write(ADDR_DECIM, 3)
+    await ela.configure_value_capture(pre=0, post=2, value=8)
+    await ela.arm()
+    await ela.drive_counter(40)
+    assert await ela.wait_done(250) & 0x4
+    assert await ela.read(ADDR_CAPTURE_LEN) == 3
+    FUNCTIONAL_COVERAGE.hit("decim_every4")
+
+
+@cocotb.test()
+async def external_trigger_disabled(dut):
+    ela = await setup(dut)
+    await ela.write(ADDR_TRIG_EXT, 0)
+    assert await ela.read(ADDR_TRIG_EXT) == 0
+    await ela.configure_value_capture(pre=0, post=2, value=0xEE)
+    await ela.arm()
+    ela.dut.trigger_in.value = 1
+    await ela.wait_sample(12)
+    ela.dut.trigger_in.value = 0
+    status = await ela.read(ADDR_STATUS)
+    assert not (status & 0x6)
+    FUNCTIONAL_COVERAGE.hit("external_trigger_disabled")
+
+
+@cocotb.test()
+async def trigger_out_pulse(dut):
+    ela = await setup(dut)
+    await ela.configure_value_capture(pre=0, post=1, value=3)
+    await ela.arm()
+    seen = 0
+    for i in range(20):
+        await RisingEdge(ela.dut.sample_clk)
+        ela.dut.probe_in.value = i
+        if int(ela.dut.trigger_out.value):
+            seen += 1
+    assert seen == 1
+    FUNCTIONAL_COVERAGE.hit("trigger_out")
+
+
+@cocotb.test()
+async def timestamp_capture(dut):
+    ela = await setup(dut)
+    assert await ela.read(ADDR_TIMESTAMP_W) == TIMESTAMP_W
+    await ela.configure_value_capture(pre=1, post=2, value=8)
+    await ela.arm()
+    await ela.drive_counter(30)
+    assert await ela.wait_done(250) & 0x4
+    ts0 = await ela.read(ADDR_TS_DATA_BASE)
+    ts1 = await ela.read(ADDR_TS_DATA_BASE + 4)
+    assert ts1 > ts0
+    FUNCTIONAL_COVERAGE.hit("timestamp")
+
+
+@cocotb.test()
+async def timestamp_decimation_gap(dut):
+    ela = await setup(dut)
+    await ela.write(ADDR_DECIM, 1)
+    await ela.configure_value_capture(pre=1, post=2, value=7)
+    await ela.arm()
+    await ela.drive_counter(30)
+    assert await ela.wait_done(250) & 0x4
+    ts0 = await ela.read(ADDR_TS_DATA_BASE)
+    ts1 = await ela.read(ADDR_TS_DATA_BASE + 4)
+    assert ts1 - ts0 >= 2
+    FUNCTIONAL_COVERAGE.hit("timestamp_decim")
+
+
+@cocotb.test()
+async def timestamp_48_upper_word(dut):
+    ela = await setup(dut)
+    await ela.configure_value_capture(pre=1, post=2, value=8)
+    await ela.arm()
+    await ela.drive_counter(30, start=0)
+    assert await ela.wait_done(250) & 0x4
+    low = await ela.read(ADDR_TS_DATA_BASE)
+    high = await ela.read(ADDR_TS_DATA_BASE + 4)
+    assert low != 0
+    assert high == 0
+    FUNCTIONAL_COVERAGE.hit("timestamp_48")
+
+
+@cocotb.test()
+async def segmented_capture(dut):
+    ela = await setup(dut)
+    assert await ela.read(ADDR_NUM_SEGMENTS) == 4
+    await ela.write(ADDR_DECIM, 0)
+    await ela.configure_value_capture(pre=0, post=3, value=3, mask=0x03)
+    await ela.arm()
+    await ela.drive_counter(80)
+    status = await ela.wait_done(300)
+    seg_status = await ela.read(ADDR_SEG_STATUS)
+    assert status & 0x4
+    assert seg_status & 0x8000_0000
+    FUNCTIONAL_COVERAGE.hit("segments")
+
+
+@cocotb.test()
+async def probe_mux_slice_selection(dut):
+    ela = await setup(dut)
+    assert await ela.read(ADDR_PROBE_MUX_W) == 32
+    await ela.write(ADDR_PROBE_SEL, 0)
+    await ela.configure_value_capture(pre=0, post=2, value=0xAA)
+    await ela.arm()
+    ela.dut.probe_in.value = 0x33_22_11_00
+    await ela.wait_sample(3)
+    ela.dut.probe_in.value = 0x33_22_11_AA
+    await ela.wait_sample(4)
+    assert await ela.wait_done() & 0x4
+    FUNCTIONAL_COVERAGE.hit("probe_mux_slice0")
+
+    await ela.reset_core()
+    await ela.write(ADDR_PROBE_SEL, 2)
+    assert await ela.read(ADDR_PROBE_SEL) == 2
+    await ela.configure_value_capture(pre=0, post=2, value=0xFF)
+    await ela.arm()
+    ela.dut.probe_in.value = 0x33_00_11_AA
+    await ela.wait_sample(3)
+    ela.dut.probe_in.value = 0x33_FF_11_AA
+    await ela.wait_sample(4)
+    assert await ela.wait_done() & 0x4
+    assert await ela.read(ADDR_DATA_BASE) & 0xFF == 0xFF
+    await ela.write(ADDR_PROBE_SEL, 3)
+    assert await ela.read(ADDR_PROBE_SEL) == 3
+    FUNCTIONAL_COVERAGE.hit("probe_mux")
+
+
+@cocotb.test()
+async def trigger_delay_startup_and_holdoff(dut):
+    ela = await setup(dut)
+    await ela.write(ADDR_TRIG_DELAY, 0)
+    await ela.configure_value_capture(pre=2, post=3, value=8)
+    await ela.arm()
+    await ela.drive_counter(20)
+    assert await ela.wait_done() & 0x4
+    assert await ela.read(ADDR_CAPTURE_LEN) == 6
+    assert await ela.read(ADDR_DATA_BASE + 2 * 4) & 0xFF == 8
+    FUNCTIONAL_COVERAGE.hit("trigger_delay_zero")
+
+    await ela.reset_core()
+    await ela.write(ADDR_TRIG_DELAY, 4)
+    assert await ela.read(ADDR_TRIG_DELAY) == 4
+    await ela.configure_value_capture(pre=2, post=3, value=8)
+    await ela.arm()
+    await ela.drive_counter(24)
+    assert await ela.wait_done() & 0x4
+    assert await ela.read(ADDR_CAPTURE_LEN) == 6
+    assert await ela.read(ADDR_DATA_BASE + 2 * 4) & 0xFF == 12
+    FUNCTIONAL_COVERAGE.hit("trigger_delay")
+
+    await ela.write(ADDR_STARTUP_ARM, 1)
+    await ela.reset_core()
+    await ela.wait_sample(12)
+    assert await ela.read(ADDR_STATUS) & 0x1
+    ela.dut.probe_in.value = 0
+    await ela.drive_counter(12)
+    assert await ela.wait_done() & 0x4
+    FUNCTIONAL_COVERAGE.hit("startup_arm")
+
+    await ela.write(ADDR_TRIG_HOLDOFF, 4)
+    assert await ela.read(ADDR_TRIG_HOLDOFF) == 4
+    await ela.reset_core()
+    await ela.configure_value_capture(pre=0, post=2, value=3)
+    await ela.arm()
+    await ela.drive_counter(16)
+    status = await ela.read(ADDR_STATUS)
+    assert not (status & 0x6)
+    await ela.reset_core()
+    await ela.configure_value_capture(pre=0, post=2, value=6)
+    await ela.arm()
+    await ela.drive_counter(20)
+    assert await ela.wait_done() & 0x4
+    FUNCTIONAL_COVERAGE.hit("trigger_holdoff")
+
+
+@cocotb.test()
+async def input_pipe_captures(dut):
+    ela = await setup(dut)
+    await ela.write(ADDR_DECIM, 0)
+    await ela.configure_value_capture(pre=0, post=0, value=0)
+    await ela.arm()
+    await ela.drive_counter(1200)
+    assert await ela.wait_done(400) & 0x4
+    assert await ela.read(ADDR_CAPTURE_LEN) == 1
+    assert await ela.read(ADDR_SEG_STATUS) & 0x8000_0000
+
+    await ela.reset_core()
+    await ela.configure_value_capture(pre=50, post=100, value=64)
+    await ela.arm()
+    await ela.drive_counter(1400)
+    assert await ela.wait_done(500) & 0x4
+    assert await ela.read(ADDR_CAPTURE_LEN) == 151
+    FUNCTIONAL_COVERAGE.hit("input_pipe")
+
+
+@cocotb.test()
+async def input_pipe_holdoff_late_ext_pulse(dut):
+    ela = await setup(dut)
+    await ela.reset_core()
+    await ela.write(ADDR_PRETRIG, 0)
+    await ela.write(ADDR_POSTTRIG, 2)
+    await ela.write(ADDR_TRIG_MODE, 1)
+    await ela.write(ADDR_TRIG_VALUE, 0)
+    await ela.write(ADDR_TRIG_MASK, 0)
+    await ela.write(ADDR_TRIG_EXT, 2)
+    await ela.write(ADDR_TRIG_HOLDOFF, 4)
+    await ela.wait_sample(12)
+    await ela.arm()
+    ela.dut.trigger_in.value = 0
+    for cycle in range(320):
+        ela.dut.probe_in.value = cycle & 0xFF
+        ela.dut.trigger_in.value = 1 if any(start <= cycle <= start + 15 for start in (20, 90, 160, 230)) else 0
+        await RisingEdge(ela.dut.sample_clk)
+    ela.dut.trigger_in.value = 0
+    assert await ela.wait_done() & 0x4
+    assert await ela.read(ADDR_CAPTURE_LEN) == 3
+    assert await ela.read(ADDR_SEG_STATUS) & 0x8000_0000
+    FUNCTIONAL_COVERAGE.hit("input_pipe_holdoff_ext")
+
+
+@cocotb.test()
+async def full_depth_capture(dut):
+    ela = await setup(dut)
+    await ela.configure_value_capture(pre=2, post=5, value=4)
+    await ela.arm()
+    await ela.drive_counter(20)
+    await ela.wait_sample(40)
+    assert await ela.read(ADDR_STATUS) & 0x4
+    data = await ela.read_samples(3)
+    assert data[0] & 0xFF == 2
+    assert data[2] & 0xFF == 4
+    FUNCTIONAL_COVERAGE.hit("full_depth")
+
+
+@cocotb.test()
+async def decimated_trigger_anchor(dut):
+    ela = await setup(dut)
+    await ela.write(ADDR_DECIM, 3)
+    await ela.configure_value_capture(pre=0, post=1, value=0x13)
+    await ela.arm()
+    await ela.drive_counter(40)
+    assert await ela.wait_done(250) & 0x4
+    assert await ela.read(ADDR_DATA_BASE) & 0xFF == 0x13
+    FUNCTIONAL_COVERAGE.hit("decimation")
+
+
+@cocotb.test()
+async def early_pretrigger_waits_for_fill(dut):
+    ela = await setup(dut)
+    await ela.write(ADDR_DECIM, 3)
+    await ela.configure_value_capture(pre=2, post=2, value=1)
+    await ela.arm()
+    await ela.drive_counter(290)
+    await ela.wait_sample(40)
+    assert await ela.read(ADDR_STATUS) & 0x4
+    data = await ela.read_samples(3)
+    assert data[0] & 0xFF == 251
+    assert data[1] & 0xFF == 255
+    assert data[2] & 0xFF == 1
+    FUNCTIONAL_COVERAGE.hit("early_pretrigger")
+
+
+@cocotb.test()
+async def sequencer_count_target_one(dut):
+    ela = await setup(dut)
+    await ela.write(ADDR_PRETRIG, 0)
+    await ela.write(ADDR_POSTTRIG, 0)
+    await ela.write(ADDR_SEQ_BASE + 0, 0x0000_1000)
+    await ela.write(ADDR_SEQ_BASE + 4, 7)
+    await ela.write(ADDR_SEQ_BASE + 8, 0xFF)
+    await ela.arm()
+    await ela.drive_counter(16)
+    assert await ela.wait_done() & 0x4
+    FUNCTIONAL_COVERAGE.hit("sequencer")
+
+
+@cocotb.test()
+async def wide_sample_readback(dut):
+    ela = await setup(dut)
+    sample = 0x1111_2222_3333
+    await ela.configure_value_capture(pre=0, post=0, value=0x33, mask=0xFF)
+    await ela.arm()
+    ela.dut.probe_in.value = sample
+    await ela.wait_sample(8)
+    assert await ela.wait_done() & 0x4
+    low = await ela.read(ADDR_DATA_BASE)
+    high = await ela.read(ADDR_DATA_BASE + 4)
+    assert low == 0x2222_3333
+    assert high == 0x0000_1111
+    FUNCTIONAL_COVERAGE.hit("wide_sample")
+
+
+@cocotb.test()
+async def config_minimal(dut):
+    ela = await setup(dut)
+    assert await ela.read(ADDR_FEATURES) == 0x0001_0101
+    assert await ela.read(ADDR_COMPARE_CAPS) == 0x0002_01C3
+    for addr in (ADDR_SQ_MODE, ADDR_SQ_VALUE, ADDR_SQ_MASK, ADDR_CHAN_SEL, ADDR_DECIM, ADDR_TRIG_EXT, ADDR_SEG_SEL, ADDR_PROBE_SEL):
+        await ela.write(addr, 0xFFFF)
+        assert await ela.read(addr) == 0
+    assert await ela.read(ADDR_SEG_STATUS) == 0x8000_0000
+    FUNCTIONAL_COVERAGE.hit("identity")
+
+
+@cocotb.test()
+async def config_user1_disabled(dut):
+    ela = await setup(dut)
+    await ela.configure_value_capture(pre=1, post=2, value=5)
+    await ela.arm()
+    await ela.drive_counter(20)
+    assert await ela.wait_done() & 0x4
+    assert await ela.read(ADDR_DATA_BASE) == 0
+    FUNCTIONAL_COVERAGE.hit("user1_disabled")
+
+
+@cocotb.test()
+async def config_rel_compare(dut):
+    ela = await setup(dut)
+    assert await ela.read(ADDR_COMPARE_CAPS) == 0x0002_01FF
+    await ela.write(ADDR_PRETRIG, 0)
+    await ela.write(ADDR_POSTTRIG, 2)
+    await ela.write(ADDR_SEQ_BASE + 0, 0x0000_1002)
+    await ela.write(ADDR_SEQ_BASE + 4, 10)
+    await ela.write(ADDR_SEQ_BASE + 8, 0xFF)
+    await ela.arm()
+    ela.dut.probe_in.value = 0x20
+    for _ in range(40):
+        await RisingEdge(ela.dut.sample_clk)
+        if int(ela.dut.probe_in.value) > 0:
+            ela.dut.probe_in.value = int(ela.dut.probe_in.value) - 1
+    assert await ela.wait_done() & 0x4
+    FUNCTIONAL_COVERAGE.hit("rel_compare")
+
+
+@cocotb.test()
+async def config_combo_sq_segments(dut):
+    ela = await setup(dut)
+    features = await ela.read(ADDR_FEATURES)
+    assert features & 0x10
+    assert ((features >> 16) & 0xFF) == 4
+    assert await ela.read(ADDR_COMPARE_CAPS) == 0x0003_01FF
+    await ela.write(ADDR_PRETRIG, 0)
+    await ela.write(ADDR_POSTTRIG, 2)
+    await ela.write(ADDR_SQ_MODE, 1)
+    await ela.write(ADDR_SQ_VALUE, 0)
+    await ela.write(ADDR_SQ_MASK, 1)
+    await ela.write(ADDR_SEQ_BASE + 0, 0x0000_1306)
+    await ela.write(ADDR_SEQ_BASE + 4, 0)
+    await ela.write(ADDR_SEQ_BASE + 8, 0xFF)
+    await ela.write(ADDR_SEQ_BASE + 12, 0)
+    await ela.write(ADDR_SEQ_BASE + 16, 0xFF)
+    await ela.arm()
+    await ela.drive_counter(80)
+    assert await ela.read(ADDR_CAPTURE_LEN) == 3
+    assert await ela.read(ADDR_SEG_STATUS) & 0x1
+    FUNCTIONAL_COVERAGE.hit("storage_qualifier")
+    FUNCTIONAL_COVERAGE.hit("segments")
+
+
+@cocotb.test()
+async def burst_start_register(dut):
+    ela = await setup(dut)
+    await ela.configure_value_capture(pre=0, post=1, value=3)
+    await ela.arm()
+    await ela.drive_counter(12)
+    assert await ela.wait_done() & 0x4
+    before = int(ela.dut.burst_start.value)
+    await ela.write(ADDR_BURST_PTR, 0)
+    await ela.wait_jtag(1)
+    after = int(ela.dut.burst_start.value)
+    assert before != after
+    FUNCTIONAL_COVERAGE.hit("burst_start")
+
+
+@cocotb.test()
+async def segmented_single_pulse_stalls(dut):
+    ela = await setup(dut)
+    await ela.write(ADDR_PRETRIG, 0)
+    await ela.write(ADDR_POSTTRIG, 2)
+    await ela.write(ADDR_TRIG_MODE, 1)
+    await ela.write(ADDR_TRIG_VALUE, 0)
+    await ela.write(ADDR_TRIG_MASK, 0)
+    await ela.write(ADDR_TRIG_EXT, 2)
+    await ela.write(ADDR_TRIG_HOLDOFF, 4)
+    await ela.wait_sample(12)
+    await ela.arm()
+    ela.dut.trigger_in.value = 0
+    for cycle in range(220):
+        ela.dut.probe_in.value = cycle & 0xFF
+        ela.dut.trigger_in.value = 1 if 8 <= cycle <= 11 else 0
+        await RisingEdge(ela.dut.sample_clk)
+    ela.dut.trigger_in.value = 0
+    await ela.wait_sample(40)
+    status = await ela.read(ADDR_STATUS)
+    seg_status = await ela.read(ADDR_SEG_STATUS)
+    assert not (status & 0x4)
+    assert not (seg_status & 0x8000_0000)
+    assert seg_status & 0x3 == 1
+    FUNCTIONAL_COVERAGE.hit("segmented_single_pulse_stall")
+
+
+@cocotb.test()
+async def segmented_rearm_pulses_complete(dut):
+    ela = await setup(dut)
+    await ela.write(ADDR_PRETRIG, 0)
+    await ela.write(ADDR_POSTTRIG, 2)
+    await ela.write(ADDR_TRIG_MODE, 1)
+    await ela.write(ADDR_TRIG_VALUE, 0)
+    await ela.write(ADDR_TRIG_MASK, 0)
+    await ela.write(ADDR_TRIG_EXT, 2)
+    await ela.write(ADDR_TRIG_HOLDOFF, 4)
+    await ela.wait_sample(12)
+    await ela.arm()
+    ela.dut.trigger_in.value = 0
+    for cycle in range(320):
+        ela.dut.probe_in.value = cycle & 0xFF
+        ela.dut.trigger_in.value = 1 if any(start <= cycle <= start + 3 for start in (8, 80, 152, 224)) else 0
+        await RisingEdge(ela.dut.sample_clk)
+    ela.dut.trigger_in.value = 0
+    assert await ela.wait_done() & 0x4
+    seg_status = await ela.read(ADDR_SEG_STATUS)
+    assert seg_status & 0x8000_0000
+    FUNCTIONAL_COVERAGE.hit("segmented_rearm_pulses")
+
+
+@cocotb.test()
+async def rolling_prehistory_and_rearm(dut):
+    ela = await setup(dut)
+    await ela.write(ADDR_PRETRIG, 8)
+    await ela.write(ADDR_POSTTRIG, 2)
+    await ela.write(ADDR_TRIG_MODE, 1)
+    await ela.write(ADDR_TRIG_VALUE, 255)
+    await ela.write(ADDR_TRIG_MASK, 0xFF)
+    await ela.write(ADDR_TRIG_EXT, 1)
+    ela.dut.probe_in.value = 0
+    await ela.drive_counter(24)
+    await ela.arm()
+    ela.dut.trigger_in.value = 0
+    for cycle in range(40):
+        await RisingEdge(ela.dut.sample_clk)
+        ela.dut.probe_in.value = (int(ela.dut.probe_in.value) + 1) & 0xFF
+        ela.dut.trigger_in.value = 1 if 2 <= cycle <= 4 else 0
+    await ela.wait_sample(40)
+    assert await ela.read(ADDR_STATUS) & 0x4
+    first = await ela.read_samples(10)
+    assert first[0] & 0xFF == 24
+    assert first[8] & 0xFF == 30
+    assert first[9] & 0xFF == 31
+    FUNCTIONAL_COVERAGE.hit("rolling_prehistory")
+
+    ela.dut.probe_in.value = 80
+    ela.dut.trigger_in.value = 0
+    await ela.drive_counter(6, start=80)
+    await ela.arm()
+    for cycle in range(40):
+        await RisingEdge(ela.dut.sample_clk)
+        ela.dut.probe_in.value = (int(ela.dut.probe_in.value) + 1) & 0xFF
+        ela.dut.trigger_in.value = 1 if 2 <= cycle <= 4 else 0
+    await ela.wait_sample(40)
+    assert await ela.read(ADDR_STATUS) & 0x4
+    second = await ela.read_samples(10)
+    assert (second[0] & 0xFF) == (first[9] & 0xFF)
+    assert second[8] & 0xFF >= 88
+    assert second[9] & 0xFF == ((second[8] & 0xFF) + 1) & 0xFF
+    FUNCTIONAL_COVERAGE.hit("rolling_rearm_history")

--- a/tb/cocotb/fcapz_async_fifo_equiv_wrap.v
+++ b/tb/cocotb/fcapz_async_fifo_equiv_wrap.v
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
+
+`timescale 1ns/1ps
+
+module fcapz_async_fifo_equiv_wrap #(
+    parameter DATA_W = 8,
+    parameter DEPTH = 16
+) (
+    input  wire              wr_clk,
+    input  wire              rd_clk,
+    input  wire              rst,
+    input  wire              wr_en,
+    input  wire [DATA_W-1:0] wr_data,
+    input  wire              rd_en,
+    output wire [DATA_W-1:0] rd_data_a,
+    output wire [DATA_W-1:0] rd_data_b,
+    output wire              rd_empty_a,
+    output wire              rd_empty_b,
+    output wire              wr_full_a,
+    output wire              wr_full_b
+);
+
+    fcapz_async_fifo #(
+        .DATA_W(DATA_W),
+        .DEPTH(DEPTH),
+        .USE_BEHAV_ASYNC_FIFO(1)
+    ) dut_a (
+        .wr_clk(wr_clk),
+        .wr_rst(rst),
+        .wr_en(wr_en),
+        .wr_data(wr_data),
+        .wr_full(wr_full_a),
+        .wr_rst_busy(),
+        .wr_count(),
+        .rd_clk(rd_clk),
+        .rd_rst(rst),
+        .rd_en(rd_en),
+        .rd_data(rd_data_a),
+        .rd_empty(rd_empty_a),
+        .rd_rst_busy(),
+        .rd_count()
+    );
+
+    fcapz_async_fifo #(
+        .DATA_W(DATA_W),
+        .DEPTH(DEPTH),
+        .USE_BEHAV_ASYNC_FIFO(0)
+    ) dut_b (
+        .wr_clk(wr_clk),
+        .wr_rst(rst),
+        .wr_en(wr_en),
+        .wr_data(wr_data),
+        .wr_full(wr_full_b),
+        .wr_rst_busy(),
+        .wr_count(),
+        .rd_clk(rd_clk),
+        .rd_rst(rst),
+        .rd_en(rd_en),
+        .rd_data(rd_data_b),
+        .rd_empty(rd_empty_b),
+        .rd_rst_busy(),
+        .rd_count()
+    );
+
+endmodule

--- a/tb/cocotb/fcapz_async_fifo_equiv_wrap.v
+++ b/tb/cocotb/fcapz_async_fifo_equiv_wrap.v
@@ -1,5 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
+//
+// NOTE: dut_b sets USE_BEHAV_ASYNC_FIFO=0, which selects xpm_fifo_async. In
+// CI (and any non-vendor build) that symbol resolves to tb/xpm_fifo_async_stub.v,
+// which itself re-instantiates fcapz_async_fifo with USE_BEHAV_ASYNC_FIFO=1.
+// As a result, against the stub this test compares the behavioral FIFO with
+// itself and cannot catch divergence from the real vendor xpm_fifo_async.
+// It still catches port-list / parameter drift between fcapz_async_fifo's two
+// branches and is meant to be re-run against the real XPM in a vendor flow.
 
 `timescale 1ns/1ps
 

--- a/tb/cocotb/fcapz_ejtagaxi_tb_wrap.v
+++ b/tb/cocotb/fcapz_ejtagaxi_tb_wrap.v
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
+
+`timescale 1ns/1ps
+
+module fcapz_ejtagaxi_tb_wrap #(
+    parameter DEBUG_EN = 0,
+    parameter FIFO_DEPTH = 16,
+    parameter CMD_FIFO_DEPTH = FIFO_DEPTH * 2,
+    parameter RESP_FIFO_DEPTH = FIFO_DEPTH * 2,
+    parameter USE_BEHAV_ASYNC_FIFO = 1,
+    parameter ASYNC_FIFO_IMPL = (USE_BEHAV_ASYNC_FIFO ? 0 : 1),
+    parameter CMD_FIFO_MEMORY_TYPE = "auto",
+    parameter RESP_FIFO_MEMORY_TYPE = "auto",
+    parameter BURST_FIFO_MEMORY_TYPE = "auto"
+) (
+    input  wire        tck,
+    input  wire        tdi,
+    output wire        tdo,
+    input  wire        capture,
+    input  wire        shift_en,
+    input  wire        update,
+    input  wire        sel,
+    input  wire        axi_clk,
+    input  wire        axi_rst,
+    output wire [31:0] mem0,
+    output wire [31:0] mem1,
+    output wire [31:0] mem4,
+    output wire [31:0] mem5,
+    output wire [31:0] mem6,
+    output wire [31:0] mem7,
+    output wire [31:0] mem8,
+    output wire [31:0] mem9,
+    output wire [31:0] mem10,
+    output wire [31:0] mem11,
+    output wire [7:0]  pending_count_probe,
+    output wire [3:0]  last_cmd_probe,
+    output wire [255:0] debug_tck,
+    output wire [255:0] debug_tck_edge,
+    output wire [255:0] debug_axi,
+    output wire [255:0] debug_axi_edge
+);
+
+    wire [31:0] m_axi_awaddr;
+    wire [7:0]  m_axi_awlen;
+    wire [2:0]  m_axi_awsize;
+    wire [1:0]  m_axi_awburst;
+    wire        m_axi_awvalid;
+    wire        m_axi_awready;
+    wire [2:0]  m_axi_awprot;
+    wire [31:0] m_axi_wdata;
+    wire [3:0]  m_axi_wstrb;
+    wire        m_axi_wvalid;
+    wire        m_axi_wready;
+    wire        m_axi_wlast;
+    wire [1:0]  m_axi_bresp;
+    wire        m_axi_bvalid;
+    wire        m_axi_bready;
+    wire [31:0] m_axi_araddr;
+    wire [7:0]  m_axi_arlen;
+    wire [2:0]  m_axi_arsize;
+    wire [1:0]  m_axi_arburst;
+    wire        m_axi_arvalid;
+    wire        m_axi_arready;
+    wire [2:0]  m_axi_arprot;
+    wire [31:0] m_axi_rdata;
+    wire [1:0]  m_axi_rresp;
+    wire        m_axi_rvalid;
+    wire        m_axi_rlast;
+    wire        m_axi_rready;
+
+    fcapz_ejtagaxi #(
+        .ADDR_W(32),
+        .DATA_W(32),
+        .FIFO_DEPTH(FIFO_DEPTH),
+        .CMD_FIFO_DEPTH(CMD_FIFO_DEPTH),
+        .RESP_FIFO_DEPTH(RESP_FIFO_DEPTH),
+        .TIMEOUT(4096),
+        .DEBUG_EN(DEBUG_EN),
+        .USE_BEHAV_ASYNC_FIFO(USE_BEHAV_ASYNC_FIFO),
+        .ASYNC_FIFO_IMPL(ASYNC_FIFO_IMPL),
+        .CMD_FIFO_MEMORY_TYPE(CMD_FIFO_MEMORY_TYPE),
+        .RESP_FIFO_MEMORY_TYPE(RESP_FIFO_MEMORY_TYPE),
+        .BURST_FIFO_MEMORY_TYPE(BURST_FIFO_MEMORY_TYPE)
+    ) dut (
+        .tck(tck),
+        .tdi(tdi),
+        .tdo(tdo),
+        .capture(capture),
+        .shift_en(shift_en),
+        .update(update),
+        .sel(sel),
+        .axi_clk(axi_clk),
+        .axi_rst(axi_rst),
+        .m_axi_awaddr(m_axi_awaddr),
+        .m_axi_awlen(m_axi_awlen),
+        .m_axi_awsize(m_axi_awsize),
+        .m_axi_awburst(m_axi_awburst),
+        .m_axi_awvalid(m_axi_awvalid),
+        .m_axi_awready(m_axi_awready),
+        .m_axi_awprot(m_axi_awprot),
+        .m_axi_wdata(m_axi_wdata),
+        .m_axi_wstrb(m_axi_wstrb),
+        .m_axi_wvalid(m_axi_wvalid),
+        .m_axi_wready(m_axi_wready),
+        .m_axi_wlast(m_axi_wlast),
+        .m_axi_bresp(m_axi_bresp),
+        .m_axi_bvalid(m_axi_bvalid),
+        .m_axi_bready(m_axi_bready),
+        .m_axi_araddr(m_axi_araddr),
+        .m_axi_arlen(m_axi_arlen),
+        .m_axi_arsize(m_axi_arsize),
+        .m_axi_arburst(m_axi_arburst),
+        .m_axi_arvalid(m_axi_arvalid),
+        .m_axi_arready(m_axi_arready),
+        .m_axi_arprot(m_axi_arprot),
+        .m_axi_rdata(m_axi_rdata),
+        .m_axi_rresp(m_axi_rresp),
+        .m_axi_rvalid(m_axi_rvalid),
+        .m_axi_rlast(m_axi_rlast),
+        .m_axi_rready(m_axi_rready),
+        .debug_tck(debug_tck),
+        .debug_tck_edge(debug_tck_edge),
+        .debug_axi(debug_axi),
+        .debug_axi_edge(debug_axi_edge)
+    );
+
+    axi4_test_slave #(
+        .ADDR_W(32),
+        .DATA_W(32),
+        .NUM_WORDS(16)
+    ) slave (
+        .clk(axi_clk),
+        .rst(axi_rst),
+        .s_axi_awaddr(m_axi_awaddr),
+        .s_axi_awlen(m_axi_awlen),
+        .s_axi_awsize(m_axi_awsize),
+        .s_axi_awburst(m_axi_awburst),
+        .s_axi_awvalid(m_axi_awvalid),
+        .s_axi_awready(m_axi_awready),
+        .s_axi_wdata(m_axi_wdata),
+        .s_axi_wstrb(m_axi_wstrb),
+        .s_axi_wlast(m_axi_wlast),
+        .s_axi_wvalid(m_axi_wvalid),
+        .s_axi_wready(m_axi_wready),
+        .s_axi_bresp(m_axi_bresp),
+        .s_axi_bvalid(m_axi_bvalid),
+        .s_axi_bready(m_axi_bready),
+        .s_axi_araddr(m_axi_araddr),
+        .s_axi_arlen(m_axi_arlen),
+        .s_axi_arsize(m_axi_arsize),
+        .s_axi_arburst(m_axi_arburst),
+        .s_axi_arvalid(m_axi_arvalid),
+        .s_axi_arready(m_axi_arready),
+        .s_axi_rdata(m_axi_rdata),
+        .s_axi_rresp(m_axi_rresp),
+        .s_axi_rlast(m_axi_rlast),
+        .s_axi_rvalid(m_axi_rvalid),
+        .s_axi_rready(m_axi_rready)
+    );
+
+    assign mem0 = slave.mem[0];
+    assign mem1 = slave.mem[1];
+    assign mem4 = slave.mem[4];
+    assign mem5 = slave.mem[5];
+    assign mem6 = slave.mem[6];
+    assign mem7 = slave.mem[7];
+    assign mem8 = slave.mem[8];
+    assign mem9 = slave.mem[9];
+    assign mem10 = slave.mem[10];
+    assign mem11 = slave.mem[11];
+    assign pending_count_probe = dut.pending_count;
+    assign last_cmd_probe = dut.last_cmd;
+
+endmodule

--- a/tb/fcapz_ela_func_cov.sv
+++ b/tb/fcapz_ela_func_cov.sv
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
+
+`timescale 1ns/1ps
+
+// Bound functional coverage for Verilator ELA coverage runs. This file is not
+// part of the Icarus simulation runner; sim/run_verilator_ela_coverage.py adds
+// it when collecting --coverage-user data.
+
+module fcapz_ela_func_cov #(
+    parameter SAMPLE_W = 32,
+    parameter DEPTH = 1024,
+    parameter TRIG_STAGES = 1,
+    parameter STOR_QUAL = 0,
+    parameter NUM_CHANNELS = 1,
+    parameter INPUT_PIPE = 0,
+    parameter DECIM_EN = 0,
+    parameter EXT_TRIG_EN = 0,
+    parameter TIMESTAMP_W = 0,
+    parameter NUM_SEGMENTS = 1,
+    parameter PROBE_MUX_W = 0,
+    parameter STARTUP_ARM = 0,
+    parameter DEFAULT_TRIG_EXT = 0,
+    parameter REL_COMPARE = 0,
+    parameter DUAL_COMPARE = 1,
+    parameter USER1_DATA_EN = 1
+) (
+    input wire sample_clk,
+    input wire sample_rst,
+    input wire trigger_in,
+    input wire trigger_out,
+    input wire armed_out,
+    input wire jtag_clk,
+    input wire jtag_rst,
+    input wire jtag_wr_en,
+    input wire jtag_rd_en,
+    input wire [15:0] jtag_addr,
+    input wire [31:0] jtag_wdata,
+    input wire [31:0] jtag_rdata,
+    input wire burst_start,
+    input wire burst_timestamp,
+    input wire armed,
+    input wire triggered,
+    input wire done,
+    input wire overflow,
+    input wire all_seg_done,
+    input wire trigger_hit,
+    input wire trigger_commit_now,
+    input wire pre_store_now,
+    input wire post_store_now,
+    input wire store_enable,
+    input wire segment_auto_rearm_now
+);
+    localparam [15:0] ADDR_CTRL         = 16'h0004;
+    localparam [15:0] ADDR_STATUS       = 16'h0008;
+    localparam [15:0] ADDR_PRETRIG      = 16'h0014;
+    localparam [15:0] ADDR_POSTTRIG     = 16'h0018;
+    localparam [15:0] ADDR_TRIG_MODE    = 16'h0020;
+    localparam [15:0] ADDR_TRIG_VALUE   = 16'h0024;
+    localparam [15:0] ADDR_TRIG_MASK    = 16'h0028;
+    localparam [15:0] ADDR_BURST_PTR    = 16'h002C;
+    localparam [15:0] ADDR_SQ_MODE      = 16'h0030;
+    localparam [15:0] ADDR_DECIM        = 16'h00B0;
+    localparam [15:0] ADDR_TRIG_EXT     = 16'h00B4;
+    localparam [15:0] ADDR_SEG_STATUS   = 16'h00BC;
+    localparam [15:0] ADDR_SEG_SEL      = 16'h00C0;
+    localparam [15:0] ADDR_PROBE_SEL    = 16'h00AC;
+    localparam [15:0] ADDR_TRIG_DELAY   = 16'h00D4;
+    localparam [15:0] ADDR_STARTUP_ARM  = 16'h00D8;
+    localparam [15:0] ADDR_TRIG_HOLDOFF = 16'h00DC;
+    localparam [15:0] ADDR_DATA_BASE    = 16'h0100;
+
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        jtag_wr_en && jtag_addr == ADDR_CTRL && jtag_wdata[0]);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        jtag_wr_en && jtag_addr == ADDR_CTRL && jtag_wdata[1]);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        jtag_wr_en && jtag_addr == ADDR_PRETRIG);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        jtag_wr_en && jtag_addr == ADDR_POSTTRIG);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        jtag_wr_en && jtag_addr == ADDR_TRIG_MODE && jtag_wdata[1:0] == 2'd1);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        jtag_wr_en && jtag_addr == ADDR_TRIG_MODE && jtag_wdata[1:0] == 2'd2);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        jtag_wr_en && jtag_addr == ADDR_TRIG_VALUE);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        jtag_wr_en && jtag_addr == ADDR_TRIG_MASK);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        STOR_QUAL != 0 && jtag_wr_en && jtag_addr == ADDR_SQ_MODE);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        DECIM_EN != 0 && jtag_wr_en && jtag_addr == ADDR_DECIM && jtag_wdata != 32'h0);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        EXT_TRIG_EN != 0 && jtag_wr_en && jtag_addr == ADDR_TRIG_EXT && jtag_wdata[1:0] != 2'd0);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        NUM_SEGMENTS > 1 && jtag_wr_en && jtag_addr == ADDR_SEG_SEL);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        PROBE_MUX_W > 0 && jtag_wr_en && jtag_addr == ADDR_PROBE_SEL);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        jtag_wr_en && jtag_addr == ADDR_TRIG_DELAY && jtag_wdata[15:0] != 16'h0);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        jtag_wr_en && jtag_addr == ADDR_STARTUP_ARM && jtag_wdata[0]);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        jtag_wr_en && jtag_addr == ADDR_TRIG_HOLDOFF && jtag_wdata[15:0] != 16'h0);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        jtag_rd_en && jtag_addr == ADDR_STATUS);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        USER1_DATA_EN != 0 && jtag_rd_en && jtag_addr >= ADDR_DATA_BASE);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        jtag_rd_en && jtag_addr == ADDR_SEG_STATUS);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        jtag_wr_en && jtag_addr == ADDR_BURST_PTR);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        $changed(burst_start));
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        $changed(burst_start) && burst_timestamp);
+    cover property (@(posedge jtag_clk) disable iff (jtag_rst)
+        jtag_rd_en && jtag_rdata != 32'h0);
+
+    cover property (@(posedge sample_clk) disable iff (sample_rst)
+        armed_out);
+    cover property (@(posedge sample_clk) disable iff (sample_rst)
+        armed && !triggered && !done);
+    cover property (@(posedge sample_clk) disable iff (sample_rst)
+        trigger_hit);
+    cover property (@(posedge sample_clk) disable iff (sample_rst)
+        trigger_commit_now);
+    cover property (@(posedge sample_clk) disable iff (sample_rst)
+        triggered && !done);
+    cover property (@(posedge sample_clk) disable iff (sample_rst)
+        done);
+    cover property (@(posedge sample_clk) disable iff (sample_rst)
+        overflow);
+    cover property (@(posedge sample_clk) disable iff (sample_rst)
+        pre_store_now);
+    cover property (@(posedge sample_clk) disable iff (sample_rst)
+        post_store_now);
+    cover property (@(posedge sample_clk) disable iff (sample_rst)
+        store_enable);
+    cover property (@(posedge sample_clk) disable iff (sample_rst)
+        EXT_TRIG_EN != 0 && trigger_in);
+    cover property (@(posedge sample_clk) disable iff (sample_rst)
+        EXT_TRIG_EN != 0 && trigger_out);
+    cover property (@(posedge sample_clk) disable iff (sample_rst)
+        NUM_SEGMENTS > 1 && segment_auto_rearm_now);
+    cover property (@(posedge sample_clk) disable iff (sample_rst)
+        NUM_SEGMENTS > 1 && all_seg_done);
+    cover property (@(posedge sample_clk) disable iff (sample_rst)
+        INPUT_PIPE != 0 && trigger_commit_now);
+    cover property (@(posedge sample_clk) disable iff (sample_rst)
+        TIMESTAMP_W != 0 && post_store_now);
+endmodule
+
+bind fcapz_ela fcapz_ela_func_cov #(
+    .SAMPLE_W(SAMPLE_W),
+    .DEPTH(DEPTH),
+    .TRIG_STAGES(TRIG_STAGES),
+    .STOR_QUAL(STOR_QUAL),
+    .NUM_CHANNELS(NUM_CHANNELS),
+    .INPUT_PIPE(INPUT_PIPE),
+    .DECIM_EN(DECIM_EN),
+    .EXT_TRIG_EN(EXT_TRIG_EN),
+    .TIMESTAMP_W(TIMESTAMP_W),
+    .NUM_SEGMENTS(NUM_SEGMENTS),
+    .PROBE_MUX_W(PROBE_MUX_W),
+    .STARTUP_ARM(STARTUP_ARM),
+    .DEFAULT_TRIG_EXT(DEFAULT_TRIG_EXT),
+    .REL_COMPARE(REL_COMPARE),
+    .DUAL_COMPARE(DUAL_COMPARE),
+    .USER1_DATA_EN(USER1_DATA_EN)
+) fcapz_ela_func_cov_i (
+    .sample_clk(sample_clk),
+    .sample_rst(sample_rst),
+    .trigger_in(trigger_in),
+    .trigger_out(trigger_out),
+    .armed_out(armed_out),
+    .jtag_clk(jtag_clk),
+    .jtag_rst(jtag_rst),
+    .jtag_wr_en(jtag_wr_en),
+    .jtag_rd_en(jtag_rd_en),
+    .jtag_addr(jtag_addr),
+    .jtag_wdata(jtag_wdata),
+    .jtag_rdata(jtag_rdata),
+    .burst_start(burst_start),
+    .burst_timestamp(burst_timestamp),
+    .armed(armed),
+    .triggered(triggered),
+    .done(done),
+    .overflow(overflow),
+    .all_seg_done(all_seg_done),
+    .trigger_hit(trigger_hit),
+    .trigger_commit_now(trigger_commit_now),
+    .pre_store_now(pre_store_now),
+    .post_store_now(post_store_now),
+    .store_enable(store_enable),
+    .segment_auto_rearm_now(segment_auto_rearm_now)
+);


### PR DESCRIPTION
## Summary

Replaces the SystemVerilog/iverilog testbenches driven by `sim/run_sim.py`
with a cocotb-based regression covering both the protocol cores and the
16-target ELA parameter matrix, and adds a Verilator-based ELA coverage
runner that emits merged line + toggle + functional coverage. CI's `sim`
job is sharded so the protocol benches and the ELA suite run in parallel.

## What's in the PR

### New cocotb suite — `tb/cocotb/`

| File | Coverage |
|------|----------|
| `core_test.py` | Trig compare (light + full), JTAG pipe/burst, EIO, core manager, ELA channel mux, Xilinx7 single-chain BSCANE2 wrapper, async-FIFO equivalence, EJTAG-AXI (incl. reset regression), EJTAG-UART |
| `ela_core_test.py` | Shared HDL-agnostic ELA stimulus: identity/features registers, value/edge capture, decimation, segmentation, timestamps, sequencer, probe mux, wide-sample readback, configuration matrix (`config_min`, `config_rel`, `config_combo`, …), functional-coverage bins written once at process exit |
| `fcapz_async_fifo_equiv_wrap.v` | Side-by-side behavioral and XPM-resolved FIFOs for the equivalence check |
| `fcapz_ejtagaxi_tb_wrap.v` | EJTAG-AXI DUT + `axi4_test_slave` with exposed scoreboard probes |

### Runners — `sim/`

| File | Role |
|------|------|
| `run_cocotb.py` | Drives the protocol cocotb regression (14 targets) on Icarus. `ela` positional re-invokes the ELA runner. `--skip-ela` for the protocol-only CI shard. WSL relaunch for Windows hosts. |
| `run_cocotb_ela.py` | Runs the 16-target ELA cocotb suite. Verilog default; `--hdl vhdl --vhdl-source <file>` runs the same Python tests against a VHDL ELA core. Merges per-target functional-coverage JSON. |
| `run_verilator_ela_coverage.py` | Builds the three SV ELA benches under Verilator with `--coverage-line --coverage-toggle --coverage-user`. Binds `tb/fcapz_ela_func_cov.sv` for SVA-style functional cover points. Emits merged coverage + annotated source under `build/verilator_ela_coverage/`. |
| `_runner_utils.py` | Shared WSL relaunch, path translation, and JUnit-XML check used by all three runners. |

### Functional coverage — `tb/fcapz_ela_func_cov.sv`

`bind` into `fcapz_ela` defining cover properties for arm, reset, trigger
commit, pre/post stores, overflow, segment auto-rearm, burst starts, and
the conditionally-instantiated features (`STOR_QUAL`, `DECIM_EN`,
`EXT_TRIG_EN`, `NUM_SEGMENTS`, `PROBE_MUX_W`, `INPUT_PIPE`, `TIMESTAMP_W`).

### CI — `.github/workflows/ci.yml`

`sim` is now a `matrix: [protocol, ela]` job with `cache: pip` keyed on
`pyproject.toml`. Both shards run with `iverilog -Wall` enabled per
bench via `cocotb.runner.runner.build(build_args=["-Wall"])`.

### One RTL change — `rtl/fcapz_ela.v`

The single-word JTAG readback path now uses `sample_chunk_word(data, 0)`
instead of `{{(32-SAMPLE_W){1'b0}}, data}`. With `SAMPLE_W==32`
(a valid configuration since `WORDS_PER_SAMPLE = (32+31)/32 = 1`)
the original form becomes `{{0{1'b0}}, data}`, a zero-replication
concat that Icarus tolerates but Verilator and several synthesis
flows reject. Functionally identical for all SAMPLE_W; portability
fix only.

### Dep — `pyproject.toml`

`hdl = ["cocotb>=1.9,<2"]` — pinned away from cocotb 2.x until the
`cocotb.runner` API changes are validated.

## Notable fixes during pre-PR review

- `check_results` was double-counting JUnit failures (element count + `<testsuite failures="N">` attribute). Element count only.
- `ElaFunctionalCoverage.hit()` rewrote `functional_coverage.json` on every
  bin increment; moved to a single `atexit` write per process.
- `--sim` restricted to `icarus` in `run_cocotb.py` because the ejtagaxi
  wrappers use hierarchical refs to internal regs that Verilator rejects
  without `/*verilator public*/` markers.
- `relaunch_in_wsl` now translates `C:\foo` / `C:/foo` argv entries to
  `/mnt/c/foo`, not just `argv[0]`.
- Triplicated `windows_to_wsl_path` / `running_in_wsl` / `relaunch_in_wsl`
  / `check_results` extracted to `sim/_runner_utils.py`.
- ~70 lines of duplicated BSCANE2 scan loops in the Xilinx7 single-chain
  test collapsed into the same `_tap_idle` / `_tap_shift_frame` /
  `_tap_shift_burst` primitives that back the module-level helpers.

## Known limitations / follow-ups

- `tb/cocotb/fcapz_async_fifo_equiv_wrap.v` compares the behavioral FIFO
  against itself when `xpm_fifo_async` resolves to the in-tree stub
  (`tb/xpm_fifo_async_stub.v`). Documented in the wrapper header; needs
  a vendor-Vivado CI lane to compare against the real XPM.
- `fcapz_ejtagaxi_tb_wrap.v` uses XMRs; the wrapper is Icarus-only until
  `/*verilator public*/` markers are added to the ELA / slave RTL.
- `tb/fcapz_ela_func_cov.sv` is a separate `bind` file that restates the
  parameter list; could fold into the ELA module to keep it in sync with
  internal-signal renames automatically.

## Test plan

- [ ] CI `lint-python` green
- [ ] CI `lint-rtl` green
- [ ] CI `lint-rtl-verilator` green
- [ ] CI `test-host` green
- [ ] CI `sim [protocol]` green
- [ ] CI `sim [ela]` green
- [ ] Spot-check `fcapz_ela_xilinx7_single_chain` locally — only test that
      exercises the parametrized BSCANE2 scan path
- [ ] Manual hardware regression on Arty A7-100T (not run in CI, opt-in
      via `FPGACAP_GUI_HW=1`)