### PR TITLE
Tighten VHDL parity coverage and trim disabled timestamp RAM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         run: pip install -e ".[hdl]"
       - name: Run cocotb RTL regression (protocol shard)
         if: matrix.shard == 'protocol'
-        run: python sim/run_cocotb.py --runner native --hdl ${{ matrix.hdl }} --clean --skip-ela --require-eio-coverage
+        run: python sim/run_cocotb.py --runner native --hdl ${{ matrix.hdl }} --clean --skip-ela --require-protocol-coverage
       - name: Run cocotb RTL regression (ELA shard)
         if: matrix.shard == 'ela'
         run: python sim/run_cocotb.py --runner native --hdl ${{ matrix.hdl }} --clean ela

--- a/README.md
+++ b/README.md
@@ -736,7 +736,7 @@ GitHub Actions runs on every push and pull request to `main` or `master`:
 | `lint-rtl` | `python sim/run_verilator_lint.py --self-test` -- full-project Verilator RTL lint plus intentional fixtures proving the gate catches one reg driven by multiple always blocks |
 | `hdl-parity` | `python sim/run_hdl_parity.py` - static generic/register-map parity for translated cores |
 | `hdl-formal-parity` | Manual `workflow_dispatch` job running `python sim/run_formal_hdl_parity.py` with GHDL/Yosys for manifest-driven sequential equivalence |
-| `sim` (matrix: `protocol`, `ela` x `verilog`, `vhdl`) | sharded cocotb RTL regression on Icarus for Verilog and GHDL for VHDL, with `iverilog -Wall` enabled per Verilog bench and a `pyproject.toml`-keyed pip cache. The `protocol` shard runs `python sim/run_cocotb.py --runner native --hdl <hdl> --clean --skip-ela --require-eio-coverage` (all Verilog protocol targets, the translated VHDL protocol targets when `<hdl>` is `vhdl`, and enforced EIO functional coverage). The `ela` shard runs `python sim/run_cocotb.py --runner native --hdl <hdl> --clean ela` and exercises the cocotb ELA suite against both languages. |
+| `sim` (matrix: `protocol`, `ela` x `verilog`, `vhdl`) | sharded cocotb RTL regression on Icarus for Verilog and GHDL for VHDL, with `iverilog -Wall` enabled per Verilog bench and a `pyproject.toml`-keyed pip cache. The `protocol` shard runs `python sim/run_cocotb.py --runner native --hdl <hdl> --clean --skip-ela --require-protocol-coverage` (all Verilog protocol targets, the translated VHDL protocol targets when `<hdl>` is `vhdl`, and enforced functional coverage for EIO, EJTAG-AXI, EJTAG-UART, JTAG burst/pipe, and async FIFO equivalence). The `ela` shard runs `python sim/run_cocotb.py --runner native --hdl <hdl> --clean ela` and exercises the cocotb ELA suite against both languages. |
 
 Hardware integration tests run manually (require physical Arty A7-100T + hw_server).
 The default run checks `examples/arty_a7/arty_a7_top.bit`; to check the mixed-language
@@ -855,10 +855,11 @@ unless `--skip-ela` is passed. With `--hdl vhdl`, it uses GHDL and the same
 Python tests for the translated VHDL EIO and ELA-derived channel-mux targets,
 plus the VHDL ELA suite; targets without VHDL implementations are skipped in a
 full run and rejected if requested explicitly.
-The EIO narrow and wide cocotb targets also write merged functional coverage to
-`build/cocotb/<hdl>_<sim>/eio_functional_coverage_merged.json`. CI runs the
-protocol shard with `--require-eio-coverage`, so EIO regressions fail unless
-all defined EIO functional bins are hit for both Verilog and VHDL.
+The cocotb protocol targets also write merged functional coverage to
+`build/cocotb/<hdl>_<sim>/*_functional_coverage_merged.json`. CI runs the
+protocol shard with `--require-protocol-coverage`, so regressions fail unless
+all defined EIO, EJTAG-AXI, EJTAG-UART, JTAG burst/pipe, and async FIFO
+equivalence functional bins are hit for both Verilog and VHDL.
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -736,7 +736,7 @@ GitHub Actions runs on every push and pull request to `main` or `master`:
 | `lint-rtl` | `python sim/run_verilator_lint.py --self-test` -- full-project Verilator RTL lint plus intentional fixtures proving the gate catches one reg driven by multiple always blocks |
 | `hdl-parity` | `python sim/run_hdl_parity.py` - static generic/register-map parity for translated cores |
 | `hdl-formal-parity` | Manual `workflow_dispatch` job running `python sim/run_formal_hdl_parity.py` with GHDL/Yosys for manifest-driven sequential equivalence |
-| `sim` (matrix: `protocol`, `ela` x `verilog`, `vhdl`) | sharded cocotb RTL regression on Icarus for Verilog and GHDL for VHDL, with `iverilog -Wall` enabled per Verilog bench and a `pyproject.toml`-keyed pip cache. The `protocol` shard runs `python sim/run_cocotb.py --runner native --hdl <hdl> --clean --skip-ela` (all Verilog protocol targets, and the translated VHDL protocol targets when `<hdl>` is `vhdl`). The `ela` shard runs `python sim/run_cocotb.py --runner native --hdl <hdl> --clean ela` and exercises the cocotb ELA suite against both languages. |
+| `sim` (matrix: `protocol`, `ela` x `verilog`, `vhdl`) | sharded cocotb RTL regression on Icarus for Verilog and GHDL for VHDL, with `iverilog -Wall` enabled per Verilog bench and a `pyproject.toml`-keyed pip cache. The `protocol` shard runs `python sim/run_cocotb.py --runner native --hdl <hdl> --clean --skip-ela --require-eio-coverage` (all Verilog protocol targets, the translated VHDL protocol targets when `<hdl>` is `vhdl`, and enforced EIO functional coverage). The `ela` shard runs `python sim/run_cocotb.py --runner native --hdl <hdl> --clean ela` and exercises the cocotb ELA suite against both languages. |
 
 Hardware integration tests run manually (require physical Arty A7-100T + hw_server).
 The default run checks `examples/arty_a7/arty_a7_top.bit`; to check the mixed-language
@@ -924,9 +924,7 @@ fpgacapZero/
       fcapz_eio_*.vhd        VHDL EIO vendor wrappers
   tb/
     *_tb.sv, *_tb.v          RTL simulations and focused regressions
-    vhdl/
-      fcapz_ela_tb.vhd       VHDL ELA regression
-      fcapz_eio_tb.vhd       VHDL EIO regression
+    cocotb/                  Shared Python RTL regressions for Verilog/VHDL
     fcapz_ela_config_matrix_tb.sv
                              ELA parameter/configuration matrix
     fcapz_ela_xilinx7_single_chain_tb.sv

--- a/rtl/fcapz_ela.v
+++ b/rtl/fcapz_ela.v
@@ -457,33 +457,40 @@ module fcapz_ela #(
     );
 
     // ---- Phase 3: Timestamp DPRAM ------------------------------------------
-    reg [TS_DATA_W-1:0] ts_counter;
     wire [TS_DATA_W-1:0] ts_dout_a;
     wire [TS_DATA_W-1:0] ts_dout_b;
-    assign ts_counter_cur = (TIMESTAMP_W > 0) ? ts_counter : {TS_DATA_W{1'b0}};
+    generate
+        if (TIMESTAMP_W > 0) begin : g_ts
+            reg [TS_DATA_W-1:0] ts_counter;
 
-    // Free-running counter in sample_clk when timestamping is enabled.
-    always @(posedge sample_clk or posedge sample_rst) begin
-        if (sample_rst)
-            ts_counter <= {TS_DATA_W{1'b0}};
-        else if (TIMESTAMP_W > 0)
-            ts_counter <= ts_counter + 1'b1;
-        else
-            ts_counter <= {TS_DATA_W{1'b0}};
-    end
+            assign ts_counter_cur = ts_counter;
 
-    dpram #(.WIDTH(TS_DATA_W), .DEPTH(DEPTH)) g_ts_mem_u_tsbuf (
-        .clk_a  (sample_clk),
-        .we_a   ((TIMESTAMP_W > 0) ? mem_we_a_ram : 1'b0),
-        .addr_a (mem_addr_a),
-        .din_a  (mem_ts_din_a_ram[TS_DATA_W-1:0]),
-        .dout_a (ts_dout_a),
-        .clk_b  (jtag_clk),
-        .addr_b (burst_rd_addr),
-        .dout_b (ts_dout_b)
-    );
-    assign ts_dout_a_mux = (TIMESTAMP_W > 0) ? ts_dout_a : {TS_MUX_W{1'b0}};
-    assign burst_rd_ts_data = (TIMESTAMP_W > 0) ? ts_dout_b : {TS_DATA_W{1'b0}};
+            // Free-running counter in sample_clk when timestamping is enabled.
+            always @(posedge sample_clk or posedge sample_rst) begin
+                if (sample_rst)
+                    ts_counter <= {TS_DATA_W{1'b0}};
+                else
+                    ts_counter <= ts_counter + 1'b1;
+            end
+
+            dpram #(.WIDTH(TS_DATA_W), .DEPTH(DEPTH)) u_tsbuf (
+                .clk_a  (sample_clk),
+                .we_a   (mem_we_a_ram),
+                .addr_a (mem_addr_a),
+                .din_a  (mem_ts_din_a_ram[TS_DATA_W-1:0]),
+                .dout_a (ts_dout_a),
+                .clk_b  (jtag_clk),
+                .addr_b (burst_rd_addr),
+                .dout_b (ts_dout_b)
+            );
+        end else begin : g_no_ts
+            assign ts_counter_cur = {TS_DATA_W{1'b0}};
+            assign ts_dout_a = {TS_DATA_W{1'b0}};
+            assign ts_dout_b = {TS_DATA_W{1'b0}};
+        end
+    endgenerate
+    assign ts_dout_a_mux = ts_dout_a;
+    assign burst_rd_ts_data = ts_dout_b;
 
     // ---- Sequencer state (sample domain) -----------------------------------
     reg [SEQ_STATE_W-1:0] seq_state;

--- a/sim/run_cocotb.py
+++ b/sim/run_cocotb.py
@@ -239,7 +239,53 @@ TARGETS: tuple[Target, ...] = (
 
 TARGET_BY_NAME = {target.name: target for target in TARGETS}
 DEFAULT_TARGETS = tuple(target.name for target in TARGETS)
-EIO_COVERAGE_TARGETS = {"fcapz_eio", "fcapz_eio_wide"}
+COVERAGE_TARGETS = {
+    "fcapz_eio": ("eio", "EIO_COCOTB_COVERAGE_JSON", "EIO_COCOTB_RUN"),
+    "fcapz_eio_wide": ("eio", "EIO_COCOTB_COVERAGE_JSON", "EIO_COCOTB_RUN"),
+    "jtag_burst_read": (
+        "jtag_burst_read",
+        "JTAG_BURST_COCOTB_COVERAGE_JSON",
+        "JTAG_BURST_COCOTB_RUN",
+    ),
+    "jtag_pipe_iface": (
+        "jtag_pipe_iface",
+        "JTAG_PIPE_COCOTB_COVERAGE_JSON",
+        "JTAG_PIPE_COCOTB_RUN",
+    ),
+    "jtag_pipe_iface_segmented": (
+        "jtag_pipe_iface",
+        "JTAG_PIPE_COCOTB_COVERAGE_JSON",
+        "JTAG_PIPE_COCOTB_RUN",
+    ),
+    "fcapz_async_fifo_equiv": (
+        "fcapz_async_fifo_equiv",
+        "ASYNC_FIFO_COCOTB_COVERAGE_JSON",
+        "ASYNC_FIFO_COCOTB_RUN",
+    ),
+    "fcapz_ejtagaxi": (
+        "fcapz_ejtagaxi",
+        "EJTAG_AXI_COCOTB_COVERAGE_JSON",
+        "EJTAG_AXI_COCOTB_RUN",
+    ),
+    "fcapz_ejtagaxi_reset_regression": (
+        "fcapz_ejtagaxi",
+        "EJTAG_AXI_COCOTB_COVERAGE_JSON",
+        "EJTAG_AXI_COCOTB_RUN",
+    ),
+    "fcapz_ejtaguart": (
+        "fcapz_ejtaguart",
+        "EJTAG_UART_COCOTB_COVERAGE_JSON",
+        "EJTAG_UART_COCOTB_RUN",
+    ),
+}
+COVERAGE_GROUP_LABELS = {
+    "eio": "EIO",
+    "jtag_burst_read": "JTAG burst reader",
+    "jtag_pipe_iface": "JTAG pipe interface",
+    "fcapz_async_fifo_equiv": "async FIFO equivalence",
+    "fcapz_ejtagaxi": "EJTAG-AXI",
+    "fcapz_ejtaguart": "EJTAG-UART",
+}
 
 
 def merge_coverage(paths: list[Path], out: Path) -> dict[str, object] | None:
@@ -286,18 +332,15 @@ def target_supports_hdl(target: Target, hdl: str) -> bool:
     return hdl == "verilog" or bool(target.vhdl_sources)
 
 
-def run_target(target: Target, args: argparse.Namespace, hdl: str) -> Path | None:
+def run_target(target: Target, args: argparse.Namespace, hdl: str) -> tuple[str, Path] | None:
     from cocotb.runner import get_runner
 
     sim = args.sim or ("icarus" if hdl == "verilog" else "ghdl")
     runner = get_runner(sim)
     build_dir = BUILD_ROOT / f"{hdl}_{sim}" / target.name
     results_xml = build_dir / "results.xml"
-    coverage_json = (
-        build_dir / "functional_coverage.json"
-        if target.name in EIO_COVERAGE_TARGETS
-        else None
-    )
+    coverage_info = COVERAGE_TARGETS.get(target.name)
+    coverage_json = build_dir / "functional_coverage.json" if coverage_info else None
     if str(TB_COCOTB) not in sys.path:
         sys.path.insert(0, str(TB_COCOTB))
 
@@ -322,9 +365,11 @@ def run_target(target: Target, args: argparse.Namespace, hdl: str) -> Path | Non
         "FCAPZ_COCOTB_HDL": hdl,
     }
     if coverage_json is not None:
+        assert coverage_info is not None
+        _, json_env_var, run_env_var = coverage_info
         extra_env.update({
-            "EIO_COCOTB_COVERAGE_JSON": str(coverage_json),
-            "EIO_COCOTB_RUN": target.name,
+            json_env_var: str(coverage_json),
+            run_env_var: target.name,
         })
 
     runner.test(
@@ -342,7 +387,9 @@ def run_target(target: Target, args: argparse.Namespace, hdl: str) -> Path | Non
     )
     check_results(results_xml)
     print(f"cocotb {hdl} target passed: {target.name}")
-    return coverage_json
+    if coverage_info is None or coverage_json is None:
+        return None
+    return coverage_info[0], coverage_json
 
 
 def parse_args() -> argparse.Namespace:
@@ -358,8 +405,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--verbose", action="store_true")
     parser.add_argument("--skip-ela", action="store_true",
                         help="run only non-ELA cocotb replacements")
+    parser.add_argument("--require-protocol-coverage", action="store_true",
+                        help="fail unless all protocol functional coverage bins are hit")
     parser.add_argument("--require-eio-coverage", action="store_true",
-                        help="fail unless all EIO functional coverage bins are hit")
+                        dest="require_protocol_coverage",
+                        help="legacy alias for --require-protocol-coverage")
     return parser.parse_args()
 
 
@@ -384,34 +434,62 @@ def main() -> None:
             run_ela(args, hdl)
 
         skipped: list[str] = []
-        eio_coverage_paths: list[Path] = []
+        coverage_paths: dict[str, list[Path]] = {}
+        expected_coverage_groups: set[str] = set()
         for name in requested:
             if name == ELA_TARGET:
                 continue
             target = TARGET_BY_NAME[name]
             if target_supports_hdl(target, hdl):
-                coverage_path = run_target(target, args, hdl)
-                if coverage_path is not None:
-                    eio_coverage_paths.append(coverage_path)
+                coverage_info = COVERAGE_TARGETS.get(name)
+                if coverage_info is not None:
+                    expected_coverage_groups.add(coverage_info[0])
+                coverage_result = run_target(target, args, hdl)
+                if coverage_result is not None:
+                    group, coverage_path = coverage_result
+                    coverage_paths.setdefault(group, []).append(coverage_path)
             elif explicit_targets:
                 raise SystemExit(f"Target {name!r} has no {hdl} implementation in this branch")
             else:
                 skipped.append(name)
-        if eio_coverage_paths:
-            sim = args.sim or ("icarus" if hdl == "verilog" else "ghdl")
-            coverage_merged = BUILD_ROOT / f"{hdl}_{sim}" / "eio_functional_coverage_merged.json"
-            payload = merge_coverage(eio_coverage_paths, coverage_merged)
+        sim = args.sim or ("icarus" if hdl == "verilog" else "ghdl")
+        for group in sorted(coverage_paths):
+            coverage_merged = (
+                BUILD_ROOT
+                / f"{hdl}_{sim}"
+                / f"{group}_functional_coverage_merged.json"
+            )
+            payload = merge_coverage(coverage_paths[group], coverage_merged)
+            label = COVERAGE_GROUP_LABELS.get(group, group)
             if payload is not None:
-                print(f"Merged EIO functional coverage: {coverage_merged.relative_to(ROOT)}")
-                if args.require_eio_coverage and payload["covered_bins"] != payload["total_bins"]:
+                print(
+                    f"Merged {label} functional coverage: "
+                    f"{coverage_merged.relative_to(ROOT)}"
+                )
+                if (
+                    args.require_protocol_coverage
+                    and payload["covered_bins"] != payload["total_bins"]
+                ):
                     raise SystemExit(
-                        "EIO functional coverage below 100%: "
+                        f"{label} functional coverage below 100%: "
                         f"{payload['covered_bins']}/{payload['total_bins']} bins"
                     )
-            elif args.require_eio_coverage:
-                raise SystemExit("EIO functional coverage was required, but no report was written")
-        elif args.require_eio_coverage:
-            raise SystemExit("EIO functional coverage was required, but no EIO targets ran")
+            elif args.require_protocol_coverage:
+                raise SystemExit(
+                    f"{label} functional coverage was required, "
+                    "but no report was written"
+                )
+        if args.require_protocol_coverage:
+            missing_groups = expected_coverage_groups - set(coverage_paths)
+            if missing_groups:
+                labels = [
+                    COVERAGE_GROUP_LABELS.get(group, group)
+                    for group in sorted(missing_groups)
+                ]
+                raise SystemExit(
+                    "Protocol functional coverage was required, but no reports "
+                    f"were written for: {', '.join(labels)}"
+                )
         if skipped and hdl == "vhdl":
             print(f"Skipped Verilog-only target(s) for VHDL run: {', '.join(skipped)}")
 

--- a/tb/cocotb/core_test.py
+++ b/tb/cocotb/core_test.py
@@ -68,7 +68,91 @@ EIO_FUNCTIONAL_COVERAGE = FunctionalCoverage(
     ),
 )
 
+JTAG_BURST_FUNCTIONAL_COVERAGE = FunctionalCoverage(
+    env_var="JTAG_BURST_COCOTB_COVERAGE_JSON",
+    run_env_var="JTAG_BURST_COCOTB_RUN",
+    bins=(
+        "data_burst_start",
+        "data_burst_contiguous_first",
+        "data_burst_contiguous_second",
+        "data_burst_wrap",
+        "timestamp_burst",
+    ),
+)
+
+JTAG_PIPE_FUNCTIONAL_COVERAGE = FunctionalCoverage(
+    env_var="JTAG_PIPE_COCOTB_COVERAGE_JSON",
+    run_env_var="JTAG_PIPE_COCOTB_RUN",
+    bins=(
+        "register_write_frame",
+        "register_read_frame",
+        "burst_pointer_command",
+        "burst_read_first",
+        "burst_read_second",
+        "segmented_burst_alignment",
+    ),
+)
+
+ASYNC_FIFO_FUNCTIONAL_COVERAGE = FunctionalCoverage(
+    env_var="ASYNC_FIFO_COCOTB_COVERAGE_JSON",
+    run_env_var="ASYNC_FIFO_COCOTB_RUN",
+    bins=(
+        "reset_empty_flags_match",
+        "write_fill_flags_match",
+        "read_drain_data_match",
+        "mixed_read_write_match",
+        "post_idle_stable",
+    ),
+)
+
+EJTAG_AXI_FUNCTIONAL_COVERAGE = FunctionalCoverage(
+    env_var="EJTAG_AXI_COCOTB_COVERAGE_JSON",
+    run_env_var="EJTAG_AXI_COCOTB_RUN",
+    bins=(
+        "single_write",
+        "single_read",
+        "partial_strobe_write",
+        "incrementing_write",
+        "incrementing_read",
+        "burst_write",
+        "burst_read",
+        "config_version",
+        "config_features",
+        "soft_reset",
+        "axi_protocol_trace",
+        "reset_post_read",
+        "reset_read_increment",
+        "reset_debug_outputs_idle",
+        "reset_axi_trace",
+    ),
+)
+
+EJTAG_UART_FUNCTIONAL_COVERAGE = FunctionalCoverage(
+    env_var="EJTAG_UART_COCOTB_COVERAGE_JSON",
+    run_env_var="EJTAG_UART_COCOTB_RUN",
+    bins=(
+        "config_registers",
+        "tx_push_serializes_byte",
+        "rx_pop_reads_byte",
+        "txrx_exchange",
+        "rx_ready_without_pop",
+        "tx_full_status",
+        "rx_overflow_status",
+        "frame_error_status",
+        "reset_clears_status",
+        "loopback_order",
+        "tx_free_accounting",
+        "rx_fifo_order",
+        "bridge_loopback_stress",
+    ),
+)
+
 atexit.register(EIO_FUNCTIONAL_COVERAGE.write)
+atexit.register(JTAG_BURST_FUNCTIONAL_COVERAGE.write)
+atexit.register(JTAG_PIPE_FUNCTIONAL_COVERAGE.write)
+atexit.register(ASYNC_FIFO_FUNCTIONAL_COVERAGE.write)
+atexit.register(EJTAG_AXI_FUNCTIONAL_COVERAGE.write)
+atexit.register(EJTAG_UART_FUNCTIONAL_COVERAGE.write)
 
 
 async def tick(signal) -> None:
@@ -300,24 +384,29 @@ async def jtag_burst_read_protocol(dut):
     await idle_tap(dut, 4)
 
     await start_burst(dut, 42, False)
+    JTAG_BURST_FUNCTIONAL_COVERAGE.hit("data_burst_start")
     await idle_tap(dut, 80)
     await scan_burst(dut)
     scan = await scan_burst(dut)
     assert_sample_sequence(scan, 42)
+    JTAG_BURST_FUNCTIONAL_COVERAGE.hit("data_burst_contiguous_first")
     scan = await scan_burst(dut)
     assert_sample_sequence(scan, 74)
+    JTAG_BURST_FUNCTIONAL_COVERAGE.hit("data_burst_contiguous_second")
 
     await start_burst(dut, 250, False)
     await idle_tap(dut, 80)
     await scan_burst(dut)
     scan = await scan_burst(dut)
     assert_sample_sequence(scan, 250)
+    JTAG_BURST_FUNCTIONAL_COVERAGE.hit("data_burst_wrap")
 
     await start_burst(dut, 64, True)
     await idle_tap(dut, 80)
     await scan_burst(dut)
     scan = await scan_burst(dut)
     assert_timestamp_sequence(scan, 64)
+    JTAG_BURST_FUNCTIONAL_COVERAGE.hit("timestamp_burst")
 
 
 async def pipe_bus_monitor(dut) -> None:
@@ -354,19 +443,24 @@ async def jtag_pipe_iface_protocol(dut):
     await scan_reg(dut, make_frame(0x0024, 0xCAFE_BABE, True))
     assert int(dut.reg_addr.value) == 0x0024
     assert int(dut.reg_wdata.value) == 0xCAFE_BABE
+    JTAG_PIPE_FUNCTIONAL_COVERAGE.hit("register_write_frame")
 
     await scan_reg(dut, make_frame(0, 0, False))
     await idle_tap(dut, 4)
     captured = await scan_reg(dut, make_frame(0, 0, False))
     assert captured == 0x1234_5678
+    JTAG_PIPE_FUNCTIONAL_COVERAGE.hit("register_read_frame")
 
     await scan_reg(dut, make_frame(0x002C, 0, True))
+    JTAG_PIPE_FUNCTIONAL_COVERAGE.hit("burst_pointer_command")
     await idle_tap(dut, 80)
     await scan_burst(dut)
     first = await scan_burst(dut)
     second = await scan_burst(dut)
     assert_sample_sequence(first, 42)
+    JTAG_PIPE_FUNCTIONAL_COVERAGE.hit("burst_read_first")
     assert_sample_sequence(second, 74)
+    JTAG_PIPE_FUNCTIONAL_COVERAGE.hit("burst_read_second")
 
 
 @cocotb.test()
@@ -395,6 +489,7 @@ async def jtag_pipe_iface_segmented_alignment(dut):
     dut.sel.value = 0
     await idle_tap(dut, 4)
     assert (int(dut.mem_addr.value) >> 8) == 1
+    JTAG_PIPE_FUNCTIONAL_COVERAGE.hit("segmented_burst_alignment")
 
 
 @cocotb.test()
@@ -774,6 +869,8 @@ async def fcapz_async_fifo_equiv(dut):
         await RisingEdge(dut.wr_clk)
     dut.rst.value = 0
     await RisingEdge(dut.wr_clk)
+    await check_stable()
+    ASYNC_FIFO_FUNCTIONAL_COVERAGE.hit("reset_empty_flags_match")
 
     for i in range(16):
         await RisingEdge(dut.wr_clk)
@@ -784,6 +881,7 @@ async def fcapz_async_fifo_equiv(dut):
     dut.wr_en.value = 0
     for _ in range(4):
         await check_stable()
+    ASYNC_FIFO_FUNCTIONAL_COVERAGE.hit("write_fill_flags_match")
 
     for _ in range(16):
         await RisingEdge(dut.rd_clk)
@@ -791,6 +889,7 @@ async def fcapz_async_fifo_equiv(dut):
         await check_stable()
     await RisingEdge(dut.rd_clk)
     dut.rd_en.value = 0
+    ASYNC_FIFO_FUNCTIONAL_COVERAGE.hit("read_drain_data_match")
 
     for _ in range(4):
         await RisingEdge(dut.wr_clk)
@@ -801,12 +900,14 @@ async def fcapz_async_fifo_equiv(dut):
         await RisingEdge(dut.rd_clk)
         dut.rd_en.value = 1
         await check_stable()
+    ASYNC_FIFO_FUNCTIONAL_COVERAGE.hit("mixed_read_write_match")
     await RisingEdge(dut.wr_clk)
     dut.wr_en.value = 0
     await RisingEdge(dut.rd_clk)
     dut.rd_en.value = 0
     for _ in range(8):
         await check_stable()
+    ASYNC_FIFO_FUNCTIONAL_COVERAGE.hit("post_idle_stable")
 
 
 CMD_NOP = 0x0
@@ -1109,10 +1210,12 @@ async def fcapz_ejtagaxi_protocol(dut):
         dut, axi_cmd(CMD_WRITE, 0x0000_0000, 0xDEAD_BEEF, 0xF), "S1 write")
     assert axi_resp(out) == 0
     assert axi_mem_read32(axi_ram, 0x0000_0000) == 0xDEAD_BEEF
+    EJTAG_AXI_FUNCTIONAL_COVERAGE.hit("single_write")
     await axi_cdc_wait(dut)
 
     out = await issue_and_wait_valid(dut, axi_cmd(CMD_READ, 0x0000_0000, 0, 0), "S2 read")
     assert axi_rdata(out) == 0xDEAD_BEEF
+    EJTAG_AXI_FUNCTIONAL_COVERAGE.hit("single_read")
     await axi_cdc_wait(dut)
 
     await issue_and_wait_valid(dut, axi_cmd(CMD_WRITE, 0x0000_0004, 0x1234_5678, 0xF), "S3 write")
@@ -1126,6 +1229,7 @@ async def fcapz_ejtagaxi_protocol(dut):
         dut, axi_cmd(CMD_WRITE, 0x0000_0008, 0xAABB_CCDD, 0x3), "S4 partial write")
     out = await issue_and_wait_valid(dut, axi_cmd(CMD_READ, 0x0000_0008, 0, 0), "S4 read")
     assert axi_rdata(out) == 0xFFFF_CCDD
+    EJTAG_AXI_FUNCTIONAL_COVERAGE.hit("partial_strobe_write")
     await axi_cdc_wait(dut)
 
     await dr_scan_72(dut, axi_cmd(CMD_SET_ADDR, 0x0000_0010, 0, 0))
@@ -1138,6 +1242,7 @@ async def fcapz_ejtagaxi_protocol(dut):
     assert axi_mem_read32(axi_ram, 0x0000_0014) == 0xA000_0001
     assert axi_mem_read32(axi_ram, 0x0000_0018) == 0xA000_0002
     assert axi_mem_read32(axi_ram, 0x0000_001C) == 0xA000_0003
+    EJTAG_AXI_FUNCTIONAL_COVERAGE.hit("incrementing_write")
 
     await dr_scan_72(dut, axi_cmd(CMD_SET_ADDR, 0x0000_0010, 0, 0))
     await axi_cdc_wait(dut)
@@ -1145,6 +1250,7 @@ async def fcapz_ejtagaxi_protocol(dut):
         out = await issue_and_wait_valid(dut, axi_cmd(CMD_READ_INC, 0, 0, 0), f"S6 read_inc {i}")
         assert axi_rdata(out) == 0xA000_0000 + i
         await axi_cdc_wait(dut)
+    EJTAG_AXI_FUNCTIONAL_COVERAGE.hit("incrementing_read")
 
     burst_setup = (0b01 << 12) | (0b010 << 8) | 3
     await dr_scan_72(dut, axi_cmd(CMD_BURST_SETUP, 0x0000_0020, burst_setup, 0))
@@ -1158,6 +1264,7 @@ async def fcapz_ejtagaxi_protocol(dut):
     assert axi_mem_read32(axi_ram, 0x0000_0024) == 0xB000_0001
     assert axi_mem_read32(axi_ram, 0x0000_0028) == 0xB000_0002
     assert axi_mem_read32(axi_ram, 0x0000_002C) == 0xB000_0003
+    EJTAG_AXI_FUNCTIONAL_COVERAGE.hit("burst_write")
 
     await dr_scan_72(dut, axi_cmd(CMD_BURST_SETUP, 0x0000_0020, burst_setup, 0))
     await axi_cdc_wait(dut)
@@ -1170,9 +1277,11 @@ async def fcapz_ejtagaxi_protocol(dut):
         out = await dr_scan_72(dut, axi_cmd(CMD_BURST_RDATA, 0, 0, 0))
         assert axi_rdata(out) == 0xB000_0000 + i
         await axi_cdc_wait(dut)
+    EJTAG_AXI_FUNCTIONAL_COVERAGE.hit("burst_read")
 
     out = await issue_and_wait_valid(dut, axi_cmd(CMD_CONFIG, 0x0000_0000, 0, 0), "S9 version")
     assert axi_rdata(out) == 0x0004_4A58
+    EJTAG_AXI_FUNCTIONAL_COVERAGE.hit("config_version")
     await axi_cdc_wait(dut)
 
     out = await issue_and_wait_valid(
@@ -1182,6 +1291,7 @@ async def fcapz_ejtagaxi_protocol(dut):
 
     out = await issue_and_wait_valid(dut, axi_cmd(CMD_CONFIG, 0x0000_002C, 0, 0), "S9 features")
     assert axi_rdata(out) == 0x000F_2020
+    EJTAG_AXI_FUNCTIONAL_COVERAGE.hit("config_features")
     await axi_cdc_wait(dut)
 
     await dr_scan_72(dut, axi_cmd(CMD_RESET, 0, 0, 0))
@@ -1189,7 +1299,9 @@ async def fcapz_ejtagaxi_protocol(dut):
     out = await drain_until_idle(dut)
     assert not (axi_status(out) & 0x4)
     assert not (axi_status(out) & 0x2)
+    EJTAG_AXI_FUNCTIONAL_COVERAGE.hit("soft_reset")
     assert_axi_protocol_trace(axi_trace)
+    EJTAG_AXI_FUNCTIONAL_COVERAGE.hit("axi_protocol_trace")
 
 
 @cocotb.test()
@@ -1221,6 +1333,7 @@ async def fcapz_ejtagaxi_reset_regression(dut):
         dut, axi_cmd(CMD_READ, 0x0000_0000, 0, 0), "first post-reset read")
     assert axi_resp(out) == 0
     assert axi_rdata(out) == 0x1234_5678
+    EJTAG_AXI_FUNCTIONAL_COVERAGE.hit("reset_post_read")
 
     await dr_scan_72(dut, axi_cmd(CMD_SET_ADDR, 0x0000_0004, 0, 0))
     await axi_cdc_wait(dut)
@@ -1228,10 +1341,12 @@ async def fcapz_ejtagaxi_reset_regression(dut):
         dut, axi_cmd(CMD_READ_INC, 0, 0, 0), "first post-reset read_inc")
     assert axi_resp(out) == 0
     assert axi_rdata(out) == 0x89AB_CDEF
+    EJTAG_AXI_FUNCTIONAL_COVERAGE.hit("reset_read_increment")
     assert int(dut.debug_tck.value) == 0
     assert int(dut.debug_tck_edge.value) == 0
     assert int(dut.debug_axi.value) == 0
     assert int(dut.debug_axi_edge.value) == 0
+    EJTAG_AXI_FUNCTIONAL_COVERAGE.hit("reset_debug_outputs_idle")
     assert len(axi_trace.aw) == 2
     assert len(axi_trace.w) == 2
     assert len(axi_trace.ar) == 2
@@ -1240,6 +1355,7 @@ async def fcapz_ejtagaxi_reset_regression(dut):
     _assert_axi_write_beats(axi_trace.w, [0x1234_5678, 0x89AB_CDEF], burst=False)
     _assert_axi_addr(axi_trace.ar[0], 0x0000_0000)
     _assert_axi_addr(axi_trace.ar[1], 0x0000_0004)
+    EJTAG_AXI_FUNCTIONAL_COVERAGE.hit("reset_axi_trace")
 
 
 UART_CMD_NOP = 0x0
@@ -1391,6 +1507,7 @@ async def fcapz_ejtaguart_protocol(dut):
     await uart_cdc_wait(dut)
     out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0x00))
     assert uart_rx_byte(out) == 0x55
+    EJTAG_UART_FUNCTIONAL_COVERAGE.hit("config_registers")
     await uart_cdc_wait(dut)
 
     await dr_scan_32(dut, uart_cmd(UART_CMD_TX_PUSH, 0xA5))
@@ -1398,6 +1515,7 @@ async def fcapz_ejtaguart_protocol(dut):
     valid, tx_byte = await uart_recv_byte_timeout(dut, UART_BIT_PERIOD_NS * 12)
     assert valid
     assert tx_byte == 0xA5
+    EJTAG_UART_FUNCTIONAL_COVERAGE.hit("tx_push_serializes_byte")
     for _ in range(20):
         await RisingEdge(dut.uart_clk)
 
@@ -1408,6 +1526,7 @@ async def fcapz_ejtaguart_protocol(dut):
     out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
     assert uart_rx_byte(out) == 0x3C
     assert uart_rx_valid(out)
+    EJTAG_UART_FUNCTIONAL_COVERAGE.hit("rx_pop_reads_byte")
     await uart_cdc_wait(dut)
 
     await uart_send_byte(dut, 0xBE)
@@ -1420,6 +1539,7 @@ async def fcapz_ejtaguart_protocol(dut):
     out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
     assert uart_rx_byte(out) == 0xBE
     assert uart_rx_valid(out)
+    EJTAG_UART_FUNCTIONAL_COVERAGE.hit("txrx_exchange")
     for _ in range(UART_BAUD_DIV * 12):
         await RisingEdge(dut.uart_clk)
 
@@ -1436,12 +1556,14 @@ async def fcapz_ejtaguart_protocol(dut):
     await uart_cdc_wait(dut)
     out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
     assert uart_rx_byte(out) == 0xAA
+    EJTAG_UART_FUNCTIONAL_COVERAGE.hit("rx_ready_without_pop")
     await uart_cdc_wait(dut)
 
     for i in range(UART_TX_FIFO_DEPTH + 8):
         await dr_scan_32(dut, uart_cmd(UART_CMD_TX_PUSH, i))
     out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
     assert uart_tx_full(out)
+    EJTAG_UART_FUNCTIONAL_COVERAGE.hit("tx_full_status")
     for _ in range(UART_TX_FIFO_DEPTH * UART_BAUD_DIV * 12):
         await RisingEdge(dut.uart_clk)
     await uart_cdc_wait(dut)
@@ -1455,6 +1577,7 @@ async def fcapz_ejtaguart_protocol(dut):
     await uart_cdc_wait(dut, 10)
     out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
     assert uart_rx_overflow(out)
+    EJTAG_UART_FUNCTIONAL_COVERAGE.hit("rx_overflow_status")
     await uart_cdc_wait(dut)
 
     await dr_scan_32(dut, uart_cmd(UART_CMD_RESET, 0))
@@ -1463,6 +1586,7 @@ async def fcapz_ejtaguart_protocol(dut):
     await uart_cdc_wait(dut, 50)
     out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
     assert uart_frame_err(out)
+    EJTAG_UART_FUNCTIONAL_COVERAGE.hit("frame_error_status")
     await uart_cdc_wait(dut)
 
     await dr_scan_32(dut, uart_cmd(UART_CMD_RESET, 0))
@@ -1472,6 +1596,7 @@ async def fcapz_ejtaguart_protocol(dut):
     assert not uart_frame_err(out)
     assert not uart_tx_full(out)
     assert not uart_rx_ready(out)
+    EJTAG_UART_FUNCTIONAL_COVERAGE.hit("reset_clears_status")
     await uart_cdc_wait(dut)
 
     for expected in (0x11, 0x22, 0x33, 0x44):
@@ -1483,6 +1608,7 @@ async def fcapz_ejtaguart_protocol(dut):
         await uart_cdc_wait(dut)
         out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
         assert uart_rx_byte(out) == expected
+    EJTAG_UART_FUNCTIONAL_COVERAGE.hit("loopback_order")
     await uart_cdc_wait(dut)
 
     await dr_scan_32(dut, uart_cmd(UART_CMD_TX_PUSH, 0xFF))
@@ -1504,6 +1630,7 @@ async def fcapz_ejtaguart_protocol(dut):
     await uart_cdc_wait(dut)
     out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
     assert uart_tx_free(out) < UART_TX_FIFO_DEPTH
+    EJTAG_UART_FUNCTIONAL_COVERAGE.hit("tx_free_accounting")
     for _ in range(100):
         await RisingEdge(dut.uart_clk)
     await uart_cdc_wait(dut)
@@ -1524,6 +1651,7 @@ async def fcapz_ejtaguart_protocol(dut):
     await uart_cdc_wait(dut)
     out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
     assert uart_rx_byte(out) == 0xD3
+    EJTAG_UART_FUNCTIONAL_COVERAGE.hit("rx_fifo_order")
     await uart_cdc_wait(dut)
 
     await dr_scan_32(dut, uart_cmd(UART_CMD_RESET, 0))
@@ -1556,6 +1684,7 @@ async def fcapz_ejtaguart_protocol(dut):
     out = await dr_scan_32(dut, uart_cmd(UART_CMD_NOP, 0))
     assert uart_rx_byte(out) == stress[-1]
     assert uart_rx_valid(out)
+    EJTAG_UART_FUNCTIONAL_COVERAGE.hit("bridge_loopback_stress")
     bridge_on = False
     bridge_task.kill()
     dut.uart_rxd.value = 1

--- a/tb/fcapz_ela_bug_probe_tb.sv
+++ b/tb/fcapz_ela_bug_probe_tb.sv
@@ -421,7 +421,7 @@ module fcapz_ela_bug_probe_tb;
         write_ts(16'h0020, 32'h1);
         write_ts(16'h0024, 32'd3);
         write_ts(16'h0028, 32'hFF);
-        dut_ts.ts_counter = 48'h0001_0000_0100;
+        dut_ts.g_ts.ts_counter = 48'h0001_0000_0100;
         write_ts(16'h0004, 32'h1);
         probe_ts = '0;
         repeat (10) begin


### PR DESCRIPTION
## Summary

This PR tightens the Verilog/VHDL regression gates around the translated core flow and removes unnecessary timestamp RAM logic from the ELA when timestamps are disabled.

## Changes

- Avoid instantiating timestamp counter/RAM storage in `fcapz_ela` when `TIMESTAMP_W=0`
- Expand cocotb protocol functional coverage beyond EIO to include:
  - JTAG burst read
  - JTAG pipe interface
  - async FIFO equivalence
  - EJTAG-AXI
  - EJTAG-UART
- Add `--require-protocol-coverage` to fail CI when required protocol coverage bins are not hit
- Keep `--require-eio-coverage` as a legacy alias
- Update CI and README docs to describe the broader protocol coverage gate
- Polish testbench/docs wording around the updated cocotb coverage flow

## Testing

- CI protocol shard now runs with `--require-protocol-coverage`
- Coverage reports are merged per protocol group under `build/cocotb/<hdl>_<sim>/`
- Existing Verilog/VHDL cocotb targets continue to share the same Python stimulus