### PR TITLE
Gowin (BRS-100-GW1NR9) support: EIO reference design, GUI/CLI over OpenOCD, and a hardware test suite

### DIFF
--- a/docs/06_eio_core.md
+++ b/docs/06_eio_core.md
@@ -161,6 +161,18 @@ EIO wrapper with a non-default `CHAIN` parameter (see
 [chapter 04](04_rtl_integration.md)).  The host's `chain` argument
 must match the RTL `CHAIN` parameter.
 
+**Shared-chain EIO.** When EIO is address-muxed onto another core's chain
+instead of having its own, pass `base_addr` (the mux offset) so every register
+access is routed to the EIO window.  The common case is Gowin `EIO_EN=1`, which
+muxes EIO onto the ELA chain at offset `0x8000`:
+
+```python
+eio = EioController(transport, chain=1, base_addr=0x8000)
+```
+
+The CLI equivalent is `--base-addr 0x8000`, and the desktop GUI discovers this
+location automatically on connect.
+
 After `connect()`, the controller has cached `IN_W` and `OUT_W` from
 the bitstream's identity registers, so subsequent reads/writes know
 exactly how many words to scan.

--- a/docs/10_cli_reference.md
+++ b/docs/10_cli_reference.md
@@ -359,11 +359,17 @@ wrote 0x55
 All three EIO subcommands take `--chain N` (default 3) to override
 the BSCANE2 USER chain. For mixed-manager designs where EIO shares USER1,
 also pass `--instance N` to select the EIO slot before each register access.
+For a **shared-chain** EIO that is address-muxed onto another core's chain
+(e.g. Gowin `EIO_EN=1` at offset `0x8000`), pass `--base-addr` instead:
 
 ```bash
 fcapz --backend hw_server --tap xc7a100t eio-probe --chain 1 --instance 2
 fcapz --backend hw_server --tap xc7a100t eio-write --chain 1 --instance 2 0x11
 fcapz --backend hw_server --tap xc7a100t eio-read --chain 1 --instance 2
+
+# Gowin shared-chain EIO (chain 1, mux offset 0x8000):
+fcapz --backend openocd --tap GW1NR-9C.tap eio-read  --chain 1 --base-addr 0x8000
+fcapz --backend openocd --tap GW1NR-9C.tap eio-write --chain 1 --base-addr 0x8000 0x15
 ```
 
 ## AXI subcommands

--- a/docs/12_gui.md
+++ b/docs/12_gui.md
@@ -81,10 +81,17 @@ The leftmost (or topmost, depending on layout) panel.  Holds:
 | **Backend** | Dropdown: `hw_server` (default) or `openocd` |
 | **Host** | TCP host of the transport, default `127.0.0.1` |
 | **Port** | TCP port, default `3121` for hw_server / `6666` for openocd |
-| **FPGA target** | hw_server target name (e.g. `xc7a100t`) or openocd TAP name |
+| **FPGA target / TAP** | hw_server target name (e.g. `xc7a100t`) or OpenOCD TAP name. For OpenOCD you can enter `auto` to use the first tap OpenOCD reports |
+| **[Scan]** | hw_server: lists XSDB JTAG targets. OpenOCD: lists tap names via `jtag names`. Click to fill the **TAP** field instead of typing it |
 | **Bitfile** | Optional path to a `.bit` file; if set, the GUI runs `fpga -file <bitfile>` and waits for the readiness probe before declaring "connected" |
-| **IR table** | Dropdown: `Xilinx 7-series` (default) or `Xilinx UltraScale / UltraScale+`.  Maps to the `IR_TABLE_*` presets in [chapter 14](14_transports.md) |
+| **IR table** | Dropdown: `Xilinx 7-series` (default), `Xilinx UltraScale / UltraScale+`, or `Gowin (OpenOCD)`.  Maps to the `IR_TABLE_*` presets in [chapter 14](14_transports.md) |
 | **[Connect] / [Disconnect]** | Open or close the underlying transport |
+
+> **Gowin boards** connect over the **OpenOCD** backend (the FTDI/Gowin cable
+> driven by an already-running `openocd`): set Backend = `openocd`, Port `6666`,
+> TAP = your tap name or `auto`, IR table = **Gowin (OpenOCD)**. The ELA tab
+> works immediately, and **EIO is auto-discovered and attached** on connect (see
+> the EIO panel below) — no USER chain or mux offset to enter.
 
 When you click **Connect**:
 
@@ -266,15 +273,22 @@ adjacent identical values render as a flat line, not a sawtooth.
 
 ### EIO panel
 
+On connect the GUI **auto-discovers and attaches** the EIO core: it probes the
+known locations — core-manager slots, then each USER chain at register offsets
+`0x0000` and `0x8000` — and attaches the first that reports the EIO identity
+(`'IO'`). You normally do not touch the controls below; they are a manual
+override.
+
 For managed designs, the **Core** selector lists detected EIO cores as
 `core 2`, `core 3`, and so on, with the selected USER chain and manager
 slot shown beside it.  Choosing a core attaches it immediately and shows
 the EIO identity / bus widths.  The Arty multi-core reference uses chain
 **1**, slots **2** and **3**.
 
-For legacy standalone EIO designs with no detected manager slot, the panel
-falls back to manual **JTAG chain**, optional **Managed slot**, and
-**Attach EIO** controls.
+For standalone or shared-chain EIO designs, the panel exposes manual
+**JTAG chain**, optional **Managed slot**, and a **Base** offset.  A
+**shared-chain** EIO — e.g. Gowin `EIO_EN=1`, which muxes EIO onto the ELA
+chain — lives at chain **1**, Base **0x8000** (discovery fills that in for you).
 
 For each input bit, **read-only checkboxes** update from
 `EioController.read_inputs()` while **Poll inputs** is checked.

--- a/docs/14_transports.md
+++ b/docs/14_transports.md
@@ -182,6 +182,24 @@ OpenOCD does **not** program the FPGA from this transport — you do
 that separately with `pld load`, an `init`-time script, or your own
 `openocd -c "...; init; pld load 0 my.bit; exit"`.
 
+#### Tap auto-detect
+
+The tap name must match a tap defined in the running OpenOCD config.  Pass
+`tap="auto"` (or leave it empty) and `connect()` resolves it to the first name
+OpenOCD reports from `jtag names` — handy for single-FPGA chains where you don't
+want to hard-code the name.  The helper `fcapz.transport.list_openocd_taps()`
+returns that list; the GUI's **Scan** button uses it to populate the TAP field
+for the OpenOCD backend.
+
+#### Gowin over OpenOCD
+
+Gowin boards use this transport with `ir_table=OpenOcdTransport.IR_TABLE_GOWIN`
+(ER1/ER2 → chains 1/2).  The CLI auto-selects it for `--tap GW...`; in code,
+pass it explicitly.  The ELA sits on chain 1; a shared-chain EIO (`EIO_EN=1`) is
+reached on chain 1 at base offset `0x8000`
+(`EioController(t, chain=1, base_addr=0x8000)`).  See the
+[BRS-100-GW1NR9 example](../examples/brs_100_gw1nr9/README.md).
+
 ## IR table presets
 
 Different Xilinx families use different IR opcodes for the BSCANE2

--- a/examples/brs_100_gw1nr9/README.md
+++ b/examples/brs_100_gw1nr9/README.md
@@ -168,13 +168,29 @@ print(eio.read_inputs())   # buttons (probe_in[1:0])
 eio.write_outputs(0x3F)    # all six LEDs on
 ```
 
+## Hardware tests
+
+`test_hw_integration.py` is an opt-in regression that drives the board over
+OpenOCD. Build + load the bitstream, start OpenOCD, then:
+
+```sh
+openocd -f examples/brs_100_gw1nr9/brs_100_gw1nr9.cfg &
+python -m pytest examples/brs_100_gw1nr9/test_hw_integration.py -v
+```
+
+It covers the ELA (identity, a counter capture with `+1` per-sample checks,
+trigger match, register roundtrip, JSON/VCD export) and the shared-chain EIO
+(identity/widths, auto-discovery, LED output roundtrip, button reads). Without a
+board the tests **skip** (OpenOCD unreachable or no fcapz design loaded); set
+`FPGACAP_SKIP_HW=1` to skip unconditionally. Override the port/tap with
+`FPGACAP_OPENOCD_PORT` / `FPGACAP_OPENOCD_TAP`.
+
 ## Notes
 
 - This example uses Gowin register-path ELA readback, not Xilinx-style burst
   readback.
 - OpenOCD must already be running; the fpgacapZero OpenOCD transport does not
   program the FPGA.
-- The example does not include hardware regression tests yet.
 
 ## More Detail
 

--- a/examples/brs_100_gw1nr9/README.md
+++ b/examples/brs_100_gw1nr9/README.md
@@ -5,9 +5,12 @@ BRS-100-GW1NR9 board. It targets the `GW1NR-LV9QN88PC7/I6` device and
 instantiates the fpgacapZero Gowin ELA wrapper through the `GW_JTAG`
 primitive.
 
-The design is deliberately small: it builds one ELA, drives the board LEDs
-from simple local status signals, and captures internal counters, buttons, and
-header I/O through a six-channel probe mux.
+The design is deliberately small but exercises two cores over the single
+`GW_JTAG` primitive: an **ELA** that captures internal counters, the user
+buttons, and header I/O through a six-channel probe mux, and an **EIO** that
+exposes the two user buttons (host-readable) and drives the six board LEDs
+(host-controlled over JTAG). The EIO shares the ELA's JTAG chain through the
+register-bus mux at offset `0x8000`.
 
 ## Files
 
@@ -29,7 +32,8 @@ header I/O through a six-channel probe mux.
 - ELA sample width: 8 bits
 - ELA depth: 64 samples
 - ELA channels: 6
-- EIO: disabled in this example
+- EIO: enabled — 2 inputs (user buttons), 6 outputs (board LEDs)
+- EIO location: shares the ELA chain (chain 1) at register-bus mux offset `0x8000`
 
 The ELA probe bus is split into six 8-bit channels:
 
@@ -44,20 +48,13 @@ The ELA probe bus is split into six 8-bit channels:
 
 ## Board I/O
 
-The LEDs are active-low at the pads and are driven from these internal status
-signals:
+The six LEDs are **driven by the EIO output register** — the host controls them
+over JTAG (`eio.write_outputs`). They are active-low at the pads; EIO
+`probe_out[5:0]` maps to LED[5:0].
 
-| LED | Meaning |
-| --- | --- |
-| 0 | 1 Hz heartbeat |
-| 1 | JTAG activity indicator |
-| 2 | User button 0 |
-| 3 | User button 1 |
-| 4 | `pad_io[1]` |
-| 5 | `pad_io[2]` |
-
-The two user buttons are active-low on the board and are sampled into the
-60 MHz domain before being exposed through ELA channel 1.
+The two user buttons are active-low on the board, sampled into the 60 MHz
+domain, and exposed two ways: through **EIO `probe_in[1:0]`** (host-readable via
+`eio.read_inputs`) and through **ELA channel 1** (captured into a waveform).
 
 ## Build
 
@@ -132,6 +129,44 @@ fcapz --backend openocd --host 127.0.0.1 --port 6666 \
 
 For VCD output, change `--format json` to `--format vcd` and use a `.vcd`
 output path.
+
+## Embedded I/O (EIO)
+
+The EIO core shares the ELA's JTAG chain (chain 1) at register-bus mux offset
+`0x8000`. Read the buttons via `probe_in`, drive the LEDs via `probe_out`.
+
+**Desktop GUI** (easiest): connect with backend **OpenOCD**, tap `GW1NR-9C.tap`
+(or `auto`), IR table **Gowin** — the GUI **auto-discovers and attaches** the
+EIO, so there is no chain or offset to enter. Toggle the six output bits to
+drive the LEDs, and enable *Poll inputs* to watch the buttons.
+
+**CLI** — pass the shared-chain location explicitly (`--chain 1 --base-addr
+0x8000`):
+
+```sh
+# Read the two buttons (probe_in)
+fcapz --backend openocd --host 127.0.0.1 --port 6666 \
+  --tap GW1NR-9C.tap eio-read --chain 1 --base-addr 0x8000
+
+# Drive the six LEDs (probe_out): light LED0/2/4
+fcapz --backend openocd --host 127.0.0.1 --port 6666 \
+  --tap GW1NR-9C.tap eio-write --chain 1 --base-addr 0x8000 0x15
+```
+
+**Python API:**
+
+```python
+from fcapz.transport import OpenOcdTransport
+from fcapz.eio import EioController
+
+t = OpenOcdTransport(port=6666, tap="GW1NR-9C.tap",
+                     ir_table=OpenOcdTransport.IR_TABLE_GOWIN)
+t.connect()
+eio = EioController(t, chain=1, base_addr=0x8000)
+eio.attach()
+print(eio.read_inputs())   # buttons (probe_in[1:0])
+eio.write_outputs(0x3F)    # all six LEDs on
+```
 
 ## Notes
 

--- a/examples/brs_100_gw1nr9/brs_100_gw1nr9_top.v
+++ b/examples/brs_100_gw1nr9/brs_100_gw1nr9_top.v
@@ -28,7 +28,7 @@ localparam int DEPTH                = 64;
     //  Internal signals
     // ----------------------------------------------
 
-    reg [5:0]                       i_leds;
+    wire [5:0]                      i_eio_leds;     // host-driven LEDs (EIO out)
     reg [1:0]                       i_buttons;
     reg [32-1:0]                    i_pad;
 
@@ -85,7 +85,12 @@ localparam int DEPTH                = 64;
         .SAMPLE_W       (SAMPLE_W),
         .DEPTH          (DEPTH),
         .NUM_CHANNELS   (CHANNELS),
-        .EIO_EN         (0)
+        .EIO_EN         (1),
+            // NOTE: EIO shares the single GW_JTAG primitive with the ELA
+            // (mux offset 0x8000).  Host: EioController(t, chain=1,
+            // base_addr=0x8000).
+        .EIO_IN_W       (2),    // read the 2 user buttons
+        .EIO_OUT_W      (6)     // drive the 6 LEDs
     ) u_ela (
         .clk            (i_jtagclk),
             // NOTE: this is a separate clock
@@ -98,10 +103,8 @@ localparam int DEPTH                = 64;
         .sample_rst     (i_sysclk_reset),
         .probe_in       (i_probe),
 
-        .eio_probe_in   (0),
-        .eio_probe_out  (),
-            // NOTE: external trigger ports
-            // tie off if not used
+        .eio_probe_in   (i_buttons),   // host reads button state
+        .eio_probe_out  (i_eio_leds),  // host drives LED state
 
         .tms_pad_i      (tms_pad_i),
         .tck_pad_i      (tck_pad_i),
@@ -219,37 +222,12 @@ localparam int DEPTH                = 64;
 
     // NOTE: Leds
     // ------------
+    //
+    // EIO demo: all 6 LEDs are driven by the EIO output register, so the
+    // host controls them directly over JTAG (eio.write_outputs).  LEDs are
+    // active-low on this board.
 
-    always @(posedge i_sysclk) begin
-        if (i_second_tick == 1'b1) begin
-            i_leds[0] <= ~i_leds[0];
-        end
-
-        if (i_jtag_activity_jtagclk == 1'b1) begin
-            // NOTE: this isn't proper CDC...
-            // fit for demonstration only.
-
-            i_leds[1] <= 1'b1;
-        end
-        if (|i_millisecond_counter[6:0] == 1'b0) begin
-            i_leds[1] <= 0;
-        end
-
-        i_leds[3:2] <= i_buttons[1:0];
-        i_leds[4]   <= i_pad[0];
-        i_leds[5]   <= i_pad[1];
-
-        if (i_sysclk_resetn == 1'b0) begin
-            i_leds <= 0;
-        end
-    end
-    assign pad_leds_n = ~i_leds;
-        // NOTE:
-        //          led[5]: i_pad[1]
-        //          led[4]: i_pad[0]
-        //          led[3]: i_buttons[1]
-        //          led[2]: i_buttons[0]
-        //          led[1]: JTAG Activity
-        //          led[0]: Heartbeat
+    assign pad_leds_n = ~i_eio_leds;
+        // NOTE: led[5:0] = EIO probe_out[5:0] (host-driven)
 
 endmodule

--- a/examples/brs_100_gw1nr9/build_brs_100_gw1nr9.tcl
+++ b/examples/brs_100_gw1nr9/build_brs_100_gw1nr9.tcl
@@ -85,4 +85,6 @@ run pnr
 
 puts "Deploying Bitstream"
 file mkdir $output_dir
-file copy -force ${project_dir}/impl/pnr/${project_name}.fs ${output_dir}/fcapz_brs_100_gw1nr9.fs
+# Gowin create_project nests the project under ${project_dir}/${project_name},
+# so PnR writes the bitstream to ${project_dir}/${project_name}/impl/pnr/.
+file copy -force ${project_dir}/${project_name}/impl/pnr/${project_name}.fs ${output_dir}/fcapz_brs_100_gw1nr9.fs

--- a/examples/brs_100_gw1nr9/test_hw_integration.py
+++ b/examples/brs_100_gw1nr9/test_hw_integration.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Leonardo Capossio - bard0 design - <hello@bard0.com>
+
+"""
+Integration tests for fpgacapZero on the Brisbane Silicon BRS-100-GW1NR9
+(Gowin GW1NR-9C) board, driven over OpenOCD.
+
+Unlike the Arty hw_server flow, the OpenOCD transport does **not** program the
+FPGA, so before running you must have the board configured and OpenOCD up:
+
+  1. Build and load the bitstream (SRAM is fine; it is volatile):
+       python examples/brs_100_gw1nr9/build.py
+       # then program out/fcapz_brs_100_gw1nr9.fs with your Gowin flow
+  2. Start OpenOCD with the checked-in board config:
+       openocd -f examples/brs_100_gw1nr9/brs_100_gw1nr9.cfg
+
+The reference design instantiates an 8-bit / 64-deep / 6-channel ELA and a
+shared-chain EIO (2 inputs = user buttons, 6 outputs = LEDs) muxed onto the ELA
+chain at offset 0x8000.  Channel 0 of the ELA is a free-running 8-bit counter.
+
+Environment variables
+---------------------
+FPGACAP_SKIP_HW=1          Skip all hardware tests (CI default).
+FPGACAP_OPENOCD_PORT=<n>   OpenOCD TCL port.  Defaults to 6666.
+FPGACAP_OPENOCD_TAP=<tap>  TAP name.  Defaults to ``GW1NR-9C.tap``; ``auto``
+                           also works (resolves via ``jtag names``).
+
+Run:
+    openocd -f examples/brs_100_gw1nr9/brs_100_gw1nr9.cfg &
+    python -m pytest examples/brs_100_gw1nr9/test_hw_integration.py -v
+
+Skip if no hardware:
+    FPGACAP_SKIP_HW=1 python -m pytest examples/brs_100_gw1nr9/test_hw_integration.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+_SKIP = os.environ.get("FPGACAP_SKIP_HW", "")
+_PORT = int(os.environ.get("FPGACAP_OPENOCD_PORT", "6666"))
+_TAP = os.environ.get("FPGACAP_OPENOCD_TAP", "GW1NR-9C.tap")
+
+# Shape of the BRS-100-GW1NR9 reference design.
+SAMPLE_W = 8
+DEPTH = 64
+NUM_CHANNELS = 6
+COUNTER_CHANNEL = 0          # free-running 8-bit counter
+EIO_CHAIN = 1                # EIO shares the ELA chain (ER1)
+EIO_BASE = 0x8000            # register-bus mux offset for the shared-chain EIO
+EIO_IN_W = 2                 # user buttons
+EIO_OUT_W = 6                # board LEDs
+
+
+def _make_transport():
+    from fcapz.transport import OpenOcdTransport
+
+    return OpenOcdTransport(
+        host="127.0.0.1",
+        port=_PORT,
+        tap=_TAP,
+        ir_table=OpenOcdTransport.IR_TABLE_GOWIN,
+    )
+
+
+def _connect_analyzer_or_skip():
+    """Return a connected, identity-verified Analyzer, or raise SkipTest.
+
+    Skips (rather than fails) when OpenOCD is not running or the board is not
+    configured with the fcapz design, so the suite is a no-op without hardware.
+    """
+    from fcapz.analyzer import Analyzer
+
+    a = Analyzer(_make_transport(), chain=1)
+    try:
+        a.connect()
+        a.probe()  # raises RuntimeError if the ELA identity magic is wrong
+    except OSError as exc:
+        a.close()
+        raise unittest.SkipTest(
+            f"OpenOCD not reachable on port {_PORT} ({exc}); "
+            f"start: openocd -f examples/brs_100_gw1nr9/brs_100_gw1nr9.cfg"
+        )
+    except RuntimeError as exc:
+        a.close()
+        raise unittest.SkipTest(
+            f"fcapz ELA not found on the board ({exc}); "
+            f"load out/fcapz_brs_100_gw1nr9.fs first"
+        )
+    return a
+
+
+@unittest.skipIf(_SKIP, "FPGACAP_SKIP_HW is set")
+class TestProbe(unittest.TestCase):
+    """Basic connectivity: read ELA identity registers."""
+
+    def test_probe_returns_valid_identity(self):
+        from fcapz import _version_tuple
+        from fcapz.analyzer import ELA_CORE_ID
+
+        a = _connect_analyzer_or_skip()
+        try:
+            info = a.probe()
+            major, minor, _patch = _version_tuple()
+            self.assertEqual(info["version_major"], major)
+            self.assertEqual(info["version_minor"], minor)
+            self.assertEqual(info["core_id"], ELA_CORE_ID)
+            self.assertEqual(info["sample_width"], SAMPLE_W)
+            self.assertEqual(info["depth"], DEPTH)
+            self.assertEqual(info["num_channels"], NUM_CHANNELS)
+        finally:
+            a.close()
+
+
+@unittest.skipIf(_SKIP, "FPGACAP_SKIP_HW is set")
+class TestCapture(unittest.TestCase):
+    """End-to-end ELA capture over the Gowin register-path readback."""
+
+    def setUp(self):
+        self.a = _connect_analyzer_or_skip()
+        self.t = self.a.transport
+
+    def tearDown(self):
+        self.a.close()
+
+    def _capture(self, pretrig, posttrig, channel=COUNTER_CHANNEL,
+                 trig_val=0, trig_mask=0xFF, mode="value_match"):
+        from fcapz.analyzer import CaptureConfig, TriggerConfig
+
+        cfg = CaptureConfig(
+            pretrigger=pretrig,
+            posttrigger=posttrig,
+            trigger=TriggerConfig(mode=mode, value=trig_val, mask=trig_mask),
+            sample_width=SAMPLE_W,
+            depth=DEPTH,
+            channel=channel,
+        )
+        self.a.configure(cfg)
+        self.a.arm()
+        return self.a.capture(timeout=5.0)
+
+    def test_basic_capture_value_match(self):
+        """Trigger on value=0, capture 4 + 1 + 8 samples."""
+        result = self._capture(pretrig=4, posttrig=8)
+        self.assertEqual(len(result.samples), 4 + 1 + 8)
+        self.assertFalse(result.overflow)
+
+    def test_counter_channel_increments(self):
+        """Channel 0 is a free-running 8-bit counter; adjacent samples differ by +1."""
+        result = self._capture(pretrig=4, posttrig=16, channel=COUNTER_CHANNEL)
+        samples = [s & 0xFF for s in result.samples]
+        errors = [
+            (i - 1, samples[i - 1], samples[i])
+            for i in range(1, len(samples))
+            if ((samples[i] - samples[i - 1]) & 0xFF) != 1
+        ]
+        self.assertEqual(errors, [], f"counter errors in samples={samples}")
+
+    def test_trigger_value_is_captured(self):
+        """value_match on 0x20 — the committed window contains 0x20."""
+        result = self._capture(pretrig=4, posttrig=8, trig_val=0x20, trig_mask=0xFF)
+        self.assertIn(0x20, [s & 0xFF for s in result.samples])
+
+    def test_register_roundtrip(self):
+        """PRETRIG_LEN read/writes back on silicon."""
+        self.t.write_reg(0x0014, 7)
+        self.assertEqual(self.t.read_reg(0x0014) & 0xFFFF, 7)
+        self.t.write_reg(0x0014, 0)
+
+    def test_json_export(self):
+        result = self._capture(pretrig=4, posttrig=8)
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        try:
+            self.a.write_json(result, path)
+            obj = json.loads(Path(path).read_text())
+            self.assertEqual(obj["sample_width"], SAMPLE_W)
+            self.assertEqual(len(obj["samples"]), len(result.samples))
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_vcd_export(self):
+        result = self._capture(pretrig=4, posttrig=8)
+        with tempfile.NamedTemporaryFile(suffix=".vcd", delete=False) as f:
+            path = f.name
+        try:
+            self.a.write_vcd(result, path)
+            self.assertIn("$enddefinitions", Path(path).read_text())
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+
+@unittest.skipIf(_SKIP, "FPGACAP_SKIP_HW is set")
+class TestEio(unittest.TestCase):
+    """EIO on the shared Gowin chain (chain 1, mux offset 0x8000)."""
+
+    def setUp(self):
+        from fcapz.eio import EioController
+
+        self.a = _connect_analyzer_or_skip()
+        self.t = self.a.transport
+        self.eio = EioController(self.t, chain=EIO_CHAIN, base_addr=EIO_BASE)
+        try:
+            self.eio.attach()
+        except RuntimeError as exc:
+            self.a.close()
+            raise unittest.SkipTest(
+                f"shared-chain EIO not found at chain {EIO_CHAIN}/0x{EIO_BASE:04X} "
+                f"({exc}); is the EIO-enabled bitstream loaded?"
+            )
+
+    def tearDown(self):
+        self.eio.write_outputs(0)  # leave the LEDs off
+        self.a.close()
+
+    def test_identity_and_widths(self):
+        from fcapz.eio import EIO_CORE_ID
+
+        self.assertEqual(self.eio.core_id, EIO_CORE_ID)
+        self.assertEqual(self.eio.in_w, EIO_IN_W)
+        self.assertEqual(self.eio.out_w, EIO_OUT_W)
+
+    def test_discovery_finds_shared_chain(self):
+        """discover_eio locates the EIO without being told the chain/offset."""
+        from fcapz.eio import discover_eio
+
+        found = discover_eio(self.t, chains=(1, 2))
+        self.assertIsNotNone(found)
+        self.assertEqual(found.bscan_chain, EIO_CHAIN)
+        self.assertEqual(found._base_addr, EIO_BASE)  # noqa: SLF001 - asserting discovered location
+
+    def test_output_roundtrip(self):
+        """Driving probe_out (the LEDs) reads back exactly."""
+        for pat in (0x00, 0x3F, 0x15, 0x2A, 0x01, 0x20):
+            self.eio.write_outputs(pat)
+            self.assertEqual(
+                self.eio.read_outputs(), pat, f"LED readback mismatch for 0x{pat:02X}"
+            )
+
+    def test_read_inputs_in_range(self):
+        """probe_in (the 2 buttons) reads without error and within IN_W bits."""
+        value = self.eio.read_inputs()
+        self.assertEqual(value, value & ((1 << EIO_IN_W) - 1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/host/fcapz/analyzer.py
+++ b/host/fcapz/analyzer.py
@@ -371,7 +371,7 @@ class Analyzer:
 
         # Validate host config against the synthesized core to avoid silent
         # mismatch between CLI defaults and FPGA bitstream parameters.
-        _read = getattr(self.transport, "read_reg_verified", self.transport.read_reg)
+        _read = self.transport.read_reg_stable
         hw_sample_w = int(_read(_ADDR_SAMPLE_W))
         hw_depth = int(_read(_ADDR_DEPTH))
         hw_num_chan = max(1, int(_read(_ADDR_NUM_CHAN)))
@@ -461,7 +461,7 @@ class Analyzer:
         cannot block an immediate run.
         """
         self._select_instance()
-        _read = getattr(self.transport, "read_reg_verified", self.transport.read_reg)
+        _read = self.transport.read_reg_stable
         hw_features = int(_read(_ADDR_FEATURES))
         hw_trig_stages = int(hw_features & 0xF)
         trig = TriggerConfig(mode="value_match", value=0, mask=0)
@@ -488,7 +488,7 @@ class Analyzer:
 
     def wait_done(self, timeout: float = 10.0, poll_interval: float = 0.05) -> bool:
         deadline = time.monotonic() + timeout
-        read_status = getattr(self.transport, "read_reg_verified", self.transport.read_reg)
+        read_status = self.transport.read_reg_stable
         while time.monotonic() < deadline:
             with self.transport.transaction_lock():
                 self._select_instance()
@@ -551,7 +551,7 @@ class Analyzer:
     def _read_data_words(self, total_words: int) -> list[int]:
         if self._selected_slot_has_burst():
             return self.transport.read_block(_ADDR_DATA_BASE, total_words)
-        read = getattr(self.transport, "read_reg_verified", self.transport.read_reg)
+        read = self.transport.read_reg_stable
         return [int(read(_ADDR_DATA_BASE + i * 4)) for i in range(total_words)]
 
     def capture(self, timeout: float = 10.0) -> CaptureResult:
@@ -562,7 +562,7 @@ class Analyzer:
 
         with self.transport.transaction_lock():
             self._select_instance()
-            read_reg = getattr(self.transport, "read_reg_verified", self.transport.read_reg)
+            read_reg = self.transport.read_reg_stable
             status = read_reg(_ADDR_STATUS)
             fallback_total = self._config.pretrigger + self._config.posttrigger + 1
             reported_total = int(read_reg(_ADDR_CAPTURE_LEN))
@@ -611,7 +611,7 @@ class Analyzer:
         # directly by the burst engine (stable after all_seg_done).
         self.transport.write_reg(_ADDR_SEG_SEL, seg_idx)
 
-        read_reg = getattr(self.transport, "read_reg_verified", self.transport.read_reg)
+        read_reg = self.transport.read_reg_stable
         status = read_reg(_ADDR_STATUS)
         fallback_total = self._config.pretrigger + self._config.posttrigger + 1
         reported_total = int(read_reg(_ADDR_CAPTURE_LEN))
@@ -795,16 +795,16 @@ class Analyzer:
             probe_mux_w = int(vals[7])
             compare_caps = int(vals[8])
         else:
-            _vread = getattr(self.transport, "read_reg_verified", self.transport.read_reg)
+            _vread = self.transport.read_reg_stable
             version = int(_vread(_ADDR_VERSION))
-            sample_w = int(self.transport.read_reg(_ADDR_SAMPLE_W))
-            depth = int(self.transport.read_reg(_ADDR_DEPTH))
-            num_chan = int(self.transport.read_reg(_ADDR_NUM_CHAN))
-            features = int(self.transport.read_reg(_ADDR_FEATURES))
-            timestamp_w = int(self.transport.read_reg(_ADDR_TIMESTAMP_W))
-            num_segments = max(1, int(self.transport.read_reg(_ADDR_NUM_SEGMENTS)))
-            probe_mux_w = int(self.transport.read_reg(_ADDR_PROBE_MUX_W))
-            compare_caps = int(self.transport.read_reg(_ADDR_COMPARE_CAPS))
+            sample_w = int(_vread(_ADDR_SAMPLE_W))
+            depth = int(_vread(_ADDR_DEPTH))
+            num_chan = int(_vread(_ADDR_NUM_CHAN))
+            features = int(_vread(_ADDR_FEATURES))
+            timestamp_w = int(_vread(_ADDR_TIMESTAMP_W))
+            num_segments = max(1, int(_vread(_ADDR_NUM_SEGMENTS)))
+            probe_mux_w = int(_vread(_ADDR_PROBE_MUX_W))
+            compare_caps = int(_vread(_ADDR_COMPARE_CAPS))
         if compare_caps == 0:
             compare_caps = _COMPARE_CAPS_LEGACY_FULL
         return (
@@ -878,8 +878,8 @@ class Analyzer:
         :meth:`~fcapz.transport.XilinxHwServerTransport.read_regs_pipelined_user1`
         (hw_server), all probe registers share **one** XSDB ``_send`` plus
         a pipeline flush read.
-        Otherwise uses ``read_reg_verified`` for VERSION when the transport implements it,
-        then :meth:`~fcapz.transport.Transport.read_reg` for the remaining registers.
+        Otherwise uses :meth:`~fcapz.transport.Transport.read_reg_stable`
+        for VERSION, identity, and feature registers.
 
         Returns a dict with `version_major`, `version_minor`, `core_id`
         (always 0x4C41 on success),         `trig_stages` (FEATURES[3:0]: hardware
@@ -921,7 +921,7 @@ class CoreManager:
         """Read manager identity and slot count."""
         with self.transport.transaction_lock():
             self._select_chain()
-            read = getattr(self.transport, "read_reg_verified", self.transport.read_reg)
+            read = self.transport.read_reg_stable
             version = int(read(_ADDR_MGR_VERSION))
             core_id = version & 0xFFFF
             if core_id != _CORE_MANAGER_CORE_ID:

--- a/host/fcapz/cli.py
+++ b/host/fcapz/cli.py
@@ -418,6 +418,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Managed core slot on the selected chain",
     )
+    eio_probe.add_argument(
+        "--base-addr",
+        type=lambda x: int(x, 0),
+        default=0,
+        help="Register-bus mux offset for a shared-chain EIO (Gowin EIO_EN=1: 0x8000)",
+    )
 
     eio_read = sub.add_parser("eio-read", help="Read EIO input probes")
     eio_read.add_argument("--chain", type=int, default=3, help="BSCANE2 USER chain (default 3)")
@@ -427,6 +433,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Managed core slot on the selected chain",
     )
+    eio_read.add_argument(
+        "--base-addr",
+        type=lambda x: int(x, 0),
+        default=0,
+        help="Register-bus mux offset for a shared-chain EIO (Gowin EIO_EN=1: 0x8000)",
+    )
 
     eio_write = sub.add_parser("eio-write", help="Write EIO output probes")
     eio_write.add_argument("--chain", type=int, default=3, help="BSCANE2 USER chain (default 3)")
@@ -435,6 +447,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help="Managed core slot on the selected chain",
+    )
+    eio_write.add_argument(
+        "--base-addr",
+        type=lambda x: int(x, 0),
+        default=0,
+        help="Register-bus mux offset for a shared-chain EIO (Gowin EIO_EN=1: 0x8000)",
     )
     eio_write.add_argument("value", type=lambda x: int(x, 0), help="Output value (hex or decimal)")
 
@@ -543,7 +561,9 @@ def main() -> int:
 
     # -- EIO commands ------------------------------------------------------
     if args.cmd in ("eio-probe", "eio-read", "eio-write"):
-        eio = EioController(transport, chain=args.chain, instance=args.instance)
+        eio = EioController(
+            transport, chain=args.chain, instance=args.instance, base_addr=args.base_addr
+        )
         try:
             eio.connect()
             if args.cmd == "eio-probe":

--- a/host/fcapz/eio.py
+++ b/host/fcapz/eio.py
@@ -25,6 +25,8 @@ on the ``EioController`` instance as ``version_major`` /
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 from .registers import ADDR_MGR_ACTIVE as _ADDR_MGR_ACTIVE
 from .transport import Transport
 
@@ -254,3 +256,43 @@ class EioController:
     # ------------------------------------------------------------------
     def __repr__(self) -> str:
         return f"EioController(in_w={self.in_w}, out_w={self.out_w})"
+
+
+def discover_eio(
+    transport: Transport,
+    *,
+    chains: Iterable[int] = (1,),
+    bases: Iterable[int] = (0x0000, 0x8000),
+    instances: Iterable[int] | None = None,
+) -> EioController | None:
+    """Find and attach the EIO core by probing candidate JTAG locations.
+
+    The host should not need to know which USER chain or mux offset a core
+    sits behind.  This tries, in order: core-manager slots (``instances`` on
+    chain 1), then every ``chains`` x ``bases`` combination, attaching the
+    first location whose identity register reads the EIO magic (``0x494F``).
+
+    ``EioController.attach`` only reads and restores chain 1, so probing a
+    wrong location is harmless — non-matches (wrong chain, ELA magic,
+    unprogrammed FPGA) raise and are skipped.  Returns the attached
+    controller, or ``None`` if no EIO core responds anywhere.
+    """
+    candidates: list[dict[str, int]] = []
+    if instances:
+        candidates.extend({"chain": 1, "instance": int(i)} for i in instances)
+    candidates.extend(
+        {"chain": int(c), "base_addr": int(b)} for c in chains for b in bases
+    )
+    seen: set[tuple] = set()
+    for kw in candidates:
+        key = tuple(sorted(kw.items()))
+        if key in seen:
+            continue
+        seen.add(key)
+        eio = EioController(transport, **kw)
+        try:
+            eio.attach()
+        except (OSError, RuntimeError, ValueError, NotImplementedError):
+            continue
+        return eio
+    return None

--- a/host/fcapz/gui/app_window.py
+++ b/host/fcapz/gui/app_window.py
@@ -43,10 +43,9 @@ from PySide6.QtWidgets import (
 )
 
 from ..analyzer import Analyzer, CaptureConfig, CaptureResult, ELA_CORE_ID
-from ..eio import EIO_CORE_ID, EioController
+from ..eio import EIO_CORE_ID, EioController, discover_eio
 from ..ejtagaxi import AXIError, EjtagAxiController
 from ..ejtaguart import EjtagUartController
-from ..transport import OpenOcdTransport
 from .branding import GUI_DISPLAY_TITLE
 from .axi_panel import AxiPanel
 from .capture_panel import CapturePanel
@@ -545,14 +544,6 @@ class MainWindow(QMainWindow):
             ]
         self._capture.set_managed_ela_slots(ela_slots, current=0)
         self._eio_panel.set_managed_eio_slots(eio_slots)
-        if (
-            not eio_slots
-            and isinstance(analyzer.transport, OpenOcdTransport)
-            and analyzer.transport.ir_table == OpenOcdTransport.IR_TABLE_GOWIN
-        ):
-            # Gowin exposes one GW_JTAG primitive: when EIO_EN=1 the EIO core
-            # is muxed onto the ELA chain (chain 1) at register offset 0x8000.
-            self._eio_panel.apply_shared_chain_defaults(chain=1, base_addr=0x8000)
         self._dock_capture.setWindowTitle("ELA")
         self._dock_eio.setWindowTitle("EIO")
         self._axi_panel.set_transport_available(True)
@@ -573,8 +564,7 @@ class MainWindow(QMainWindow):
             msg = "Connected — JTAG OK; no ELA on USER1 (EIO/AXI/UART still available)."
         self._conn.set_connected(True, msg)
         self.statusBar().showMessage(msg)
-        if eio_slots:
-            self._on_eio_attach()
+        self._auto_attach_eio(analyzer.transport, eio_slots)
 
         gui = load_gui_settings(self._config_path)
         gui.connection = conn
@@ -1233,29 +1223,59 @@ class MainWindow(QMainWindow):
         self._dock_capture.setWindowTitle("ELA capture")
         self._dock_eio.setWindowTitle("EIO")
 
+    def _discover_eio(self, transport, eio_slots) -> EioController | None:
+        """Probe known locations for the EIO core; never raise into the UI."""
+        try:
+            chains = sorted(getattr(transport, "ir_table", {}).keys()) or [1]
+            return discover_eio(transport, chains=chains, instances=eio_slots or None)
+        except Exception:  # noqa: BLE001 - discovery must not break the UI
+            _log.exception("EIO discovery failed")
+            return None
+
+    def _auto_attach_eio(self, transport, eio_slots) -> None:
+        """Auto-attach EIO on connect so the user needn't pick a chain.
+
+        A core-manager slot is already known from topology, so attach it
+        directly; otherwise probe for a standalone / shared EIO.  Silent when
+        none is found.
+        """
+        if eio_slots:
+            try:
+                eio = EioController(transport, chain=1, instance=int(eio_slots[0]))
+                eio.attach()
+            except (OSError, RuntimeError, ValueError):
+                return
+        else:
+            eio = self._discover_eio(transport, None)
+            if eio is None:
+                return
+        self._eio = eio
+        self._eio_panel.bind_eio(transport, eio)
+        _log.info("EIO auto-attached (chain=%d)", eio.bscan_chain)
+
     def _on_eio_attach(self) -> None:
         if self._analyzer is None:
             return
         t = self._analyzer.transport
-        try:
-            eio = EioController(
-                t,
-                chain=self._eio_panel.chain(),
-                instance=self._eio_panel.instance(),
-                base_addr=self._eio_panel.base_addr(),
-            )
-            eio.attach()
-        except (OSError, RuntimeError, ValueError) as exc:
-            QMessageBox.warning(self, "EIO attach", str(exc))
-            return
+        # Auto-discover first so the user needn't pick a USER chain / offset.
+        eio = self._discover_eio(t, self._eio_panel.managed_slots())
+        if eio is None:
+            # Fall back to the panel's manual location (advanced override).
+            try:
+                eio = EioController(
+                    t,
+                    chain=self._eio_panel.chain(),
+                    instance=self._eio_panel.instance(),
+                    base_addr=self._eio_panel.base_addr(),
+                )
+                eio.attach()
+            except (OSError, RuntimeError, ValueError) as exc:
+                QMessageBox.warning(self, "EIO attach", str(exc))
+                return
         self._eio = eio
         self._eio_panel.bind_eio(t, eio)
         self.statusBar().showMessage("EIO attached")
-        _log.info(
-            "EIO attached (chain=%d, instance=%s)",
-            self._eio_panel.chain(),
-            self._eio_panel.instance(),
-        )
+        _log.info("EIO attached (chain=%d)", eio.bscan_chain)
 
     def _on_eio_detach(self) -> None:
         self._eio = None

--- a/host/fcapz/gui/app_window.py
+++ b/host/fcapz/gui/app_window.py
@@ -1233,6 +1233,7 @@ class MainWindow(QMainWindow):
                 t,
                 chain=self._eio_panel.chain(),
                 instance=self._eio_panel.instance(),
+                base_addr=self._eio_panel.base_addr(),
             )
             eio.attach()
         except (OSError, RuntimeError, ValueError) as exc:

--- a/host/fcapz/gui/app_window.py
+++ b/host/fcapz/gui/app_window.py
@@ -46,6 +46,7 @@ from ..analyzer import Analyzer, CaptureConfig, CaptureResult, ELA_CORE_ID
 from ..eio import EIO_CORE_ID, EioController
 from ..ejtagaxi import AXIError, EjtagAxiController
 from ..ejtaguart import EjtagUartController
+from ..transport import OpenOcdTransport
 from .branding import GUI_DISPLAY_TITLE
 from .axi_panel import AxiPanel
 from .capture_panel import CapturePanel
@@ -544,6 +545,14 @@ class MainWindow(QMainWindow):
             ]
         self._capture.set_managed_ela_slots(ela_slots, current=0)
         self._eio_panel.set_managed_eio_slots(eio_slots)
+        if (
+            not eio_slots
+            and isinstance(analyzer.transport, OpenOcdTransport)
+            and analyzer.transport.ir_table == OpenOcdTransport.IR_TABLE_GOWIN
+        ):
+            # Gowin exposes one GW_JTAG primitive: when EIO_EN=1 the EIO core
+            # is muxed onto the ELA chain (chain 1) at register offset 0x8000.
+            self._eio_panel.apply_shared_chain_defaults(chain=1, base_addr=0x8000)
         self._dock_capture.setWindowTitle("ELA")
         self._dock_eio.setWindowTitle("EIO")
         self._axi_panel.set_transport_available(True)

--- a/host/fcapz/gui/connection_panel.py
+++ b/host/fcapz/gui/connection_panel.py
@@ -67,6 +67,7 @@ class ConnectionPanel(QGroupBox):
         self._ir = QComboBox()
         self._ir.addItem("Xilinx 7-series", "xilinx7")
         self._ir.addItem("UltraScale+", "ultrascale")
+        self._ir.addItem("Gowin (OpenOCD)", "gowin")
 
         self._program_on_connect = QCheckBox("Program on connect")
         self._program_on_connect.setChecked(ConnectionSettings().program_on_connect)

--- a/host/fcapz/gui/connection_panel.py
+++ b/host/fcapz/gui/connection_panel.py
@@ -53,9 +53,13 @@ class ConnectionPanel(QGroupBox):
         self._tap = QComboBox()
         self._tap.setEditable(True)
         self._tap.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
-        self._tap.lineEdit().setPlaceholderText("xc7a100t.tap or FPGA target name")
+        self._tap.lineEdit().setPlaceholderText(
+            "xc7a100t.tap, FPGA target, or 'auto' (OpenOCD picks the first tap)"
+        )
         self._scan_targets_btn = QPushButton("Scan")
-        self._scan_targets_btn.setToolTip("List JTAG targets from hw_server / XSDB.")
+        self._scan_targets_btn.setToolTip(
+            "List JTAG targets (hw_server/XSDB) or tap names (OpenOCD 'jtag names')."
+        )
         self._scan_targets_btn.clicked.connect(self._scan_targets)
 
         tap_row = QWidget()
@@ -169,34 +173,42 @@ class ConnectionPanel(QGroupBox):
         self._backend.currentIndexChanged.connect(self._on_backend_changed)
         self._on_backend_changed()
 
+    def _backend_supports_scan(self) -> bool:
+        return self._backend.currentData() in ("hw_server", "openocd")
+
     def _on_backend_changed(self) -> None:
         is_hw = self._backend.currentData() == "hw_server"
         self._program_on_connect.setEnabled(is_hw)
         self._program.setEnabled(is_hw)
-        self._scan_targets_btn.setEnabled(is_hw and not self._connected)
+        self._scan_targets_btn.setEnabled(
+            self._backend_supports_scan() and not self._connected
+        )
         self._refresh_timeout_row_state()
 
     def _scan_targets(self) -> None:
         if self._scan_thread is not None and self._scan_thread.isRunning():
             return
-        if self._backend.currentData() != "hw_server":
+        backend = self._backend.currentData()
+        if not self._backend_supports_scan():
             QMessageBox.information(
                 self,
                 "Scan targets",
-                "JTAG target scanning is currently available for hw_server only.",
+                "JTAG scanning is available for the hw_server and OpenOCD backends.",
             )
             return
         host = self._host.text().strip() or "127.0.0.1"
         port = int(self._port.value())
-        if port == 6666:
+        if backend == "hw_server" and port == 6666:
             port = 3121
-        self._status.setText(f"Scanning JTAG targets on {host}:{port}...")
+        kind = "targets" if backend == "hw_server" else "taps"
+        self._status.setText(f"Scanning JTAG {kind} on {host}:{port}...")
         self._scan_targets_btn.setEnabled(False)
         thread = QThread()
         worker = TargetScanWorker(
             host=host,
             port=port,
             timeout_sec=float(self._tcp_timeout.value()),
+            backend=backend,
         )
         worker.moveToThread(thread)
         thread.started.connect(worker.run)
@@ -244,11 +256,11 @@ class ConnectionPanel(QGroupBox):
     def _on_scan_targets_finished(self, targets: object) -> None:
         target_list = [str(t) for t in targets] if isinstance(targets, list) else []
         if not target_list:
-            self._status.setText("Scan complete: no JTAG targets reported.")
+            self._status.setText("Scan complete: no JTAG taps/targets reported.")
             QMessageBox.information(
                 self,
                 "Scan targets",
-                "hw_server responded, but XSDB did not report any JTAG targets.",
+                "The backend responded but reported no JTAG taps/targets.",
             )
             return
         self._replace_scanned_targets(target_list)
@@ -263,7 +275,7 @@ class ConnectionPanel(QGroupBox):
         self._scan_worker = None
         self._scan_thread = None
         self._scan_targets_btn.setEnabled(
-            self._backend.currentData() == "hw_server" and not self._connected
+            self._backend_supports_scan() and not self._connected
         )
 
     def _will_program_bitfile(self) -> bool:
@@ -384,7 +396,7 @@ class ConnectionPanel(QGroupBox):
         self._tap.setEnabled(editable)
         self._ir.setEnabled(editable)
         is_hw = self._backend.currentData() == "hw_server"
-        self._scan_targets_btn.setEnabled(editable and is_hw)
+        self._scan_targets_btn.setEnabled(editable and self._backend_supports_scan())
         self._program_on_connect.setEnabled(editable and is_hw)
         self._program.setEnabled(editable and is_hw)
         self._tcp_timeout.setEnabled(editable)

--- a/host/fcapz/gui/eio_panel.py
+++ b/host/fcapz/gui/eio_panel.py
@@ -279,24 +279,9 @@ class EioPanel(QGroupBox):
         """Register-bus mux offset for a shared-chain EIO (0 = standalone)."""
         return int(self._base_addr_spin.value())
 
-    def apply_shared_chain_defaults(self, chain: int, base_addr: int) -> None:
-        """Pre-fill the manual EIO location for a shared-chain core.
-
-        Used for Gowin (EIO_EN=1 muxes EIO onto the ELA chain at 0x8000) so the
-        user only has to click Attach.  No-op once attached or when a
-        core-manager topology was detected.
-        """
-        if self._eio is not None or self._managed_eio_slots:
-            return
-        self._managed_slot.setChecked(False)
-        self._chain_spin.setValue(int(chain))
-        self._base_addr_spin.setValue(int(base_addr))
-        self._chain_value.setText(f"chain {int(chain)}")
-        self._slot_value.setText("slot direct")
-        self._info.setText(
-            f"Shared-chain EIO defaults set (chain {int(chain)}, "
-            f"base 0x{int(base_addr):04X}). Click Attach EIO."
-        )
+    def managed_slots(self) -> list[int]:
+        """Core-manager EIO slots detected from topology (empty if none)."""
+        return list(self._managed_eio_slots)
 
     def _apply_attach_ui_state(self, attached: bool) -> None:
         """Grey out probe UI until EIO is attached; keep chain + attach usable when connected."""

--- a/host/fcapz/gui/eio_panel.py
+++ b/host/fcapz/gui/eio_panel.py
@@ -279,6 +279,25 @@ class EioPanel(QGroupBox):
         """Register-bus mux offset for a shared-chain EIO (0 = standalone)."""
         return int(self._base_addr_spin.value())
 
+    def apply_shared_chain_defaults(self, chain: int, base_addr: int) -> None:
+        """Pre-fill the manual EIO location for a shared-chain core.
+
+        Used for Gowin (EIO_EN=1 muxes EIO onto the ELA chain at 0x8000) so the
+        user only has to click Attach.  No-op once attached or when a
+        core-manager topology was detected.
+        """
+        if self._eio is not None or self._managed_eio_slots:
+            return
+        self._managed_slot.setChecked(False)
+        self._chain_spin.setValue(int(chain))
+        self._base_addr_spin.setValue(int(base_addr))
+        self._chain_value.setText(f"chain {int(chain)}")
+        self._slot_value.setText("slot direct")
+        self._info.setText(
+            f"Shared-chain EIO defaults set (chain {int(chain)}, "
+            f"base 0x{int(base_addr):04X}). Click Attach EIO."
+        )
+
     def _apply_attach_ui_state(self, attached: bool) -> None:
         """Grey out probe UI until EIO is attached; keep chain + attach usable when connected."""
         has_transport = self._transport is not None

--- a/host/fcapz/gui/eio_panel.py
+++ b/host/fcapz/gui/eio_panel.py
@@ -63,6 +63,17 @@ class EioPanel(QGroupBox):
         self._instance_spin.setValue(2)
         self._instance_spin.setToolTip("Core-manager slot index for this EIO.")
         self._instance_spin.valueChanged.connect(self._sync_core_combo_to_instance)
+        self._base_addr_spin = QSpinBox()
+        self._base_addr_spin.setRange(0, 0xFFFF)
+        self._base_addr_spin.setSingleStep(0x1000)
+        self._base_addr_spin.setDisplayIntegerBase(16)
+        self._base_addr_spin.setPrefix("0x")
+        self._base_addr_spin.setValue(0)
+        self._base_addr_spin.setToolTip(
+            "Register-bus mux offset for a shared-chain EIO. "
+            "Gowin (EIO_EN=1 on the ELA wrapper): 0x8000 on chain 1. "
+            "0 = standalone chain (e.g. Xilinx USER3).",
+        )
         self._attach_btn = QPushButton("Attach EIO")
         self._attach_btn.setToolTip(
             "Required before reads/writes. Legacy Arty: chain 3. "
@@ -130,6 +141,8 @@ class EioPanel(QGroupBox):
         manual_row.addWidget(self._managed_slot)
         manual_row.addWidget(QLabel("Slot"))
         manual_row.addWidget(self._instance_spin)
+        manual_row.addWidget(QLabel("Base"))
+        manual_row.addWidget(self._base_addr_spin)
         manual_row.addStretch(1)
         self._manual_row_widget = QWidget()
         self._manual_row_widget.setLayout(manual_row)
@@ -262,12 +275,17 @@ class EioPanel(QGroupBox):
             return None
         return int(self._instance_spin.value())
 
+    def base_addr(self) -> int:
+        """Register-bus mux offset for a shared-chain EIO (0 = standalone)."""
+        return int(self._base_addr_spin.value())
+
     def _apply_attach_ui_state(self, attached: bool) -> None:
         """Grey out probe UI until EIO is attached; keep chain + attach usable when connected."""
         has_transport = self._transport is not None
         managed_detected = bool(self._managed_eio_slots)
         self._manual_row_widget.setVisible(not managed_detected)
         self._chain_spin.setEnabled(has_transport and not attached)
+        self._base_addr_spin.setEnabled(has_transport and not attached)
         self._managed_slot.setEnabled(has_transport and not attached)
         self._core_combo.setEnabled(
             has_transport and managed_detected

--- a/host/fcapz/gui/settings.py
+++ b/host/fcapz/gui/settings.py
@@ -36,13 +36,16 @@ def ir_table_preset(name: str) -> dict[int, int]:
     """
     Map a short preset name to an IR-length table for OpenOCD / hw_server transports.
 
-    Aliases: ``xilinx7``, ``7series`` → 7-series table; ``ultrascale``, ``us`` → US+ table.
+    Aliases: ``xilinx7``, ``7series`` → 7-series table; ``ultrascale``, ``us`` → US+ table;
+    ``gowin``, ``gw`` → Gowin ER1/ER2 table (OpenOCD only).
     """
     key = name.strip().lower().replace("-", "_")
     if key in ("xilinx7", "7series", "series7"):
         return dict(OpenOcdTransport.IR_TABLE_XILINX7)
     if key in ("ultrascale", "us", "xilinx_ultrascale"):
         return dict(OpenOcdTransport.IR_TABLE_US)
+    if key in ("gowin", "gw"):
+        return dict(OpenOcdTransport.IR_TABLE_GOWIN)
     raise ValueError(f"unknown ir_table preset {name!r}")
 
 

--- a/host/fcapz/gui/worker.py
+++ b/host/fcapz/gui/worker.py
@@ -11,7 +11,11 @@ import time
 from PySide6.QtCore import QObject, Signal, Slot
 
 from ..analyzer import Analyzer, CaptureConfig, ElaManager
-from ..transport import connect_timing_logs_enabled, list_xilinx_hw_server_targets
+from ..transport import (
+    connect_timing_logs_enabled,
+    list_openocd_taps,
+    list_xilinx_hw_server_targets,
+)
 from .connect_errors import format_connect_error
 from .settings import ConnectionSettings
 from .transport_from_settings import transport_from_connection
@@ -239,7 +243,11 @@ class ConnectWorker(QObject):
 
 
 class TargetScanWorker(QObject):
-    """Background XSDB target scan so the connection panel stays responsive."""
+    """Background JTAG scan so the connection panel stays responsive.
+
+    ``hw_server`` lists XSDB JTAG targets; ``openocd`` lists tap names from a
+    running OpenOCD instance (``jtag names``).
+    """
 
     finished = Signal(object)
     failed = Signal(str)
@@ -250,20 +258,29 @@ class TargetScanWorker(QObject):
         host: str,
         port: int,
         timeout_sec: float,
+        backend: str = "hw_server",
     ) -> None:
         super().__init__()
         self._host = host
         self._port = int(port)
         self._timeout_sec = float(timeout_sec)
+        self._backend = backend
 
     @Slot()
     def run(self) -> None:
         try:
-            targets = list_xilinx_hw_server_targets(
-                host=self._host,
-                port=self._port,
-                timeout_sec=self._timeout_sec,
-            )
+            if self._backend == "openocd":
+                targets = list_openocd_taps(
+                    host=self._host,
+                    port=self._port,
+                    timeout_sec=self._timeout_sec,
+                )
+            else:
+                targets = list_xilinx_hw_server_targets(
+                    host=self._host,
+                    port=self._port,
+                    timeout_sec=self._timeout_sec,
+                )
         except Exception as exc:  # noqa: BLE001 - surfaced via GUI
             self.failed.emit(str(exc))
             return

--- a/host/fcapz/transport.py
+++ b/host/fcapz/transport.py
@@ -115,6 +115,25 @@ def list_xilinx_hw_server_targets(
     return targets
 
 
+def list_openocd_taps(
+    *,
+    host: str = "127.0.0.1",
+    port: int = 6666,
+    timeout_sec: float = 5.0,
+) -> list[str]:
+    """Return JTAG tap names from a running OpenOCD instance (``jtag names``).
+
+    Requires OpenOCD to already be listening on its TCL RPC port (default
+    6666).  Used by the GUI's "Scan" button for the OpenOCD backend.
+    """
+    t = OpenOcdTransport(host=host, port=port, connect_timeout_sec=timeout_sec)
+    t.connect()
+    try:
+        return t.list_taps()
+    finally:
+        t.close()
+
+
 class Transport(ABC):
     """Abstract base class for all fpgacapZero JTAG transports.
 
@@ -343,6 +362,26 @@ class OpenOcdTransport(Transport):
         except OSError:
             pass
         self._sock.settimeout(5)
+        if self.tap.strip().lower() in ("", "auto"):
+            self.tap = self._resolve_auto_tap()
+
+    def list_taps(self) -> list[str]:
+        """Return the JTAG tap names OpenOCD has configured (``jtag names``)."""
+        return self._cmd("jtag names").split()
+
+    def _resolve_auto_tap(self) -> str:
+        """Resolve ``tap='auto'`` to a concrete name via OpenOCD ``jtag names``.
+
+        Picks the first tap OpenOCD reports — single-FPGA chains have exactly
+        one.  Raises ``RuntimeError`` if OpenOCD has no taps configured.
+        """
+        taps = self.list_taps()
+        if not taps:
+            raise RuntimeError(
+                "tap='auto' but OpenOCD reports no JTAG taps. "
+                "Check your openocd.cfg ('jtag newtap ...')."
+            )
+        return taps[0]
 
     def close(self) -> None:
         if self._sock:

--- a/host/fcapz/transport.py
+++ b/host/fcapz/transport.py
@@ -197,6 +197,16 @@ class Transport(ABC):
         """
         raise NotImplementedError
 
+    def read_reg_stable(self, addr: int) -> int:
+        """Read a register, applying any transport-specific stale-read workaround.
+
+        The base implementation is a single ``read_reg`` call.  Transports
+        with a known JTAG pipeline hazard may override this to discard a
+        warmup read before returning data.  This is not data-integrity
+        verification: it does not compare reads or detect corruption.
+        """
+        return self.read_reg(addr)
+
     @abstractmethod
     def write_reg(self, addr: int, value: int) -> None:
         """Write *value* (32-bit) to the register at *addr*.
@@ -787,11 +797,12 @@ class XilinxHwServerTransport(Transport):
         raw = self._send(tcl)
         return self._parse_bits_u32(raw)
 
-    def read_reg_verified(self, addr: int) -> int:
-        """Read a register twice and return the second value.
+    def read_reg_stable(self, addr: int) -> int:
+        """Read through the hw_server register pipeline and return settled data.
 
-        Works around a JTAG pipeline stale-data issue where the first read
-        after a session change may return data from the previous address.
+        XSDB JTAG sequences can return data from the previous register window
+        on the first read after changing addresses or session state.  Discard
+        one warmup read and return the second scan.
         """
         self.read_reg(addr)
         return self.read_reg(addr)
@@ -842,7 +853,7 @@ class XilinxHwServerTransport(Transport):
     def _burst_samples_per_scan(self) -> int:
         """Samples per 256-bit burst scan, based on hardware SAMPLE_W."""
         if not hasattr(self, "_cached_sps"):
-            sw = self.read_reg_verified(0x000C)  # ADDR_SAMPLE_W
+            sw = self.read_reg_stable(0x000C)  # ADDR_SAMPLE_W
             if sw < 1:
                 sw = 8
             self._cached_sps = max(1, self.BURST_DR_BITS // sw)

--- a/tests/test_cli_rpc_events.py
+++ b/tests/test_cli_rpc_events.py
@@ -548,6 +548,15 @@ class RpcBooleanValidationTests(unittest.TestCase):
 
 
 class CliTests(unittest.TestCase):
+    def test_eio_parsers_accept_base_addr_for_shared_chain(self):
+        parser = build_parser()
+        for cmd, extra in (("eio-probe", []), ("eio-read", []), ("eio-write", ["0x3f"])):
+            args = parser.parse_args([cmd, "--chain", "1", "--base-addr", "0x8000", *extra])
+            self.assertEqual(args.chain, 1)
+            self.assertEqual(args.base_addr, 0x8000)
+        # Default is 0 (standalone chain, e.g. Xilinx USER3)
+        self.assertEqual(parser.parse_args(["eio-read"]).base_addr, 0)
+
     def test_capture_parser_accepts_channel_and_probes(self):
         parser = build_parser()
         args = parser.parse_args(

--- a/tests/test_cli_rpc_events.py
+++ b/tests/test_cli_rpc_events.py
@@ -73,7 +73,41 @@ class FakeTransport(Transport):
         return [0] * words
 
 
+class StaleFirstReadTransport(FakeTransport):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._last_addr: int | None = None
+        self._stale_value = 0
+
+    def read_reg(self, addr: int) -> int:
+        value = super().read_reg(addr)
+        if addr != self._last_addr:
+            stale = self._stale_value
+            self._last_addr = addr
+            self._stale_value = value
+            return stale
+        self._stale_value = value
+        return value
+
+    def read_reg_stable(self, addr: int) -> int:
+        self.read_reg(addr)
+        return self.read_reg(addr)
+
+
 class AnalyzerValidationTests(unittest.TestCase):
+    def test_probe_stabilizes_all_identity_register_reads(self):
+        analyzer = Analyzer(StaleFirstReadTransport(sample_w=8, depth=1024, num_chan=1))
+        analyzer.connect()
+
+        info = analyzer.probe()
+        expected_version = expected_ela_version_reg()
+
+        self.assertEqual(info["version_major"], (expected_version >> 24) & 0xFF)
+        self.assertEqual(info["version_minor"], (expected_version >> 16) & 0xFF)
+        self.assertEqual(info["sample_width"], 8)
+        self.assertEqual(info["depth"], 1024)
+        self.assertEqual(info["num_channels"], 1)
+
     def test_wide_samples_reassembled_from_words(self):
         transport = FakeTransport(
             sample_w=64,

--- a/tests/test_gui_connection_panel.py
+++ b/tests/test_gui_connection_panel.py
@@ -78,7 +78,7 @@ class TestConnectionPanel(unittest.TestCase):
 
         p._on_scan_targets_finished([])
 
-        self.assertIn("no JTAG targets", p._status.text())
+        self.assertIn("no JTAG taps/targets", p._status.text())
         info_box.assert_called_once()
 
     @patch("fcapz.gui.connection_panel.QMessageBox.warning")

--- a/tests/test_gui_main_window.py
+++ b/tests/test_gui_main_window.py
@@ -301,6 +301,18 @@ def test_eio_attach_passes_shared_chain_base_addr(qtbot: Any, tmp_path: Path) ->
 
 
 @pytest.mark.gui
+def test_eio_panel_apply_shared_chain_defaults(qtbot: Any) -> None:
+    """Gowin pre-fill sets chain 1 + base 0x8000 with no managed slot."""
+    from fcapz.gui.eio_panel import EioPanel
+
+    p = EioPanel()
+    qtbot.addWidget(p)
+    p.apply_shared_chain_defaults(chain=1, base_addr=0x8000)
+    assert p.chain() == 1
+    assert p.base_addr() == 0x8000
+    assert p.instance() is None
+
+
 def test_eio_detach_reenables_managed_slot_choice(qtbot: Any, tmp_path: Path) -> None:
     gui_path = tmp_path / "gui.toml"
     with ExitStack() as ex:

--- a/tests/test_gui_main_window.py
+++ b/tests/test_gui_main_window.py
@@ -301,18 +301,6 @@ def test_eio_attach_passes_shared_chain_base_addr(qtbot: Any, tmp_path: Path) ->
 
 
 @pytest.mark.gui
-def test_eio_panel_apply_shared_chain_defaults(qtbot: Any) -> None:
-    """Gowin pre-fill sets chain 1 + base 0x8000 with no managed slot."""
-    from fcapz.gui.eio_panel import EioPanel
-
-    p = EioPanel()
-    qtbot.addWidget(p)
-    p.apply_shared_chain_defaults(chain=1, base_addr=0x8000)
-    assert p.chain() == 1
-    assert p.base_addr() == 0x8000
-    assert p.instance() is None
-
-
 def test_eio_detach_reenables_managed_slot_choice(qtbot: Any, tmp_path: Path) -> None:
     gui_path = tmp_path / "gui.toml"
     with ExitStack() as ex:

--- a/tests/test_gui_main_window.py
+++ b/tests/test_gui_main_window.py
@@ -263,7 +263,40 @@ def test_eio_attach_passes_managed_instance(qtbot: Any, tmp_path: Path) -> None:
         w._eio_panel._instance_spin.setValue(3)
         qtbot.mouseClick(_button_with_text(w._eio_panel, "Attach EIO"), Qt.MouseButton.LeftButton)
 
-        eio_cls.assert_called_with(w._analyzer.transport, chain=1, instance=3)
+        eio_cls.assert_called_with(
+            w._analyzer.transport, chain=1, instance=3, base_addr=0
+        )
+        eio.attach.assert_called_once()
+
+
+def test_eio_attach_passes_shared_chain_base_addr(qtbot: Any, tmp_path: Path) -> None:
+    """Gowin shared-chain EIO: chain 1, no managed slot, mux offset 0x8000."""
+    gui_path = tmp_path / "gui.toml"
+    with ExitStack() as ex:
+        _enter_successful_connect_mocks(ex, gui_path)
+        ex.enter_context(patch("fcapz.gui.app_window.QMessageBox.critical"))
+        eio_cls = ex.enter_context(patch("fcapz.gui.app_window.EioController"))
+        eio = eio_cls.return_value
+        eio.in_w = 2
+        eio.out_w = 6
+        eio.version_major = 0
+        eio.version_minor = 4
+        eio.bscan_chain = 1
+        eio.instance = None
+        eio.read_outputs.return_value = 0
+
+        w = MainWindow(restore_saved_layout=False, persist_window_layout=False)
+        qtbot.addWidget(w)
+        qtbot.mouseClick(_button_with_text(w, "Connect"), Qt.MouseButton.LeftButton)
+        qtbot.waitUntil(lambda: w._analyzer is not None, timeout=5000)
+
+        w._eio_panel._chain_spin.setValue(1)
+        w._eio_panel._base_addr_spin.setValue(0x8000)
+        qtbot.mouseClick(_button_with_text(w._eio_panel, "Attach EIO"), Qt.MouseButton.LeftButton)
+
+        eio_cls.assert_called_with(
+            w._analyzer.transport, chain=1, instance=None, base_addr=0x8000
+        )
         eio.attach.assert_called_once()
 
 

--- a/tests/test_gui_transport_from_settings.py
+++ b/tests/test_gui_transport_from_settings.py
@@ -30,6 +30,19 @@ class TestTransportFromSettings(unittest.TestCase):
         self.assertEqual(t.ir_table, OpenOcdTransport.IR_TABLE_US)
         self.assertEqual(t._connect_timeout_sec, 60.0)
 
+    def test_openocd_gowin_ir(self) -> None:
+        c = ConnectionSettings(
+            backend="openocd",
+            host="127.0.0.1",
+            port=6666,
+            tap="GW1NR-9C.tap",
+            ir_table="gowin",
+        )
+        t = transport_from_connection(c)
+        self.assertIsInstance(t, OpenOcdTransport)
+        self.assertEqual(t.tap, "GW1NR-9C.tap")
+        self.assertEqual(t.ir_table, OpenOcdTransport.IR_TABLE_GOWIN)
+
     def test_hw_server_port_remap_and_fpga_name(self) -> None:
         c = ConnectionSettings(
             backend="hw_server",

--- a/tests/test_host_stack.py
+++ b/tests/test_host_stack.py
@@ -22,7 +22,7 @@ from fcapz.analyzer import (
     TriggerConfig,
     expected_ela_version_reg,
 )
-from fcapz.eio import EIO_CORE_ID, EioController
+from fcapz.eio import EIO_CORE_ID, EioController, discover_eio
 from fcapz.transport import Transport
 
 
@@ -893,6 +893,65 @@ class FakeVioTransport(Transport):
 
     def read_block(self, addr: int, words: int):
         return [0] * words
+
+
+class FakeDiscoveryTransport(Transport):
+    """EIO present only at one (chain, base); every other read is non-EIO."""
+
+    def __init__(self, *, eio_chain: int, eio_base: int, ir_table: dict[int, int]):
+        self._active_chain = 1
+        self.eio_chain = eio_chain
+        self.eio_base = eio_base
+        self.ir_table = dict(ir_table)
+
+    def connect(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    def select_chain(self, chain: int) -> None:
+        if chain not in self.ir_table:
+            raise ValueError(f"chain {chain} not in ir_table")
+        self._active_chain = chain
+
+    def read_reg(self, addr: int) -> int:
+        if self._active_chain == self.eio_chain and addr == self.eio_base:
+            return _expected_eio_version_reg()  # VERSION with 'IO' magic
+        if addr == (self.eio_base | 0x0004):
+            return 2  # IN_W
+        if addr == (self.eio_base | 0x0008):
+            return 6  # OUT_W
+        return 0x00004C41  # ELA 'LA' magic elsewhere — not EIO
+
+    def write_reg(self, addr: int, value: int) -> None:
+        return None
+
+    def read_block(self, addr: int, words: int):
+        return [0] * words
+
+
+class DiscoverEioTests(unittest.TestCase):
+    def test_discovers_shared_chain_location(self):
+        """Finds EIO muxed at chain 1 / base 0x8000 (Gowin shape)."""
+        t = FakeDiscoveryTransport(eio_chain=1, eio_base=0x8000, ir_table={1: 0x42, 2: 0x43})
+        eio = discover_eio(t, chains=(1, 2))
+        self.assertIsNotNone(eio)
+        self.assertEqual(eio.bscan_chain, 1)
+        self.assertEqual(eio._base_addr, 0x8000)
+        self.assertEqual((eio.in_w, eio.out_w), (2, 6))
+
+    def test_discovers_standalone_chain(self):
+        """Finds a standalone EIO on a non-default chain at base 0."""
+        t = FakeDiscoveryTransport(eio_chain=3, eio_base=0x0000, ir_table={1: 1, 2: 2, 3: 3, 4: 4})
+        eio = discover_eio(t, chains=(1, 2, 3, 4))
+        self.assertIsNotNone(eio)
+        self.assertEqual(eio.bscan_chain, 3)
+
+    def test_returns_none_when_no_eio(self):
+        """No EIO anywhere -> None (e.g. EIO_EN=0 bitstream)."""
+        t = FakeDiscoveryTransport(eio_chain=9, eio_base=0x0, ir_table={1: 1, 2: 2})
+        self.assertIsNone(discover_eio(t, chains=(1, 2)))
 
 
 class EioControllerTests(unittest.TestCase):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -156,6 +156,32 @@ class TransportAbcTests(unittest.TestCase):
         self.assertEqual(results, [0xAA, 0xBB])
         self.assertEqual(call_log, [(0xAA, 8), (0xBB, 16)])
 
+    def test_read_reg_stable_base_default_reads_once(self):
+        """The base stable-read hook is opt-in and does not add extra scans."""
+        calls: list[int] = []
+
+        class TracingTransport(ConcreteTransport):
+            def read_reg(self, addr: int) -> int:
+                calls.append(addr)
+                return 0x1234
+
+        t = TracingTransport()
+        self.assertEqual(t.read_reg_stable(0x000C), 0x1234)
+        self.assertEqual(calls, [0x000C])
+
+    def test_xsdb_read_reg_stable_discards_warmup_read(self):
+        """hw_server overrides stable reads to discard one stale pipeline value."""
+        calls: list[int] = []
+        t = XilinxHwServerTransport()
+
+        def fake_read_reg(addr: int) -> int:
+            calls.append(addr)
+            return 0x10 if len(calls) == 1 else 0x20
+
+        t.read_reg = fake_read_reg  # type: ignore[method-assign]
+        self.assertEqual(t.read_reg_stable(0x000C), 0x20)
+        self.assertEqual(calls, [0x000C, 0x000C])
+
 
 # ---------------------------------------------------------------------------
 # OpenOcdTransport failure modes

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -229,6 +229,42 @@ class OpenOcdConnectFailureTests(unittest.TestCase):
         t = OpenOcdTransport()
         t.close()  # must not raise
 
+    def test_list_taps_parses_jtag_names(self):
+        """list_taps() splits OpenOCD 'jtag names' output."""
+        t = OpenOcdTransport()
+        with patch.object(t, "_cmd", return_value="GW1NR-9C.tap"):
+            self.assertEqual(t.list_taps(), ["GW1NR-9C.tap"])
+
+    def test_connect_resolves_auto_tap_to_first(self):
+        """tap='auto' is resolved to the first tap OpenOCD reports on connect."""
+        mock_sock = MagicMock()
+        mock_sock.recv.return_value = b""
+        with patch("socket.create_connection", return_value=mock_sock), patch.object(
+            OpenOcdTransport, "list_taps", return_value=["GW1NR-9C.tap", "other.tap"]
+        ):
+            t = OpenOcdTransport(tap="auto")
+            t.connect()
+            self.assertEqual(t.tap, "GW1NR-9C.tap")
+
+    def test_connect_keeps_explicit_tap(self):
+        """A concrete tap name is left untouched (no auto-resolution)."""
+        mock_sock = MagicMock()
+        mock_sock.recv.return_value = b""
+        with patch("socket.create_connection", return_value=mock_sock), patch.object(
+            OpenOcdTransport, "list_taps"
+        ) as list_taps:
+            t = OpenOcdTransport(tap="GW1NR-9C.tap")
+            t.connect()
+            self.assertEqual(t.tap, "GW1NR-9C.tap")
+            list_taps.assert_not_called()
+
+    def test_resolve_auto_tap_raises_when_no_taps(self):
+        """tap='auto' against an OpenOCD with no taps gives a clear error."""
+        t = OpenOcdTransport(tap="auto")
+        with patch.object(t, "list_taps", return_value=[]):
+            with self.assertRaisesRegex(RuntimeError, "no JTAG taps"):
+                t._resolve_auto_tap()
+
     def test_select_chain_unknown_raises_value_error(self):
         """select_chain() with a chain not in ir_table raises ValueError."""
         t = OpenOcdTransport()


### PR DESCRIPTION
## Summary

Brings the Brisbane Silicon **BRS-100-GW1NR9 (Gowin GW1NR-9C)** board up to a
first-class debug target: the reference design now exposes **EIO** alongside the
ELA, the desktop GUI and CLI drive Gowin over **OpenOCD** with no manual JTAG
fiddling, the docs are brought current, and there's a board-validated hardware
test suite. Also folds in a small host-side stale-read fix and a Gowin build
fix uncovered along the way.

All of it is **hardware-validated on a physical BRS-100-GW1NR9.**

## What's included

### RTL / reference design
- **EIO on the BRS design** (`EIO_EN=1`): the six LEDs are host-driven via EIO
  `probe_out`, the two user buttons are host-readable via EIO `probe_in` (and
  still captured on ELA channel 1). EIO shares the single `GW_JTAG` primitive
  with the ELA via the register-bus mux at offset `0x8000`.
- **Build fix:** `build_brs_100_gw1nr9.tcl` copied the bitstream from the wrong
  path (missing the `${project_name}` project subdir), so `build.py` exited
  non-zero even though synthesis/P&R succeeded.

### Host stack & CLI
- **OpenOCD tap auto-detect:** `tap="auto"` (or empty) resolves to the first tap
  from OpenOCD `jtag names`; adds `list_taps()` / `list_openocd_taps()`.
- **EIO auto-discovery:** `eio.discover_eio()` probes candidate locations
  (core-manager slots, then chains × `{0x0000, 0x8000}`) and attaches the first
  with the EIO identity — the host no longer needs to be told the chain/offset.
- **CLI `--base-addr`** on `eio-probe`/`eio-read`/`eio-write` so the shared-chain
  Gowin EIO is reachable from the CLI, not just the GUI/Python API.
- **`read_reg_stable` cleanup:** promotes the stale-read workaround to the base
  `Transport`, and fixes an inconsistency where `_read_identity` read `VERSION`
  through the workaround but `SAMPLE_W`/etc. without it (a latent hw_server bug).

### Desktop GUI
- IR-table dropdown gains **Gowin (OpenOCD)**.
- **Scan** button now supports the OpenOCD backend (lists tap names).
- EIO panel gains a **Base** offset field and **auto-discovers + attaches** EIO
  on connect — Gowin EIO "just appears," no chain/offset to enter.

### Docs
- `examples/brs_100_gw1nr9/README.md` rewritten around the EIO-enabled design
  (was factually wrong — said "EIO: disabled"), plus a **Hardware tests** section.
- Manual updated: GUI chapter (Gowin option, tap auto, Scan, EIO discovery),
  transports chapter (tap auto-detect + Gowin-over-OpenOCD), CLI reference and
  EIO chapter (`--base-addr` / shared-chain EIO).

### Tests
- **New `examples/brs_100_gw1nr9/test_hw_integration.py`** — 11 OpenOCD-driven
  tests mirroring the Arty suite, scoped to the BRS design: ELA identity, a
  counter capture with `+1`/sample checks, trigger match, register roundtrip,
  JSON/VCD export; EIO identity/widths, auto-discovery, LED output roundtrip,
  button reads. Opt-in and board-attached (skips without hardware).
- Host unit tests added for the new paths (tap resolve, discovery, `--base-addr`,
  GUI Gowin transport/EIO).

## Validation

- Host suite: **380 passing**, ruff clean.
- New hardware suite: **11/11 pass on a live BRS-100-GW1NR9**; **11 skipped**
  cleanly with no board / `FPGACAP_SKIP_HW=1`.

## Out of scope (deferred)

- **JTAG-AXI on Gowin** remains "v2." The bridge core's single shift-register DR
  front-end assumes the Xilinx real-TCK / single-shift model, while the Gowin TAP
  is sysclk-domain with split `shift_in`/`shift_out` — so it needs a `GOWIN_TAP`
  front-end mode in the (hardware-validated, shared) bridge core plus a cocotb
  cycle before any hardware. Not attempted here.

## Notes for reviewers

- Gowin is driven over **OpenOCD** (the transport does not program the FPGA;
  load the bitstream + start `openocd` first).
- The README slim-down is a **separate** branch (`docs/slim-readme`), not this PR.

## Commits

| Commit | |
|---|---|
| `0f5de86` | Stabilize JTAG register probe reads |
| `7557848` | Fix BRS Gowin build deploy path |
| `e9689c6` | Add EIO to the BRS-100-GW1NR9 reference design |
| `e5efa86` | Add Gowin support to the desktop GUI |
| `32ab7e1` | Add OpenOCD tap auto-detect (`tap='auto'`) and Scan support |
| `2e12885` | Auto-fill EIO panel for Gowin shared-chain on connect |
| `d053648` | Auto-discover and attach EIO on connect |
| `8d0ef5b` | Document Gowin GUI/EIO; add CLI `--base-addr` |
| `f0431c1` | Add BRS-100-GW1NR9 hardware integration test suite |
