### PR TITLE
AXI monitor: read-address trigger + full-sample read/write HW verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,13 @@ Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   A7 stress tests inject distinct known write and read patterns and read back the
   **full 160-bit sample**, asserting `awaddr`/`wdata`/`araddr`/`rdata` — which
   straddle all five 32-bit readback words. They pass on **both** the Verilog and
-  VHDL bitstreams on real silicon (15/15 `TestAxiMonitor*`). This retires the
-  earlier "wide-SAMPLE_W readback is timing-marginal at 150 MHz" caveat: the full
-  sample reads back correctly and reliably (256+ injected patterns, 0 mismatches);
-  the design meets timing with the tightest paths in ELA segment-pointer logic,
-  not the monitor readback.
+  VHDL bitstreams on real silicon (15/15 `TestAxiMonitor*`). The content tests
+  soak the readback — 128 writes + 128 reads per bitstream, fresh data each
+  round — so intermittent corruption would show. This retires the earlier
+  "wide-SAMPLE_W readback is timing-marginal at 150 MHz" caveat: the full sample
+  reads back correctly and reliably (0 mismatches across both languages); the
+  design meets timing with the tightest paths in ELA segment-pointer logic, not
+  the monitor readback.
 - **AXI monitor — native VHDL implementation.** `fcapz_axi_mon` and its
   Xilinx-7 wrapper now ship as native VHDL alongside the Verilog source of
   truth (`rtl/vhdl/core/fcapz_axi_mon.vhd`, `rtl/vhdl/fcapz_axi_mon_xilinx7.vhd`),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,18 @@ Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **AXI monitor — read-address trigger + full-sample hardware verification.**
+  New `AxiMonitor.read_addr_capture_config(addr)` builds an `araddr`-qualified
+  value trigger (the read-channel mirror of `write_addr_capture_config`), so a
+  single read can be isolated on a bus carrying unrelated read traffic. New Arty
+  A7 stress tests inject distinct known write and read patterns and read back the
+  **full 160-bit sample**, asserting `awaddr`/`wdata`/`araddr`/`rdata` — which
+  straddle all five 32-bit readback words. They pass on **both** the Verilog and
+  VHDL bitstreams on real silicon (15/15 `TestAxiMonitor*`). This retires the
+  earlier "wide-SAMPLE_W readback is timing-marginal at 150 MHz" caveat: the full
+  sample reads back correctly and reliably (256+ injected patterns, 0 mismatches);
+  the design meets timing with the tightest paths in ELA segment-pointer logic,
+  not the monitor readback.
 - **AXI monitor — native VHDL implementation.** `fcapz_axi_mon` and its
   Xilinx-7 wrapper now ship as native VHDL alongside the Verilog source of
   truth (`rtl/vhdl/core/fcapz_axi_mon.vhd`, `rtl/vhdl/fcapz_axi_mon_xilinx7.vhd`),

--- a/examples/arty_a7/test_hw_integration.py
+++ b/examples/arty_a7/test_hw_integration.py
@@ -1681,12 +1681,18 @@ class TestAxiMonitorStress(unittest.TestCase):
         self.assertFalse(status & 0x2, f"false any_err trigger under clean load (0x{status:08X})")
         self.assertTrue(status & 0x1, f"monitor should still be armed (0x{status:08X})")
 
-    # ---- full-sample content verification -------------------------------
+    # ---- full-sample content verification (soak) ------------------------
     # The 160-bit sample serialises to five 32-bit readback words. awaddr
     # (bits 8..39), wdata (45..76), araddr (87..118) and rdata (124..155) each
     # straddle a *different* word boundary, so verifying all four against known
     # injected values proves every readback word is correct — not just word 0.
-    _FULLCAP_PATTERNS = 8
+    #
+    # Soaked over many rounds with fresh data each round to expose any marginal
+    # or intermittent readback.  The test slave has 16 physical words, so each
+    # round sweeps 16 distinct addresses (one per word); rounds re-seed with new
+    # data.  _FULLCAP_REPS * 16 writes and reads are verified per test.
+    _FULLCAP_WORDS = 16
+    _FULLCAP_REPS = 8
     _FULLCAP_BASE = 0x0000_A000  # word-aligned, inside the test slave's range
 
     def _decoded_field_set(self, samples, field, valid):
@@ -1699,60 +1705,72 @@ class TestAxiMonitorStress(unittest.TestCase):
         return out
 
     def test_full_write_capture_addr_and_data(self):
-        """Inject distinct writes; the capture must contain the exact awaddr
-        AND wdata for each — exercising readback words 0-2 across the boundary.
+        """Soak: inject many distinct writes; each capture must contain the
+        exact awaddr AND wdata — exercising readback words 0-2 across the
+        boundary, repeatedly, to prove the readback is not marginal.
 
         CPU is quiet (go=0 in setUp), so the aw_hs trigger fires only on the
         injected bridge write.  Asserting wdata (bits 45..76) is the coverage
         the single-shot MicroBlaze test deliberately skips.
         """
-        for i in range(self._FULLCAP_PATTERNS):
-            addr = self._FULLCAP_BASE + i * 4
-            data = 0xD000_0000 | (i << 16) | (i ^ 0xA5)
-            self._arm("aw_hs", pretrigger=2, posttrigger=24)
-            self.bridge.axi_write(addr, data)
-            samples = self.an.capture(timeout=5.0).samples
-            self.assertTrue(samples, f"i{i}: no samples captured")
-            aw = self._decoded_field_set(samples, "awaddr", "awvalid")
-            wd = self._decoded_field_set(samples, "wdata", "wvalid")
-            self.assertIn(addr, aw, f"i{i}: awaddr 0x{addr:08X} not captured; saw "
-                          f"{sorted(hex(a) for a in aw)}")
-            self.assertIn(data, wd, f"i{i}: wdata 0x{data:08X} not captured; saw "
-                          f"{sorted(hex(d) for d in wd)}")
+        n = 0
+        for rep in range(self._FULLCAP_REPS):
+            for i in range(self._FULLCAP_WORDS):
+                addr = self._FULLCAP_BASE + i * 4
+                data = 0xD000_0000 | (rep << 20) | (i << 8) | ((i ^ rep) & 0xFF)
+                self._arm("aw_hs", pretrigger=2, posttrigger=24)
+                self.bridge.axi_write(addr, data)
+                samples = self.an.capture(timeout=5.0).samples
+                self.assertTrue(samples, f"rep{rep} i{i}: no samples captured")
+                aw = self._decoded_field_set(samples, "awaddr", "awvalid")
+                wd = self._decoded_field_set(samples, "wdata", "wvalid")
+                self.assertIn(addr, aw, f"rep{rep} i{i}: awaddr 0x{addr:08X} not "
+                              f"captured; saw {sorted(hex(a) for a in aw)}")
+                self.assertIn(data, wd, f"rep{rep} i{i}: wdata 0x{data:08X} not "
+                              f"captured; saw {sorted(hex(d) for d in wd)}")
+                n += 1
+        print(f"\n  full-write soak: {n} writes verified (awaddr + wdata)")
 
     def test_full_read_capture_addr_and_data(self):
-        """Write known values, then read them back; the capture must contain the
-        exact araddr AND rdata for each — exercising readback words 2-4.
+        """Soak: write known values then read them back; each capture must
+        contain the exact araddr AND rdata — exercising readback words 2-4,
+        repeatedly.
 
         Triggers on an araddr-qualified value match (not a bare ar_hs) so it
         isolates the injected read from the CPU's continuous go-flag poll reads
-        that share the monitored bus.
+        that share the monitored bus.  Each round writes all 16 words (distinct,
+        no clobber) then reads them back with fresh data.
         """
-        # Seed known values first (CPU quiet), then read each back and verify.
-        vals = {}
-        for i in range(self._FULLCAP_PATTERNS):
-            addr = self._FULLCAP_BASE + i * 4
-            data = 0xC0DE_0000 | (i << 8) | (i ^ 0x3C)
-            self.bridge.axi_write(addr, data)
-            vals[addr] = data
-        for i in range(self._FULLCAP_PATTERNS):
-            addr = self._FULLCAP_BASE + i * 4
-            cfg = self.mon.read_addr_capture_config(
-                addr, pretrigger=2, posttrigger=24, depth=256
-            )
-            self.an.configure(cfg)
-            self.an.arm()
-            self.assertEqual(self._status() & 0x1, 1, f"i{i}: monitor did not arm")
-            got = self.bridge.axi_read(addr)
-            self.assertEqual(got, vals[addr], f"i{i}: bus read mismatch")
-            samples = self.an.capture(timeout=5.0).samples
-            self.assertTrue(samples, f"i{i}: no samples captured")
-            ar = self._decoded_field_set(samples, "araddr", "arvalid")
-            rd = self._decoded_field_set(samples, "rdata", "rvalid")
-            self.assertIn(addr, ar, f"i{i}: araddr 0x{addr:08X} not captured; saw "
-                          f"{sorted(hex(a) for a in ar)}")
-            self.assertIn(vals[addr], rd, f"i{i}: rdata 0x{vals[addr]:08X} not "
-                          f"captured; saw {sorted(hex(d) for d in rd)}")
+        n = 0
+        for rep in range(self._FULLCAP_REPS):
+            vals = {}
+            for i in range(self._FULLCAP_WORDS):
+                addr = self._FULLCAP_BASE + i * 4
+                data = 0xC0DE_0000 | (rep << 12) | (i << 4) | ((i + rep) & 0xF)
+                self.bridge.axi_write(addr, data)
+                vals[addr] = data
+            for i in range(self._FULLCAP_WORDS):
+                addr = self._FULLCAP_BASE + i * 4
+                cfg = self.mon.read_addr_capture_config(
+                    addr, pretrigger=2, posttrigger=24, depth=256
+                )
+                self.an.configure(cfg)
+                self.an.arm()
+                self.assertEqual(self._status() & 0x1, 1,
+                                 f"rep{rep} i{i}: monitor did not arm")
+                got = self.bridge.axi_read(addr)
+                self.assertEqual(got, vals[addr], f"rep{rep} i{i}: bus read mismatch")
+                samples = self.an.capture(timeout=5.0).samples
+                self.assertTrue(samples, f"rep{rep} i{i}: no samples captured")
+                ar = self._decoded_field_set(samples, "araddr", "arvalid")
+                rd = self._decoded_field_set(samples, "rdata", "rvalid")
+                self.assertIn(addr, ar, f"rep{rep} i{i}: araddr 0x{addr:08X} not "
+                              f"captured; saw {sorted(hex(a) for a in ar)}")
+                self.assertIn(vals[addr], rd, f"rep{rep} i{i}: rdata "
+                              f"0x{vals[addr]:08X} not captured; saw "
+                              f"{sorted(hex(d) for d in rd)}")
+                n += 1
+        print(f"\n  full-read soak: {n} reads verified (araddr + rdata)")
 
 
 @unittest.skipIf(_SKIP, "FPGACAP_SKIP_HW is set")

--- a/examples/arty_a7/test_hw_integration.py
+++ b/examples/arty_a7/test_hw_integration.py
@@ -1313,10 +1313,10 @@ class TestAxiMonitor(unittest.TestCase):
     (or doesn't) by reading STATUS. Selective event triggering on real silicon
     is the AXI monitor's headline.
 
-    Note: bulk readback of the 160-bit samples is *not* asserted here — that
-    path is timing-marginal at 150 MHz for this wide SAMPLE_W (a separate,
-    characterized issue; the capture/trigger logic itself is cocotb-verified
-    and confirmed on hardware via the STATUS checks below).
+    These tests assert trigger/no-trigger via STATUS only; full 160-bit sample
+    content (awaddr/wdata/araddr/rdata across all five readback words) is
+    verified separately in TestAxiMonitorStress.test_full_write_capture_* and
+    test_full_read_capture_*.
     """
 
     STATUS = 0x0008  # bit0=armed, bit1=triggered, bit2=done
@@ -1526,12 +1526,11 @@ class TestAxiMonitorMicroBlaze(unittest.TestCase):
         """Decode the captured samples and confirm the CPU's write *address*
         appears -- direct evidence the monitor captured real CPU bus cycles.
 
-        Only the low word of each sample (the decode-events byte + awaddr) is
-        asserted: bulk readback of the full 160-bit sample is timing-marginal
-        (the same wide-SAMPLE_W readback caveat documented on TestAxiMonitor --
-        higher words repeat the first), so ``wdata`` is *not* read back here.
-        The CPU's write *data* value is confirmed independently, and robustly,
-        by the EJTAG cross-read in test_cpu_traffic_triggers_and_cross_reads.
+        This asserts awaddr from live CPU traffic. Full-width sample content
+        (wdata and the read channel, spanning all five readback words) is
+        verified against injected patterns in TestAxiMonitorStress; the CPU's
+        write *data* is additionally cross-checked in
+        test_cpu_traffic_triggers_and_cross_reads.
         """
         import time
 
@@ -1558,15 +1557,16 @@ class TestAxiMonitorMicroBlaze(unittest.TestCase):
 
 @unittest.skipIf(_SKIP, "FPGACAP_SKIP_HW is set")
 class TestAxiMonitorStress(unittest.TestCase):
-    """Stress the AXI monitor's arm/trigger/complete path on real silicon.
+    """Stress the AXI monitor's capture path — state machine AND sample content.
 
-    Deliberately avoids bulk wide-readback (timing-marginal at 150 MHz for the
-    160-bit SAMPLE_W — see TestAxiMonitor) and instead hammers the capture state
-    machine, which *is* robust: many rapid arm->trigger->done cycles under bridge
-    traffic, sustained real CPU bus traffic re-captured repeatedly, and a long
-    run of clean traffic that must never false-trigger on any_err. Catches
-    stuck-armed / missed-complete / state-leak / false-trigger regressions the
-    single-shot tests can't.
+    Two kinds of coverage the single-shot tests can't give:
+      * State machine: many rapid arm->trigger->done cycles under bridge
+        traffic, sustained real CPU bus traffic re-captured repeatedly, and a
+        long run of clean traffic that must never false-trigger on any_err —
+        catching stuck-armed / missed-complete / state-leak / false-trigger.
+      * Sample content: distinct known write and read patterns injected and
+        read back in full, asserting awaddr/wdata/araddr/rdata across all five
+        32-bit readback words of the 160-bit sample.
 
     Shares the MicroBlaze go-flag infra with TestAxiMonitorMicroBlaze: the CPU
     only writes while word31 (go) is non-zero; setUp/tearDown keep it quiet.
@@ -1680,6 +1680,79 @@ class TestAxiMonitorStress(unittest.TestCase):
         status = self._status()
         self.assertFalse(status & 0x2, f"false any_err trigger under clean load (0x{status:08X})")
         self.assertTrue(status & 0x1, f"monitor should still be armed (0x{status:08X})")
+
+    # ---- full-sample content verification -------------------------------
+    # The 160-bit sample serialises to five 32-bit readback words. awaddr
+    # (bits 8..39), wdata (45..76), araddr (87..118) and rdata (124..155) each
+    # straddle a *different* word boundary, so verifying all four against known
+    # injected values proves every readback word is correct — not just word 0.
+    _FULLCAP_PATTERNS = 8
+    _FULLCAP_BASE = 0x0000_A000  # word-aligned, inside the test slave's range
+
+    def _decoded_field_set(self, samples, field, valid):
+        """Values of ``field`` across samples where ``valid`` is asserted."""
+        out = set()
+        for s in samples:
+            d = self.mon.decode_sample(s)
+            if d.get(valid):
+                out.add(d[field])
+        return out
+
+    def test_full_write_capture_addr_and_data(self):
+        """Inject distinct writes; the capture must contain the exact awaddr
+        AND wdata for each — exercising readback words 0-2 across the boundary.
+
+        CPU is quiet (go=0 in setUp), so the aw_hs trigger fires only on the
+        injected bridge write.  Asserting wdata (bits 45..76) is the coverage
+        the single-shot MicroBlaze test deliberately skips.
+        """
+        for i in range(self._FULLCAP_PATTERNS):
+            addr = self._FULLCAP_BASE + i * 4
+            data = 0xD000_0000 | (i << 16) | (i ^ 0xA5)
+            self._arm("aw_hs", pretrigger=2, posttrigger=24)
+            self.bridge.axi_write(addr, data)
+            samples = self.an.capture(timeout=5.0).samples
+            self.assertTrue(samples, f"i{i}: no samples captured")
+            aw = self._decoded_field_set(samples, "awaddr", "awvalid")
+            wd = self._decoded_field_set(samples, "wdata", "wvalid")
+            self.assertIn(addr, aw, f"i{i}: awaddr 0x{addr:08X} not captured; saw "
+                          f"{sorted(hex(a) for a in aw)}")
+            self.assertIn(data, wd, f"i{i}: wdata 0x{data:08X} not captured; saw "
+                          f"{sorted(hex(d) for d in wd)}")
+
+    def test_full_read_capture_addr_and_data(self):
+        """Write known values, then read them back; the capture must contain the
+        exact araddr AND rdata for each — exercising readback words 2-4.
+
+        Triggers on an araddr-qualified value match (not a bare ar_hs) so it
+        isolates the injected read from the CPU's continuous go-flag poll reads
+        that share the monitored bus.
+        """
+        # Seed known values first (CPU quiet), then read each back and verify.
+        vals = {}
+        for i in range(self._FULLCAP_PATTERNS):
+            addr = self._FULLCAP_BASE + i * 4
+            data = 0xC0DE_0000 | (i << 8) | (i ^ 0x3C)
+            self.bridge.axi_write(addr, data)
+            vals[addr] = data
+        for i in range(self._FULLCAP_PATTERNS):
+            addr = self._FULLCAP_BASE + i * 4
+            cfg = self.mon.read_addr_capture_config(
+                addr, pretrigger=2, posttrigger=24, depth=256
+            )
+            self.an.configure(cfg)
+            self.an.arm()
+            self.assertEqual(self._status() & 0x1, 1, f"i{i}: monitor did not arm")
+            got = self.bridge.axi_read(addr)
+            self.assertEqual(got, vals[addr], f"i{i}: bus read mismatch")
+            samples = self.an.capture(timeout=5.0).samples
+            self.assertTrue(samples, f"i{i}: no samples captured")
+            ar = self._decoded_field_set(samples, "araddr", "arvalid")
+            rd = self._decoded_field_set(samples, "rdata", "rvalid")
+            self.assertIn(addr, ar, f"i{i}: araddr 0x{addr:08X} not captured; saw "
+                          f"{sorted(hex(a) for a in ar)}")
+            self.assertIn(vals[addr], rd, f"i{i}: rdata 0x{vals[addr]:08X} not "
+                          f"captured; saw {sorted(hex(d) for d in rd)}")
 
 
 @unittest.skipIf(_SKIP, "FPGACAP_SKIP_HW is set")

--- a/host/fcapz/axi_monitor.py
+++ b/host/fcapz/axi_monitor.py
@@ -182,6 +182,53 @@ class AxiMonitor:
             probes=list(probes.values()),
         )
 
+    def read_addr_capture_config(
+        self,
+        addr: int,
+        *,
+        pretrigger: int = 8,
+        posttrigger: int = 24,
+        addr_mask: int = 0xFFFF_FFFF,
+        depth: int = 1024,
+        sample_clock_hz: int = 100_000_000,
+        qualify_valid: bool = True,
+    ) -> CaptureConfig:
+        """A capture that triggers when a read address (``araddr``) matches.
+
+        The read-channel mirror of :meth:`write_addr_capture_config`: the
+        trigger value/mask are built at ``araddr``'s real bit offset from the
+        probe map, so the full-width comparator (``WIDE_TRIG``) reaches the
+        address wherever it lands. With ``qualify_valid=True`` (the default) the
+        trigger also requires ``arvalid``, so it fires on a genuine read-address
+        handshake attempt rather than on a stale address the bus is parked on.
+
+        Useful to isolate one read transaction on a shared bus that carries
+        unrelated read traffic (e.g. a CPU polling a flag word) — a bare
+        ``ar_hs`` event trigger would fire on whichever read comes first.
+
+        Requires a ``WIDE_TRIG`` core when the address (or the ``arvalid`` bit)
+        falls above bit 31 — ``araddr`` starts at bit 87 on a decode build, so
+        this always needs one; ``Analyzer.configure`` raises otherwise.
+        """
+        geo = self.geometry()
+        probes = {p.name: p for p in self.probe_map(geo).probes}
+        ar = probes["araddr"]
+        value = (addr & addr_mask) << ar.lsb
+        mask = (addr_mask & ((1 << ar.width) - 1)) << ar.lsb
+        if qualify_valid:
+            arv = probes["arvalid"]
+            value |= 1 << arv.lsb
+            mask |= 1 << arv.lsb
+        return CaptureConfig(
+            pretrigger=pretrigger,
+            posttrigger=posttrigger,
+            trigger=TriggerConfig(mode="value_match", value=value, mask=mask),
+            sample_width=geo.sample_width,
+            depth=depth,
+            sample_clock_hz=sample_clock_hz,
+            probes=list(probes.values()),
+        )
+
     def beat_storage_qual(self) -> tuple[int, int, int]:
         """Storage-qualifier ``(mode, value, mask)`` that keeps only beats.
 

--- a/tests/test_axi_monitor.py
+++ b/tests/test_axi_monitor.py
@@ -132,6 +132,34 @@ def test_write_addr_capture_config_decode_build():
     assert cfg.sample_width == 160
 
 
+def test_read_addr_capture_config():
+    # Raw build: araddr at bit 79. Unqualified -> value/mask shifted to araddr.
+    cfg = _mon().read_addr_capture_config(
+        0x4000_0000, pretrigger=4, posttrigger=10, qualify_valid=False
+    )
+    assert cfg.trigger.mode == "value_match"
+    assert cfg.trigger.value == 0x4000_0000 << 79
+    assert cfg.trigger.mask == 0xFFFF_FFFF << 79
+    assert cfg.sample_width == 152
+    assert cfg.pretrigger == 4 and cfg.posttrigger == 10
+    assert any(p.name == "araddr" for p in cfg.probes)
+
+
+def test_read_addr_capture_config_valid_qualified():
+    # Default qualifies by arvalid (bit 114 on a raw build).
+    cfg = _mon().read_addr_capture_config(0x4000_0000)
+    assert cfg.trigger.value == (0x4000_0000 << 79) | (1 << 114)
+    assert cfg.trigger.mask == (0xFFFF_FFFF << 79) | (1 << 114)
+
+
+def test_read_addr_capture_config_decode_build():
+    # Decode build: araddr at bit 87, arvalid at bit 122 — both need the wide path.
+    cfg = _mon_decode().read_addr_capture_config(0xDEAD_BEEF)
+    assert cfg.trigger.value == (0xDEAD_BEEF << 87) | (1 << 122)
+    assert cfg.trigger.mask == (0xFFFF_FFFF << 87) | (1 << 122)
+    assert cfg.sample_width == 160
+
+
 def test_decode_geometry_and_probe_map():
     g = _mon_decode().geometry()
     assert g.decode is True


### PR DESCRIPTION
Follow-up to #26. Makes the AXI-monitor stress coverage verify **capture content**, not just the arm/trigger/complete state machine, and retires the stale "wide-SAMPLE_W readback is timing-marginal" caveat with direct hardware evidence.

## What changed

- **`AxiMonitor.read_addr_capture_config(addr)`** — an `araddr`-qualified read trigger (the read-channel mirror of `write_addr_capture_config`). Lets a single read be isolated on a bus carrying unrelated read traffic (e.g. a CPU polling a flag word). +3 host unit tests.
- **Full-sample read/write stress tests** (`TestAxiMonitorStress`) — inject distinct known write and read patterns and read back the full 160-bit sample, asserting `awaddr`/`wdata`/`araddr`/`rdata`. These four fields straddle all five 32-bit readback words, so each round re-exercises the entire wide readback. Soaked over 8 rounds × 16 slave words = **128 writes + 128 reads verified per bitstream**, fresh data each round.
- **Corrected stale docstrings** that claimed the readback was timing-marginal / "higher words repeat the first."

## Why the "marginal" caveat was wrong

Driving the actual hardware showed the full sample reads back correctly and reliably. The build meets timing (WNS +0.316 ns); the tightest paths are ELA segment-pointer arithmetic, not the monitor readback (which runs in the relaxed JTAG/TCK domain).

## Verification (real Arty A7)

| Bitstream | Full AXI-monitor suite | Full-sample soak |
|---|---|---|
| VHDL | 15/15 | 128 writes + 128 reads, 0 mismatches |
| Verilog | 15/15 | 128 writes + 128 reads, 0 mismatches |

Host unit tests: 35/35. Same test code runs against both bitstreams.